### PR TITLE
発着時刻の`HH`部分について、0~23のみを表示するようにした。

### DIFF
--- a/TRViS/DTAC/TimeCell.xaml.cs
+++ b/TRViS/DTAC/TimeCell.xaml.cs
@@ -31,9 +31,9 @@ public partial class TimeCell : Grid
 			IsVisible = false;
 		else if (newValue.Hour is not null || newValue.Minute is not null || newValue.Second is not null)
 		{
-			hhmm = $"{newValue.Hour}";
+			hhmm = string.Empty;
 			if (newValue.Hour is not null)
-				hhmm += ".";
+				hhmm += $"{newValue.Hour % 24}.";
 
 			hhmm += $"{newValue.Minute ?? 0:D02}";
 		}


### PR DESCRIPTION
resolves #11 

24時をまたぐ時刻については、「24時」のように表示されるのではなく、「0時」のように表示されるため、その仕様に対応したものである。