### PR TITLE
両数表示について、不要なときに表示しないようにした

### DIFF
--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -5,6 +5,7 @@
 	xmlns:dtac="clr-namespace:TRViS.DTAC"
 	xmlns:models="clr-namespace:TRViS.IO.Models;assembly=TRViS.IO"
 	xmlns:ctrls="clr-namespace:TRViS.Controls"
+	xmlns:conv="clr-namespace:TRViS.ValueConverters"
 	x:Class="TRViS.DTAC.VerticalStylePage"
 	x:Name="this"
 	x:DataType="models:TrainData">
@@ -146,6 +147,7 @@
 				Grid.Column="0"/>
 
 			<Frame
+				IsVisible="{Binding CarCount, Converter={x:Static conv:IsOneOrMoreIntConverter.Default}}"
 				Grid.Column="1"
 				BackgroundColor="White"
 				BorderColor="Transparent"

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -149,7 +149,7 @@
 			<Frame
 				IsVisible="{Binding CarCount, Converter={x:Static conv:IsOneOrMoreIntConverter.Default}}"
 				Grid.Column="1"
-				BackgroundColor="White"
+				BackgroundColor="#FEFEFE"
 				BorderColor="Transparent"
 				CornerRadius="4"
 				Padding="0"
@@ -165,6 +165,7 @@
 
 					<Label
 						Style="{StaticResource LabelStyle}"
+						FontSize="18"
 						VerticalOptions="End"
 						HorizontalOptions="End"
 						Text="両"/>

--- a/TRViS/ValueConverters/IsOneOrMoreIntConverter.cs
+++ b/TRViS/ValueConverters/IsOneOrMoreIntConverter.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace TRViS.ValueConverters;
+
+public class IsOneOrMoreIntConverter : IValueConverter
+{
+	static public IsOneOrMoreIntConverter Default { get; } = new();
+
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		=> value is int and >= 1;
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		=> throw new NotImplementedException();
+}


### PR DESCRIPTION
fix #28 

両数表示は、例えば機関車列車では表示されない。
このため、`car_count`がNULL、あるいは０以下の場合に非表示にするようにした。

ついでに、両数表示のスタイルも、以下の2点について修正している。

- 背景色 (`#FEFEFE`と、若干暗くした)
- 「両」のフォントサイズを大きくした

## 両数表示あり = サンプル列車1
![Screen Shot 2022-10-21 at 19 24 11](https://user-images.githubusercontent.com/31824852/197174981-70f8f830-5ffb-424c-a556-8703f44f989c.png)

## 両数表示なし = サンプル列車2
![Screen Shot 2022-10-21 at 19 27 08](https://user-images.githubusercontent.com/31824852/197174999-6536894d-5869-49a3-a081-f5b2a0993322.png)