### PR TITLE
マーカー機能を実装

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -158,9 +158,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.100-rc.1.22431.12'
+        dotnet-version: '7.0.x'
+        dotnet-quality: 'preview'
     - name: Install dotnet workloads
       run: dotnet workload install maui-ios maui-android maccatalyst
 
@@ -228,9 +229,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.100-rc.1.22431.12'
+        dotnet-version: '7.0.x'
+        dotnet-quality: 'preview'
     - name: Install dotnet workloads
       run: dotnet workload install maui-ios maui-android maccatalyst
 

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -158,10 +158,9 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '7.0.x'
-        dotnet-quality: 'preview'
+        dotnet-version: '7.0.100-rc.1.22431.12'
     - name: Install dotnet workloads
       run: dotnet workload install maui-ios maui-android maccatalyst
 
@@ -229,10 +228,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '7.0.x'
-        dotnet-quality: 'preview'
+        dotnet-version: '7.0.100-rc.1.22431.12'
     - name: Install dotnet workloads
       run: dotnet workload install maui-ios maui-android maccatalyst
 

--- a/TRViS/DTAC/MarkerButton.xaml
+++ b/TRViS/DTAC/MarkerButton.xaml
@@ -2,7 +2,9 @@
 <Frame
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:local="clr-namespace:TRViS.DTAC"
 	x:Class="TRViS.DTAC.MarkerButton"
+	x:Name="this"
 	CornerRadius="4"
 	Padding="0"
 	WidthRequest="56"
@@ -27,7 +29,16 @@
 			HorizontalOptions="Start"
 			VerticalOptions="Start"
 			FontAttributes="Bold"
-			Text="ﾏｰｶｰ"/>
+			Text="ﾏｰｶｰ">
+			<Label.Triggers>
+				<DataTrigger
+						TargetType="Label"
+						Binding="{Binding Source={x:Reference this}, Path=IsMarkModeToggled}"
+						Value="True">
+					<Setter Property="TextColor" Value="White"/>
+				</DataTrigger>
+			</Label.Triggers>
+		</Label>
 
 		<Label
 			Style="{StaticResource HeaderLabel}"
@@ -38,6 +49,29 @@
 			ScaleX="0.5"
 			AnchorX="1"
 			TextColor="{StaticResource DarkerGreen}"
-			Text="&#xe9a2;"/>
+			Text="&#xe9a2;">
+			<Label.Triggers>
+				<DataTrigger
+						TargetType="Label"
+						Binding="{Binding Source={x:Reference this}, Path=IsMarkModeToggled}"
+						Value="True">
+					<Setter Property="TextColor" Value="White"/>
+				</DataTrigger>
+			</Label.Triggers>
+		</Label>
 	</Grid>
+
+	<Frame.GestureRecognizers>
+		<TapGestureRecognizer
+			Tapped="TapGestureRecognizer_Tapped"/>
+	</Frame.GestureRecognizers>
+
+	<Frame.Triggers>
+		<DataTrigger
+			TargetType="Frame"
+			Binding="{Binding Source={x:Reference this}, Path=IsMarkModeToggled}"
+			Value="True">
+			<Setter Property="BackgroundColor" Value="{StaticResource DarkerGreen}"/>
+		</DataTrigger>
+	</Frame.Triggers>
 </Frame>

--- a/TRViS/DTAC/MarkerButton.xaml
+++ b/TRViS/DTAC/MarkerButton.xaml
@@ -2,8 +2,9 @@
 <Frame
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	xmlns:local="clr-namespace:TRViS.DTAC"
+	xmlns:vm="clr-namespace:TRViS.ViewModels"
 	x:Class="TRViS.DTAC.MarkerButton"
+	x:DataType="vm:DTACMarkerViewModel"
 	x:Name="this"
 	CornerRadius="4"
 	Padding="0"
@@ -33,7 +34,7 @@
 			<Label.Triggers>
 				<DataTrigger
 						TargetType="Label"
-						Binding="{Binding Source={x:Reference this}, Path=IsMarkModeToggled}"
+						Binding="{Binding IsToggled}"
 						Value="True">
 					<Setter Property="TextColor" Value="White"/>
 				</DataTrigger>
@@ -53,7 +54,7 @@
 			<Label.Triggers>
 				<DataTrigger
 						TargetType="Label"
