### PR TITLE
Resolves issue of Cannot Show Package License Text

### DIFF
--- a/TRViS/Models/LicensesData.cs
+++ b/TRViS/Models/LicensesData.cs
@@ -1,3 +1,10 @@
 namespace TRViS.Models;
 
-public record LicenseData(string id, string resolvedVersion, string license, string author, string? projectUrl, string? copyrightText);
+public record LicenseData(
+	string id,
+	string resolvedVersion,
+	string license,
+	string author,
+	string? projectUrl,
+	string? copyrightText
+);

--- a/TRViS/Models/LicensesData.cs
+++ b/TRViS/Models/LicensesData.cs
@@ -4,6 +4,7 @@ public record LicenseData(
 	string id,
 	string resolvedVersion,
 	string license,
+	string licenseDataType,
 	string author,
 	string? projectUrl,
 	string? copyrightText

--- a/TRViS/Resources/Raw/licenses/license_list_custom.json
+++ b/TRViS/Resources/Raw/licenses/license_list_custom.json
@@ -2,6 +2,7 @@
   {
     "id": "material-design-icons",
     "resolvedVersion": "4.0.0",
+    "licenseDataType": "expression",
     "license": "Apache-2.0",
     "author": "Google",
     "projectUrl": "https://github.com/google/material-design-icons",

--- a/TRViS/ThirdPartyLicenses.xaml
+++ b/TRViS/ThirdPartyLicenses.xaml
@@ -4,7 +4,6 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:models="clr-namespace:TRViS.Models"
 	xmlns:viewmodels="clr-namespace:TRViS.ViewModels"
-	xmlns:ctrls="clr-namespace:TRViS.Controls"
 	x:DataType="viewmodels:ThirdPartyLicensesViewModel"
 	x:Class="TRViS.ThirdPartyLicenses"
 	Title="ThirdPartyLicenses">
@@ -61,26 +60,12 @@
 								Property="IsVisible"
 								Value="False"/>
 						</DataTrigger>
-
 					</Label.Triggers>
 				</Label>
 
-				<ListView
-					SelectionMode="None"
-					Grid.Row="2"
-					ItemsSource="{Binding LicenseTextList}"
-					HasUnevenRows="True">
-					<ListView.ItemTemplate>
-						<DataTemplate
-							x:DataType="{x:Type viewmodels:MyKeyValuePair}">
-							<ViewCell>
-								<ctrls:HtmlAutoDetectLabel
-									HorizontalOptions="Start"
-									Text="{Binding Value}"/>
-							</ViewCell>
-						</DataTemplate>
-					</ListView.ItemTemplate>
-				</ListView>
+				<ScrollView
+					x:Name="LicenseTextArea"
+					Grid.Row="2"/>
 			</Grid>
 		</Frame>
 	</FlexLayout>

--- a/TRViS/ThirdPartyLicenses.xaml
+++ b/TRViS/ThirdPartyLicenses.xaml
@@ -36,10 +36,39 @@
 			Margin="4"
 			FlexLayout.Grow="2"
 			FlexLayout.Basis="600">
-			<ScrollView>
+			<Grid>
+				<Grid.RowDefinitions>
+					<RowDefinition Height="40"/>
+					<RowDefinition Height="20"/>
+					<RowDefinition Height="*"/>
+				</Grid.RowDefinitions>
 				<Label
-					Text="{Binding LicenseText}"/>
-			</ScrollView>
+					FontSize="Title"
+					Grid.Row="0"
+					HorizontalOptions="Start"
+					Text="{Binding SelectedLicenseData.id}"/>
+				<Label
+					Grid.Row="1"
+					HorizontalOptions="Start"
+					Text="{Binding LicenseExpression}"/>
+
+				<ListView
+					SelectionMode="None"
+					Grid.Row="2"
+					ItemsSource="{Binding LicenseTextList}"
+					HasUnevenRows="True">
+					<ListView.ItemTemplate>
+						<DataTemplate
+							x:DataType="{x:Type viewmodels:MyKeyValuePair}">
+							<ViewCell>
+								<Label
+									HorizontalOptions="Start"
+									Text="{Binding Value}"/>
+							</ViewCell>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+			</Grid>
 		</Frame>
 	</FlexLayout>
 </ContentPage>

--- a/TRViS/ThirdPartyLicenses.xaml
+++ b/TRViS/ThirdPartyLicenses.xaml
@@ -51,7 +51,19 @@
 				<Label
 					Grid.Row="1"
 					HorizontalOptions="Start"
-					Text="{Binding LicenseExpression}"/>
+					Text="{Binding LicenseExpression, StringFormat='License Expression: \'{}\''}">
+					<Label.Triggers>
+						<DataTrigger
+							TargetType="Label"
+							Binding="{Binding LicenseExpression}"
+							Value="">
+							<Setter
+								Property="IsVisible"
+								Value="False"/>
+						</DataTrigger>
+
+					</Label.Triggers>
+				</Label>
 
 				<ListView
 					SelectionMode="None"

--- a/TRViS/ThirdPartyLicenses.xaml
+++ b/TRViS/ThirdPartyLicenses.xaml
@@ -4,6 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:models="clr-namespace:TRViS.Models"
 	xmlns:viewmodels="clr-namespace:TRViS.ViewModels"
+	xmlns:ctrls="clr-namespace:TRViS.Controls"
 	x:DataType="viewmodels:ThirdPartyLicensesViewModel"
 	x:Class="TRViS.ThirdPartyLicenses"
 	Title="ThirdPartyLicenses">
@@ -61,7 +62,7 @@
 						<DataTemplate
 							x:DataType="{x:Type viewmodels:MyKeyValuePair}">
 							<ViewCell>
-								<Label
+								<ctrls:HtmlAutoDetectLabel
 									HorizontalOptions="Start"
 									Text="{Binding Value}"/>
 							</ViewCell>

--- a/TRViS/ThirdPartyLicenses.xaml
+++ b/TRViS/ThirdPartyLicenses.xaml
@@ -51,7 +51,7 @@
 				<Label
 					Grid.Row="1"
 					HorizontalOptions="Start"
-					Text="{Binding LicenseExpression, StringFormat='License Expression: \'{}\''}">
+					Text="{Binding LicenseExpression, StringFormat='License Expression: {0}'}">
 					<Label.Triggers>
 						<DataTrigger
 							TargetType="Label"

--- a/TRViS/ThirdPartyLicenses.xaml.cs
+++ b/TRViS/ThirdPartyLicenses.xaml.cs
@@ -1,4 +1,6 @@
+using System.ComponentModel;
 using System.Text.Json;
+using TRViS.Controls;
 using TRViS.Models;
 using TRViS.ViewModels;
 
@@ -15,7 +17,42 @@ public partial class ThirdPartyLicenses : ContentPage
 
 		BindingContext = viewModel;
 
+		viewModel.PropertyChanged += ViewModel_PropertyChanged;
+
 		Task.Run(LoadLicenseList);
+	}
+
+	private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName != nameof(ThirdPartyLicensesViewModel.LicenseTextList))
+			return;
+
+		VerticalStackLayout licenses = new();
+		if (viewModel.LicenseTextList?.Count > 0)
+		{
+			foreach (var v in viewModel.LicenseTextList)
+			{
+				licenses.Children.Add(new HtmlAutoDetectLabel()
+				{
+					Text = v.Value
+				});
+				licenses.Children.Add(new BoxView()
+				{
+					HeightRequest = 1,
+					BackgroundColor = new(0x80, 0x80, 0x80)
+				});
+			}
+		}
+		else
+		{
+			// NULL or Length=0
+			licenses.Children.Add(new Label()
+			{
+				Text = "(No License Info)"
+			});
+		}
+
+		LicenseTextArea.Content = licenses;
 	}
 
 	async void LoadLicenseList()

