### PR TITLE
Upgrade Framework and NuGet Packages

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -19,7 +19,7 @@ env:
   CSPROJ_PATH: ./TRViS/TRViS.csproj
   THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
   THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net6.0-ios
+  TARGET_FRAMEWORK: net7.0-ios
   TARGET_RUNTIME: ios-arm64
   TARGET_FRAMEWORK_ANDROID: net7.0-android
   OUTPUT_DIR: ./out

--- a/TRViS.IO.Tests/TRViS.IO.Tests.csproj
+++ b/TRViS.IO.Tests/TRViS.IO.Tests.csproj
@@ -9,11 +9,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.5.0"/>
+		<PackageReference Include="coverlet.collector" Version="3.2.0"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TRViS/DTAC/Remarks.xaml
+++ b/TRViS/DTAC/Remarks.xaml
@@ -20,7 +20,6 @@
 	<Grid.RowDefinitions>
 		<RowDefinition Height="64"/>
 		<RowDefinition Height="{Binding ContentAreaHeight}"/>
-		<RowDefinition Height="{Binding BottomPadding}"/>
 	</Grid.RowDefinitions>
 
 	<Label
@@ -53,8 +52,4 @@
 			HorizontalOptions="Start"
 			VerticalOptions="Start"/>
 	</ScrollView>
-
-	<BoxView
-		Grid.Row="2"
-		Color="#333"/>
 </Grid>

--- a/TRViS/DTAC/Remarks.xaml.cs
+++ b/TRViS/DTAC/Remarks.xaml.cs
@@ -9,13 +9,13 @@ namespace TRViS.DTAC;
 [DependencyProperty<bool>("IsOpen", DefaultBindingMode = DefaultBindingMode.TwoWay)]
 [DependencyProperty<IHasRemarksProperty>("RemarksData", DefaultBindingMode = DefaultBindingMode.TwoWay)]
 [DependencyProperty<GridLength>("ContentAreaHeight", IsReadOnly = true)]
-[DependencyProperty<GridLength>("BottomPadding", IsReadOnly = true)]
+[DependencyProperty<double>("BottomSafeAreaHeight")]
 public partial class Remarks : Grid
 {
 	public const double HEADER_HEIGHT = 64;
 	const double DEFAULT_CONTENT_AREA_HEIGHT = 256;
 	double BottomMargin
-		=> -ContentAreaHeight.Value - BottomPadding.Value;
+		=> -ContentAreaHeight.Value - BottomSafeAreaHeight;
 
 	public Remarks()
 	{
@@ -24,25 +24,24 @@ public partial class Remarks : Grid
 		BindingContext = this;
 
 		ContentAreaHeight = new(DEFAULT_CONTENT_AREA_HEIGHT);
-		BottomPadding = new(0);
 	}
 
 	partial void OnIsOpenChanged(bool newValue)
 		=> this.TranslateTo(0, newValue ? BottomMargin : 0, easing: Easing.SinInOut);
 
-	partial void OnBottomPaddingChanged(GridLength newValue)
-		=> HeightChanged(ContentAreaHeight.Value, newValue.Value);
+	partial void OnBottomSafeAreaHeightChanged(double newValue)
+		=> Margin = new(0, BottomMargin);
 
 	partial void OnContentAreaHeightChanged(GridLength newValue)
-		=> HeightChanged(newValue.Value, BottomPadding.Value);
+		=> HeightChanged(newValue.Value);
 
 	partial void OnRemarksDataChanged(IHasRemarksProperty? newValue)
 		=> RemarksLabel.Text = newValue?.Remarks;
 
-	void HeightChanged(in double contentAreaHeight, in double bottomPadding)
+	void HeightChanged(in double contentAreaHeight)
 	{
 		Margin = new(0, BottomMargin);
-		HeightRequest = HEADER_HEIGHT + contentAreaHeight + bottomPadding;
+		HeightRequest = HEADER_HEIGHT + contentAreaHeight;
 		OnIsOpenChanged(IsOpen);
 	}
 
@@ -56,37 +55,10 @@ public partial class Remarks : Grid
 		});
 	}
 
-#if IOS
-	UIKit.UIWindow? UIWindow = null;
-
-	protected override void OnSizeAllocated(double width, double height)
-	{
-		// SafeAreaInsets ref: https://stackoverflow.com/questions/46829840/get-safe-area-inset-top-and-bottom-heights
-		// ios15 >= ref: https://zenn.dev/paraches/articles/windows_was_depricated_in_ios15
-		if (UIWindow is null)
-		{
-			if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
-			{
-				if (UIKit.UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault(v => v is UIKit.UIWindowScene) is UIKit.UIWindowScene scene)
-					UIWindow = scene.Windows.FirstOrDefault();
-			}
-			else
-				UIWindow = UIKit.UIApplication.SharedApplication.Windows.FirstOrDefault();
-		}
-
-		if (UIWindow is not null)
-			BottomPadding = new(UIWindow.SafeAreaInsets.Bottom.Value);
-
-		OnPageHeightChanged(Shell.Current.CurrentPage.Height * 0.4);
-
-		base.OnSizeAllocated(width, height);
-	}
-#else
 	protected override void OnSizeAllocated(double width, double height)
 	{
 		OnPageHeightChanged(Shell.Current.CurrentPage.Height * 0.4);
 
 		base.OnSizeAllocated(width, height);
 	}