-						Binding="{Binding Source={x:Reference this}, Path=IsMarkModeToggled}"
+						Binding="{Binding IsToggled}"
 						Value="True">
 					<Setter Property="TextColor" Value="White"/>
 				</DataTrigger>
@@ -69,7 +70,7 @@
 	<Frame.Triggers>
 		<DataTrigger
 			TargetType="Frame"
-			Binding="{Binding Source={x:Reference this}, Path=IsMarkModeToggled}"
+			Binding="{Binding IsToggled}"
 			Value="True">
 			<Setter Property="BackgroundColor" Value="{StaticResource DarkerGreen}"/>
 		</DataTrigger>

--- a/TRViS/DTAC/MarkerButton.xaml
+++ b/TRViS/DTAC/MarkerButton.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Frame
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="TRViS.DTAC.MarkerButton"
+	CornerRadius="4"
+	Padding="0"
+	WidthRequest="56"
+	HeightRequest="44"
+	HorizontalOptions="Center"
+	VerticalOptions="Center"
+	BorderColor="{x:Null}"
+	HasShadow="False"
+	BackgroundColor="White">
+	<Frame.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="Style_VerticalView.xaml" />
+			</ResourceDictionary.MergedDictionaries>
+		</ResourceDictionary>
+	</Frame.Resources>
+
+	<Grid
+		Margin="{OnPlatform iOS='4,6', MacCatalyst='4,6', Default='4,0'}">
+		<Label
+			Style="{StaticResource HeaderLabel}"
+			HorizontalOptions="Start"
+			VerticalOptions="Start"
+			FontAttributes="Bold"
+			Text="ﾏｰｶｰ"/>
+
+		<Label
+			Style="{StaticResource HeaderLabel}"
+			HorizontalOptions="End"
+			VerticalOptions="Center"
+			FontFamily="MaterialIconsRegular"
+			FontSize="44"
+			ScaleX="0.5"
+			AnchorX="1"
+			TextColor="{StaticResource DarkerGreen}"
+			Text="&#xe9a2;"/>
+	</Grid>
+</Frame>