--- a/TRViS/ViewModels/ThirdPartyLicensesViewModel.cs
+++ b/TRViS/ViewModels/ThirdPartyLicensesViewModel.cs
@@ -35,7 +35,7 @@ public partial class ThirdPartyLicensesViewModel : ObservableObject
 
 		if (value.licenseDataType == "expression")
 		{
-			LicenseExpression = $"License Expression: '{value.license}'";
+			LicenseExpression = value.license;
 
 			foreach (string fileName in
 				Regex.Split(value.license, @"\(|\)| ")

--- a/TRViS/ViewModels/ThirdPartyLicensesViewModel.cs
+++ b/TRViS/ViewModels/ThirdPartyLicensesViewModel.cs
@@ -1,7 +1,10 @@
+using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using TRViS.Models;
 
 namespace TRViS.ViewModels;
+
+public record MyKeyValuePair(string Key, string Value);
 
 public partial class ThirdPartyLicensesViewModel : ObservableObject
 {
@@ -12,28 +15,60 @@ public partial class ThirdPartyLicensesViewModel : ObservableObject
 	LicenseData? _SelectedLicenseData;
 
 	[ObservableProperty]
-	string _LicenseText = "";
+	List<MyKeyValuePair>? _LicenseTextList;
+
+	[ObservableProperty]
+	string _LicenseExpression = "";
 
 	public const string licenseFileDir = "licenses";
 	async partial void OnSelectedLicenseDataChanged(LicenseData? value)
 	{
+		List<MyKeyValuePair> list = new();
+
 		if (value is null)
 		{
-			LicenseText = "";
+			LicenseTextList = list;
+			LicenseExpression = "";
 			return;
 		}
 
-		string path = Path.Combine(licenseFileDir, value.license);
 
+		if (value.licenseDataType == "expression")
+		{
+			LicenseExpression = $"License Expression: '{value.license}'";
+
+			foreach (string fileName in
+				Regex.Split(value.license, @"\(|\)| ")
+					.Where(v => !string.IsNullOrWhiteSpace(v) && v != "AND" && v != "OR")
+			)
+				await loadLicenseText(list, fileName);
+		}
+		else
+		{
+			LicenseExpression = "";
+			await loadLicenseText(list, value.license);
+		}
+
+		LicenseTextList = list;
+	}
+
+	async static Task loadLicenseText(List<MyKeyValuePair> list, string fileName)
+	{
+		string path = Path.Combine(licenseFileDir, fileName);
+
+		string text = "";
 		if (await FileSystem.AppPackageFileExistsAsync(path) != true)
 		{
-			LicenseText = "(Cannot Find File)";
-			return;
+			text = $"(Cannot Find File: {fileName})";
+		}
+		else
+		{
+			using Stream stream = await FileSystem.OpenAppPackageFileAsync(path);
+			using StreamReader reader = new(stream);
+
+			text = await reader.ReadToEndAsync();
 		}
 
-		using Stream stream = await FileSystem.OpenAppPackageFileAsync(path);
-		using StreamReader reader = new(stream);
-
-		LicenseText = await reader.ReadToEndAsync();
+		list.Add(new(fileName, text));
 	}
 }

--- a/iosSim.sh
+++ b/iosSim.sh
@@ -3,6 +3,7 @@
 cd `dirname $0`
 
 TARGET_PROJ="TRViS/TRViS.csproj"
+TARGET_FRAMEWORK="net6.0-ios15.4"
 
 UDID_PATTERN="[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}"
 
@@ -18,7 +19,7 @@ iOS Simulator Launcher
 If you don't specify UDID/DeviceName, you can select Device from available device list.
 
 dotnet command will executed like below ...
-	dotnet build -t:Run $TARGET_PROJ -f net6.0-ios15.4 -r iossimulator-x64 --no-self-contained --nologo "/p:_DeviceName=[DeviceName|:v2:udid=UDID]" [dotnet command options]
+	dotnet build -t:Run $TARGET_PROJ -f $TARGET_FRAMEWORK -r iossimulator-x64 --no-self-contained --nologo "/p:_DeviceName=[DeviceName|:v2:udid=UDID]" [dotnet command options]
 
 ---
 
@@ -95,5 +96,5 @@ else
 fi
 
 if [ ! -z "$DeviceName" ]; then
-  dotnet build -t:Run $TARGET_PROJ -f net6.0-ios -r $RUNTIME_IDENTIFIER --self-contained --nologo "/p:_DeviceName=$DeviceName" ${ARGS[@]}
+  dotnet build -t:Run $TARGET_PROJ -f $TARGET_FRAMEWORK -r $RUNTIME_IDENTIFIER --self-contained --nologo "/p:_DeviceName=$DeviceName" ${ARGS[@]}
 fi


### PR DESCRIPTION
resolves #21 

例えば`licenseDataType`が`expression`の場合に、`license`として`MIT AND Apache-2.0`が設定される場合がある。
この場合、`MIT AND Apache-2.0`というファイルを探しに行ってしまい、ファイルを表示できないバグがあった。

このPRでは、複数ライセンスが設定されているケースに対応した。

ついでに、Package IDの表示およびLicense Expressionの表示を追加した。

![Screenshot_1665122456](https://user-images.githubusercontent.com/31824852/194478385-91706233-bb71-40fb-b83f-63bebcdd9226.png)