-#endif
 }

--- a/TRViS/DTAC/WithRemarksView.cs
+++ b/TRViS/DTAC/WithRemarksView.cs
@@ -9,15 +9,27 @@ namespace TRViS.DTAC;
 public partial class WithRemarksView : Grid
 {
 	Remarks RemarksView { get; } = new();
+	RowDefinition RemarksAreaRowDefinition { get; } = new(new(Remarks.HEADER_HEIGHT, GridUnitType.Absolute));
+
+#if IOS
+	BoxView BottomPaddingView { get; } = new()
+	{
+		Color = new(0x33, 0x33, 0x33),
+	};
+#endif
 
 	public WithRemarksView()
 	{
 		RowDefinitions.Add(new(new(1, GridUnitType.Star)));
-		RowDefinitions.Add(new(new(Remarks.HEADER_HEIGHT, GridUnitType.Absolute)));
+		RowDefinitions.Add(RemarksAreaRowDefinition);
 
 		IgnoreSafeArea = true;
 		Margin = new(0);
 		Padding = new(0);
+
+#if IOS
+		this.Add(BottomPaddingView, row: 1);
+#endif
 
 		this.Add(RemarksView, row: 1);
 	}
@@ -34,5 +46,47 @@ public partial class WithRemarksView : Grid
 	{
 		RemarksView.RemarksData = newValue;
 	}
+
+#if IOS
+	UIKit.UIWindow? UIWindow = null;
+
+	protected override void OnSizeAllocated(double width, double height)
+	{
+		// SafeAreaInsets ref: https://stackoverflow.com/questions/46829840/get-safe-area-inset-top-and-bottom-heights
+		// ios15 >= ref: https://zenn.dev/paraches/articles/windows_was_depricated_in_ios15
+		if (UIWindow is null)
+		{
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
+			{
+				if (UIKit.UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault(v => v is UIKit.UIWindowScene) is UIKit.UIWindowScene scene)
+					UIWindow = scene.Windows.FirstOrDefault();
+			}
+			else
+				UIWindow = UIKit.UIApplication.SharedApplication.Windows.FirstOrDefault();
+		}
+
+		double bottomPaddingValue = 0;
+
+		if (UIWindow is not null)
+		{
+			bottomPaddingValue = UIWindow.SafeAreaInsets.Bottom.Value;
+		}
+
+		if (bottomPaddingValue > 0)
+		{
+			BottomPaddingView.IsVisible = true;
+			BottomPaddingView.Margin = new(0, 0, 0, -bottomPaddingValue);
+		}
+		else
+		{
+			BottomPaddingView.IsVisible = false;
+		}
+
+		RemarksAreaRowDefinition.Height = Remarks.HEADER_HEIGHT - bottomPaddingValue;
+		RemarksView.BottomSafeAreaHeight = bottomPaddingValue;
+
+		base.OnSizeAllocated(width, height);
+	}
+#endif
 }
 

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net7.0-android;</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TRViS</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -56,10 +56,10 @@
 			ExcludeAssets="runtime" />
 		<PackageReference
 			Include="System.Text.Json"
-			Version="6.0.6" />
+			Version="7.0.0" />
 		<PackageReference
 			Include="CommunityToolkit.Maui"
-			Version="1.3.0" />
+			Version="3.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\TRViS.IO\TRViS.IO.csproj" />

--- a/iosSim.sh
+++ b/iosSim.sh
@@ -3,7 +3,7 @@
 cd `dirname $0`
 
 TARGET_PROJ="TRViS/TRViS.csproj"
-TARGET_FRAMEWORK="net6.0-ios"
+TARGET_FRAMEWORK="net7.0-ios"
 
 UDID_PATTERN="[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}"
 


### PR DESCRIPTION
net6.0 + `CommunityToolkit.Maui`のv1.3.0を手元でビルドしたときに、「マーカー」ボタン押下ででクラッシュするバグが発生した。

一応net7.0 + `CommunityToolkit.Maui`のv3.0.0で解消したものの、MAUI側に`IgnoreSafeArea`まわりのバグがあるらしく、「注意事項」の下部に隙間が表示されたり、画面両端に表示が伸びないバグが発生した。

「注意事項」下部の隙間はレイアウト構造の変更で解消したものの、画面両端に表示が伸びないバグは健在である。

## PR適用前 (iPhone 14 Pro Max)
![simulator_screenshot_DE2EC5B4-1277-4251-8B5D-E3395C97E6D6](https://user-images.githubusercontent.com/31824852/204852196-15538351-3c4e-415a-9021-eea7b911506a.png)

## PR適用後 (iPhone 14 Pro Max)
![simulator_screenshot_749FA7B9-F011-41FF-97BD-8232653123C1](https://user-images.githubusercontent.com/31824852/204860657-9c2851b1-2ae8-4333-b4f9-ead4704fc2c4.png)