--- a/TRViS/DTAC/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/MarkerButton.xaml.cs
@@ -6,30 +6,33 @@ using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
-[DependencyProperty<bool>("IsMarkModeToggled")]
+[DependencyProperty<DTACMarkerViewModel>("MarkerSettings")]
 public partial class MarkerButton : Frame
 {
-	DTACMarkerViewModel VM { get; } = new();
-
 	public MarkerButton()
 	{
 		InitializeComponent();
 	}
 
+	partial void OnMarkerSettingsChanged(DTACMarkerViewModel? newValue)
+	{
+		BindingContext = newValue;
+	}
+
 	async void TapGestureRecognizer_Tapped(object sender, EventArgs e)
 	{
-		if (Shell.Current.CurrentPage is not ViewHost page)
+		if (Shell.Current.CurrentPage is not ViewHost page || MarkerSettings is null)
 			return;
 
-		if (IsMarkModeToggled)
+		if (MarkerSettings.IsToggled)
 		{
-			IsMarkModeToggled = false;
+			MarkerSettings.IsToggled = false;
 			return;
 		}
 
-		IsMarkModeToggled = true;
+		MarkerSettings.IsToggled = true;
 
-		SelectMarkerPopup popup = new(VM)
+		SelectMarkerPopup popup = new(MarkerSettings)
 		{
 			Anchor = this,
 		};

--- a/TRViS/DTAC/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/MarkerButton.xaml.cs
@@ -1,0 +1,12 @@
+using DependencyPropertyGenerator;
+
+namespace TRViS.DTAC;
+
+[DependencyProperty<bool>("IsMarkModeToggled")]
+public partial class MarkerButton : Frame
+{
+	public MarkerButton()
+	{
+		InitializeComponent();
+	}
+}

--- a/TRViS/DTAC/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/MarkerButton.xaml.cs
@@ -1,12 +1,39 @@
+using CommunityToolkit.Maui.Views;
+
 using DependencyPropertyGenerator;
+
+using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
 [DependencyProperty<bool>("IsMarkModeToggled")]
 public partial class MarkerButton : Frame
 {
+	DTACMarkerViewModel VM { get; } = new();
+
 	public MarkerButton()
 	{
 		InitializeComponent();
+	}
+
+	async void TapGestureRecognizer_Tapped(object sender, EventArgs e)
+	{
+		if (Shell.Current.CurrentPage is not ViewHost page)
+			return;
+
+		if (IsMarkModeToggled)
+		{
+			IsMarkModeToggled = false;
+			return;
+		}
+
+		IsMarkModeToggled = true;
+
+		SelectMarkerPopup popup = new(VM)
+		{
+			Anchor = this,
+		};
+
+		await page.ShowPopupAsync(popup);
 	}
 }

--- a/TRViS/DTAC/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml
@@ -22,16 +22,26 @@
 				SeparatorVisibility="Default"
 				ios:ListView.SeparatorStyle="FullWidth"
 				ItemsSource="{Binding ColorList, Mode=OneTime}"
-				SelectedItem="{Binding SelectedColor, Mode=TwoWay}">
+				SelectedItem="{Binding SelectedMarkerInfo, Mode=TwoWay}">
 				<ListView.ItemTemplate>
 					<DataTemplate>
-						<ViewCell>
-							<BoxView
-								Color="{Binding .}"
-								HeightRequest="16"
-								WidthRequest="16"
-								HorizontalOptions="Center"
-								VerticalOptions="Center"/>
+						<ViewCell
+							x:DataType="vm:MarkerInfo">
+							<ContentView>
+								<Frame
+									HeightRequest="32"
+									WidthRequest="32"
+									VerticalOptions="Center"
+									HorizontalOptions="Center"
+									BackgroundColor="{Binding Color}">
+									<Label
+										Text="{Binding Name}"
+										TextColor="Black"
+										Background="#AFFF"
+										HorizontalOptions="Center"
+										VerticalOptions="Center"/>
+								</Frame>
+							</ContentView>
 						</ViewCell>
 					</DataTemplate>
 				</ListView.ItemTemplate>

--- a/TRViS/DTAC/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml
@@ -28,7 +28,10 @@
 						<ViewCell>
 							<BoxView
 								Color="{Binding .}"
-								Margin="12"/>
+								HeightRequest="16"
+								WidthRequest="16"
+								HorizontalOptions="Center"
+								VerticalOptions="Center"/>
 						</ViewCell>
 					</DataTemplate>
 				</ListView.ItemTemplate>

--- a/TRViS/DTAC/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<xct:Popup
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:xct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+	xmlns:vm="clr-namespace:TRViS.ViewModels"
+	xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+	x:Class="TRViS.DTAC.SelectMarkerPopup"
+	x:DataType="vm:DTACMarkerViewModel"
+	VerticalOptions="Center"
+	HorizontalOptions="End"
+	Size="240,240">
+	<HorizontalStackLayout
+		Padding="8"
+		HorizontalOptions="Center">
+		<Frame
+			Margin="4"
+			Padding="16"
+			WidthRequest="80">
+			<ListView
+				SelectionMode="Single"
+				SeparatorVisibility="Default"
+				ios:ListView.SeparatorStyle="FullWidth"
+				ItemsSource="{Binding ColorList, Mode=OneTime}"
+				SelectedItem="{Binding SelectedColor, Mode=TwoWay}">
+				<ListView.ItemTemplate>
+					<DataTemplate>
+						<ViewCell>
+							<BoxView
+								Color="{Binding .}"
+								Margin="12"/>
+						</ViewCell>
+					</DataTemplate>
+				</ListView.ItemTemplate>
+			</ListView>
+		</Frame>
+
+		<Frame
+			Margin="4"
+			Padding="16"
+			WidthRequest="128">
+			<ListView
+				SelectionMode="Single"
+				SeparatorVisibility="Default"
+				ios:ListView.SeparatorStyle="FullWidth"
+				ItemsSource="{Binding TextList, Mode=OneTime}"
+				SelectedItem="{Binding SelectedText, Mode=TwoWay}"/>
+		</Frame>
+	</HorizontalStackLayout>
+</xct:Popup>

--- a/TRViS/DTAC/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml.cs
@@ -1,0 +1,18 @@
+using CommunityToolkit.Maui.Views;
+using DependencyPropertyGenerator;
+using TRViS.ViewModels;
+
+namespace TRViS.DTAC;
+
+public partial class SelectMarkerPopup : Popup
+{
+	public SelectMarkerPopup()
+	{
+		InitializeComponent();
+	}
+
+	public SelectMarkerPopup(DTACMarkerViewModel vm) : this()
+	{
+		BindingContext = vm;
+	}
+}

--- a/TRViS/DTAC/TimetableHeader.xaml
+++ b/TRViS/DTAC/TimetableHeader.xaml
@@ -83,5 +83,6 @@
 		Text="記事"/>
 
 	<dtac:MarkerButton
+		x:Name="MarkerBtn"
 		Grid.Column="7"/>
 </Grid>

--- a/TRViS/DTAC/TimetableHeader.xaml
+++ b/TRViS/DTAC/TimetableHeader.xaml
@@ -82,32 +82,6 @@
 		Grid.Column="6"
 		Text="記事"/>
 
-	<Frame
-		Grid.Column="7"
-		CornerRadius="4"
-		Padding="0"
-		Margin="4,8"
-		BorderColor="{x:Null}"
-		HasShadow="False"
-		BackgroundColor="White">
-		<Grid
-			Margin="{OnPlatform iOS='4,6', MacCatalyst='4,6', Default='4,0'}">
-			<Label
-				Style="{StaticResource HeaderLabel}"
-				HorizontalOptions="Start"
-				VerticalOptions="Start"
-				FontAttributes="Bold"
-				Text="ﾏｰｶｰ"/>
-			<Label
-				Style="{StaticResource HeaderLabel}"
-				HorizontalOptions="End"
-				VerticalOptions="Center"
-				FontFamily="MaterialIconsRegular"
-				FontSize="44"
-				ScaleX="0.5"
-				AnchorX="1"
-				TextColor="{StaticResource DarkerGreen}"
-				Text="&#xe9a2;"/>
-		</Grid>
-	</Frame>
+	<dtac:MarkerButton
+		Grid.Column="7"/>
 </Grid>

--- a/TRViS/DTAC/TimetableHeader.xaml.cs
+++ b/TRViS/DTAC/TimetableHeader.xaml.cs
@@ -1,13 +1,19 @@
 using DependencyPropertyGenerator;
+using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
 [DependencyProperty<double>("FontSize_Large")]
-[DependencyProperty<bool>("IsMarkModeToggled")]
+[DependencyProperty<DTACMarkerViewModel>("MarkerSettings")]
 public partial class TimetableHeader : Grid
 {
 	public TimetableHeader()
 	{
 		InitializeComponent();
+	}
+
+	partial void OnMarkerSettingsChanged(DTACMarkerViewModel? newValue)
+	{
+		MarkerBtn.MarkerSettings = newValue;
 	}
 }

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -194,6 +194,7 @@
 		</Grid>
 
 		<dtac:TimetableHeader
+			x:Name="TimetableHeader"
 			BackgroundColor="#ddd"
 			FontSize_Large="28"
 			Grid.Row="4"/>

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -9,8 +9,9 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("AffectDate")]
 public partial class VerticalStylePage : ContentView
 {
+	public const double RUN_TIME_COLUMN_WIDTH = 60;
 	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(
-		new(new(60)),
+		new(new(RUN_TIME_COLUMN_WIDTH)),
 		new(new(140)),
 		new(new(140)),
 		new(new(140)),

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
@@ -47,6 +48,8 @@ public partial class VerticalStylePage : ContentView
 	public VerticalStylePage()
 	{
 		InitializeComponent();
+
+		this.TimetableHeader.MarkerSettings = TimetableView.MarkerViewModel;
 
 		if (DeviceInfo.Current.Idiom == DeviceIdiom.Phone || DeviceInfo.Current.Idiom == DeviceIdiom.Unknown)
 			Content = new ScrollView()

--- a/TRViS/DTAC/VerticalTimetableRow.xaml
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml
@@ -5,8 +5,10 @@
 	xmlns:dtac="clr-namespace:TRViS.DTAC"
 	xmlns:models="clr-namespace:TRViS.IO.Models;assembly=TRViS.IO"
 	xmlns:ctrls="clr-namespace:TRViS.Controls"
+	xmlns:conv="clr-namespace:TRViS.ValueConverters"
 	x:Class="TRViS.DTAC.VerticalTimetableRow"
 	x:DataType="models:TimetableRow"
+	x:Name="this"
 	ColumnDefinitions="{x:Static dtac:VerticalStylePage.TimetableColumnWidthCollection}"
 	Margin="0"
 	Padding="0">
@@ -178,6 +180,35 @@
 		HorizontalOptions="Fill"
 		VerticalOptions="End"
 		Grid.ColumnSpan="8"/>
+
+	<Button
+		x:Name="MarkerBox"
+		Text="{Binding Source={x:Reference this}, Path=MarkedText}"
+		Clicked="MarkerBoxClicked"
+		IsVisible="False"
+		IsEnabled="{Binding Source={x:Reference this}, Path=IsMarkingMode}"
+		Grid.Column="7"
+		BackgroundColor="{Binding Source={x:Reference this}, Path=MarkedColor}"
+		TextColor="{Binding Source={x:Reference this}, Path=MarkedColor, Converter={x:Static conv:BGColorToTextColorConverter.Default}}"
+		FontFamily="Hiragino Sans"
+		FontAttributes="Bold"
+		FontSize="18"
+		BorderColor="Transparent"
+		CornerRadius="4"
+		Padding="0"
+		Margin="8"
+		HorizontalOptions="Start"
+		VerticalOptions="Center"
+		HeightRequest="40"
+		WidthRequest="40">
+		<Button.Shadow>
+			<Shadow
+				Brush="Black"
+				Offset="2,2"
+				Radius="2"
+				Opacity="0.2" />
+		</Button.Shadow>
+	</Button>
 
 	<BoxView
 		x:Name="CurrentLocationLine"

--- a/TRViS/DTAC/VerticalTimetableRow.xaml
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml
@@ -188,7 +188,7 @@
 		IsVisible="False"
 		IsEnabled="{Binding Source={x:Reference this}, Path=IsMarkingMode}"
 		Grid.Column="7"
-		BackgroundColor="{Binding Source={x:Reference this}, Path=MarkedColor}"
+		Background="{Binding Source={x:Reference this}, Path=MarkedBrush}"
 		TextColor="{Binding Source={x:Reference this}, Path=MarkedColor, Converter={x:Static conv:BGColorToTextColorConverter.Default}}"
 		FontFamily="Hiragino Sans"
 		FontAttributes="Bold"

--- a/TRViS/DTAC/VerticalTimetableRow.xaml
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml
@@ -25,7 +25,7 @@
 		HeightRequest="60"
 		Margin="0"
 		VerticalOptions="End"
-		Color="#080"/>
+		Color="{x:Static dtac:VerticalTimetableView.CURRENT_LOCATION_MARKER_COLOR}"/>
 
 	<Grid
 		Margin="2,0"
@@ -209,13 +209,4 @@
 				Opacity="0.2" />
 		</Button.Shadow>
 	</Button>
-
-	<BoxView
-		x:Name="CurrentLocationLine"
-		Margin="0,-2"
-		HeightRequest="4"
-		Color="#080"
-		HorizontalOptions="Fill"
-		VerticalOptions="End"
-		Grid.ColumnSpan="8"/>
 </Grid>

--- a/TRViS/DTAC/VerticalTimetableRow.xaml.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml.cs
@@ -7,6 +7,7 @@ namespace TRViS.DTAC;
 
 [DependencyProperty<bool>("IsMarkingMode", IsReadOnly = true)]
 [DependencyProperty<Color>("MarkedColor", IsReadOnly = true)]
+[DependencyProperty<Brush>("MarkedBrush", IsReadOnly = true)]
 [DependencyProperty<string>("MarkedText", IsReadOnly = true)]
 [DependencyProperty<DTACMarkerViewModel>("MarkerViewModel", IsReadOnly = true)]
 public partial class VerticalTimetableRow : Grid
@@ -117,6 +118,7 @@ public partial class VerticalTimetableRow : Grid
 	partial void OnMarkedColorChanged(Color? newValue)
 	{
 		BackgroundColor = newValue == DefaultMarkButtonColor ? null : newValue?.WithAlpha(BG_ALPHA);
+		MarkedBrush = new SolidColorBrush(newValue ?? DefaultMarkButtonColor);
 	}
 
 	partial void OnIsMarkingModeChanged(bool newValue)

--- a/TRViS/DTAC/VerticalTimetableRow.xaml.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml.cs
@@ -1,9 +1,19 @@
+using System.ComponentModel;
+using DependencyPropertyGenerator;
 using TRViS.IO.Models;
+using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
+[DependencyProperty<bool>("IsMarkingMode", IsReadOnly = true)]
+[DependencyProperty<Color>("MarkedColor", IsReadOnly = true)]
+[DependencyProperty<string>("MarkedText", IsReadOnly = true)]
+[DependencyProperty<DTACMarkerViewModel>("MarkerViewModel", IsReadOnly = true)]
 public partial class VerticalTimetableRow : Grid
 {
+	static readonly Color DefaultMarkButtonColor = new(0xFA, 0xFA, 0xFA);
+	const float BG_ALPHA = 0.3f;
+
 	public enum LocationStates
 	{
 		Undefined,
@@ -53,10 +63,60 @@ public partial class VerticalTimetableRow : Grid
 
 		CurrentLocationBoxView.IsVisible = false;
 		CurrentLocationLine.IsVisible = false;
+
+		MarkedColor = DefaultMarkButtonColor;
+		IsMarkingMode = false;
 	}
 
-	public VerticalTimetableRow(TimetableRow rowData) : this()
+	public VerticalTimetableRow(TimetableRow rowData, DTACMarkerViewModel? markerViewModel = null) : this()
 	{
 		BindingContext = rowData;
+
+		MarkerViewModel = markerViewModel;
+	}
+
+	void MarkerBoxClicked(object sender, EventArgs e)
+	{
+		if (MarkerViewModel is null)
+			return;
+
+		if (MarkedColor == DefaultMarkButtonColor)
+		{
+			MarkedColor = MarkerViewModel.SelectedColor;
+			MarkedText = MarkerViewModel.SelectedText;
+		}
+		else
+		{
+			MarkedColor = DefaultMarkButtonColor;
+			MarkedText = null;
+		}
+	}
+
+	partial void OnMarkerViewModelChanged(DTACMarkerViewModel? oldValue, DTACMarkerViewModel? newValue)
+	{
+		if (oldValue is not null)
+			oldValue.PropertyChanged -= OnMarkerViewModelValueChanged;
+
+		if (newValue is not null)
+			newValue.PropertyChanged += OnMarkerViewModelValueChanged;
+	}
+
+	private void OnMarkerViewModelValueChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (sender is not DTACMarkerViewModel vm)
+			return;
+
+		if (e.PropertyName == nameof(DTACMarkerViewModel.IsToggled))
+			IsMarkingMode = vm.IsToggled;
+	}
+
+	partial void OnMarkedColorChanged(Color? newValue)
+	{
+		BackgroundColor = newValue == DefaultMarkButtonColor ? null : newValue?.WithAlpha(BG_ALPHA);
+	}
+
+	partial void OnIsMarkingModeChanged(bool newValue)
+	{
+		MarkerBox.IsVisible = newValue || (MarkedColor != DefaultMarkButtonColor);
 	}
 }

--- a/TRViS/DTAC/VerticalTimetableRow.xaml.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml.cs
@@ -33,10 +33,13 @@ public partial class VerticalTimetableRow : Grid
 			if (!IsEnabled || value == LocationStates.Undefined)
 			{
 				CurrentLocationBoxView.IsVisible = false;
-				CurrentLocationLine.IsVisible = false;
 				_LocationState = LocationStates.Undefined;
 				return;
 			}
+
+			// 最終行の場合は、次の駅に進まないようにする。
+			if (IsLastRow && value == LocationStates.RunningToNextStation)
+				return;
 
 			_LocationState = value;
 
@@ -45,34 +48,35 @@ public partial class VerticalTimetableRow : Grid
 				case LocationStates.AroundThisStation:
 					CurrentLocationBoxView.IsVisible = true;
 					CurrentLocationBoxView.Margin = new(0);
-					CurrentLocationLine.IsVisible = false;
 					break;
 
 				case LocationStates.RunningToNextStation:
 					CurrentLocationBoxView.IsVisible = true;
 					CurrentLocationBoxView.Margin = new(0, -30);
-					CurrentLocationLine.IsVisible = true;
 					break;
 			}
 		}
 	}
+
+	public bool IsLastRow { get; }
 
 	public VerticalTimetableRow()
 	{
 		InitializeComponent();
 
 		CurrentLocationBoxView.IsVisible = false;
-		CurrentLocationLine.IsVisible = false;
 
 		MarkedColor = DefaultMarkButtonColor;
 		IsMarkingMode = false;
 	}
 
-	public VerticalTimetableRow(TimetableRow rowData, DTACMarkerViewModel? markerViewModel = null) : this()
+	public VerticalTimetableRow(TimetableRow rowData, DTACMarkerViewModel? markerViewModel = null, bool isLastRow = false) : this()
 	{
 		BindingContext = rowData;
 
 		MarkerViewModel = markerViewModel;
+
+		IsLastRow = isLastRow;
 	}
 
 	void MarkerBoxClicked(object sender, EventArgs e)

--- a/TRViS/DTAC/VerticalTimetableView.cs
+++ b/TRViS/DTAC/VerticalTimetableView.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
@@ -26,6 +27,8 @@ public partial class VerticalTimetableView : Grid
 	public event EventHandler? IsBusyChanged;
 
 	public event EventHandler<ScrollRequestedEventArgs>? ScrollRequested;
+
+	public DTACMarkerViewModel MarkerViewModel { get; init; } = new();
 
 	partial void OnSelectedTrainDataChanged(TrainData? newValue)
 	{
@@ -65,7 +68,7 @@ public partial class VerticalTimetableView : Grid
 		if (row is null)
 			return;
 
-		VerticalTimetableRow rowView = await MainThread.InvokeOnMainThreadAsync(() => new VerticalTimetableRow(row));
+		VerticalTimetableRow rowView = await MainThread.InvokeOnMainThreadAsync(() => new VerticalTimetableRow(row, MarkerViewModel));
 
 		TapGestureRecognizer tapGestureRecognizer = new();
 		tapGestureRecognizer.Tapped += RowTapped;

--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Maui;
 using TRViS.IO;
 using TRViS.ViewModels;
 
@@ -10,6 +11,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
+			.UseMauiCommunityToolkit()
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -56,6 +56,9 @@
 		<PackageReference
 			Include="System.Text.Json"
 			Version="6.0.6" />
+		<PackageReference
+			Include="CommunityToolkit.Maui"
+			Version="1.3.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\TRViS.IO\TRViS.IO.csproj" />

--- a/TRViS/Utils/GetTextColorFromBGColor.cs
+++ b/TRViS/Utils/GetTextColorFromBGColor.cs
@@ -1,0 +1,12 @@
+namespace TRViS;
+
+public static partial class Utils
+{
+	// ref: http://www.asahi-net.or.jp/~gx4s-kmgi/page04.html
+
+	public static Color GetTextColorFromBGColor(Color v)
+		=> GetTextColorFromBGColor((int)(v.Red * 0xFF), (int)(v.Green * 0xFF), (int)(v.Blue * 0xFF));
+
+	public static Color GetTextColorFromBGColor(int Color_Red, int Color_Green, int Color_Blue)
+		=> (((Color_Red * 299) + (Color_Green * 587) + (Color_Blue * 114)) / 1000) >= 128 ? Colors.Black : Colors.White;
+}

--- a/TRViS/ValueConverters/BGColorToTextColorConverter.cs
+++ b/TRViS/ValueConverters/BGColorToTextColorConverter.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+
+namespace TRViS.ValueConverters;
+
+public class BGColorToTextColorConverter : IValueConverter
+{
+	public static BGColorToTextColorConverter Default { get; } = new();
+
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		=> value is not Color v ? value : Utils.GetTextColorFromBGColor(v);
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -26,8 +26,14 @@ public partial class DTACMarkerViewModel : ObservableObject
 	};
 
 	[ObservableProperty]
-	private Color _SelectedColor = Colors.Red;
+	private Color _SelectedColor;
 
 	[ObservableProperty]
-	private string _SelectedText = string.Empty;
+	private string _SelectedText;
+
+	public DTACMarkerViewModel()
+	{
+		_SelectedColor = ColorList[0];
+		_SelectedText = TextList[0];
+	}
 }

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -2,21 +2,23 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace TRViS.ViewModels;
 
+public record MarkerInfo(string Name, Color Color);
+
 public partial class DTACMarkerViewModel : ObservableObject
 {
-	public List<Color> ColorList { get; } = new()
+	public List<MarkerInfo> ColorList { get; } = new()
 	{
 		// Red
-		new(0xF0, 0x40, 0x20),
+		new("赤", new(0xF0, 0x40, 0x20)),
 
 		// Lime
-		new(0x40, 0xF0, 0x20),
+		new("緑", new(0x40, 0xF0, 0x20)),
 
 		// Blue
-		new(0x20, 0x40, 0xF0),
+		new("青", new(0x20, 0x40, 0xF0)),
 
 		// Yellow
-		new(0xf0, 0xf0, 0x40),
+		new("黄", new(0xf0, 0xf0, 0x40)),
 	};
 
 	public List<string> TextList { get; } = new()
@@ -29,14 +31,28 @@ public partial class DTACMarkerViewModel : ObservableObject
 	private bool _IsToggled;
 
 	[ObservableProperty]
-	private Color _SelectedColor;
+	private MarkerInfo? _SelectedMarkerInfo;
+
+	[ObservableProperty]
+	private Color? _SelectedColor;
 
 	[ObservableProperty]
 	private string _SelectedText;
 
 	public DTACMarkerViewModel()
 	{
-		_SelectedColor = ColorList[0];
+		_SelectedMarkerInfo = ColorList[0];
+		_SelectedColor = _SelectedMarkerInfo.Color;
 		_SelectedText = TextList[0];
+	}
+
+	partial void OnSelectedMarkerInfoChanged(MarkerInfo? value)
+	{
+		SelectedColor = value?.Color;
+	}
+
+	partial void OnSelectedColorChanged(Color? value)
+	{
+		SelectedMarkerInfo = ColorList.FirstOrDefault(v => v.Color == value);
 	}
 }

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -26,6 +26,9 @@ public partial class DTACMarkerViewModel : ObservableObject
 	};
 
 	[ObservableProperty]
+	private bool _IsToggled;
+
+	[ObservableProperty]
 	private Color _SelectedColor;
 
 	[ObservableProperty]

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -1,0 +1,33 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace TRViS.ViewModels;
+
+public partial class DTACMarkerViewModel : ObservableObject
+{
+	public List<Color> ColorList { get; } = new()
+	{
+		// Red
+		new(0xF0, 0x40, 0x20),
+
+		// Lime
+		new(0x40, 0xF0, 0x20),
+
+		// Blue
+		new(0x20, 0x40, 0xF0),
+
+		// Yellow
+		new(0xf0, 0xf0, 0x40),
+	};
+
+	public List<string> TextList { get; } = new()
+	{
+		string.Empty,
+		"停車",
+	};
+
+	[ObservableProperty]
+	private Color _SelectedColor = Colors.Red;
+
+	[ObservableProperty]
+	private string _SelectedText = string.Empty;
+}

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -46,8 +46,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 	void SetTitleTextColor()
 	{
 		// ref: http://www.asahi-net.or.jp/~gx4s-kmgi/page04.html
-		int diff = ((Color_Red * 299) + (Color_Green * 587) + (Color_Blue * 114)) / 1000;
-		ShellTitleTextColor = diff >= 128 ? Colors.Black : Colors.White;
+		ShellTitleTextColor = Utils.GetTextColorFromBGColor(Color_Red, Color_Green, Color_Blue);
 	}
 
 	partial void OnColor_RedChanged(int value)


### PR DESCRIPTION
時刻表部分の各行に色を付ける、マーカー機能を実装した。

なお、フレームワーク側の制約により、Androidでは正常に動作しない。

### iPad mini Gen5 マーカー機能の使用例
![Screen Shot 2022-10-22 at 5 47 48](https://user-images.githubusercontent.com/31824852/197286572-099f6048-f5c2-433f-88a4-df9986dcfd77.png)

### iPad mini Gen5 マーカー選択画面
![Screen Shot 2022-10-22 at 5 48 36](https://user-images.githubusercontent.com/31824852/197286603-4f46792c-7573-44d3-82fb-2394efe49aa7.png)

### iPad mini Gen5 マーカー機能の使用例2
![Screen Shot 2022-10-22 at 5 53 40](https://user-images.githubusercontent.com/31824852/197287023-d57383f0-5d2e-46f6-aede-194562d965eb.png)

上記のように、マーカーを引いた状態でマーカーを終了すると、マーカーが引かれた行のみボックスが残る仕様にしている。
