### PR TITLE
空白挿入のしきい値を変更

### DIFF
--- a/TRViS/ValueConverters/DTAC.TrainNumberConverter.cs
+++ b/TRViS/ValueConverters/DTAC.TrainNumberConverter.cs
@@ -12,8 +12,8 @@ public class TrainNumberConverter : IValueConverter
 
 		return s.Length switch
 		{
-			<= 5 => Utils.InsertCharBetweenCharAndMakeWide(s, Utils.SPACE_CHAR),
-			<= 8 => Utils.InsertCharBetweenCharAndMakeWide(s, Utils.THIN_SPACE),
+			<= 6 => Utils.InsertCharBetweenCharAndMakeWide(s, Utils.SPACE_CHAR),
+			<= 9 => Utils.InsertCharBetweenCharAndMakeWide(s, Utils.THIN_SPACE),
 			_ => s
 		};
 	}


### PR DESCRIPTION
実測して決定した

ギリギリまでスペースを活用するように方針変更した

なお、全角9文字でギリギリなため、10文字以上で「半角→全角」の変換は行わない。

### 6文字 (iPad mini 2)
![9D7B88BE-8CA1-459E-9AF1-2782BDD88798_1_101_o](https://user-images.githubusercontent.com/31824852/208282036-93613cee-b620-4624-820d-53012dc10edc.jpeg)

### 9文字 (iPad mini 2)
![3985FF3B-AB22-454D-815F-60C53869D8AA_1_101_o](https://user-images.githubusercontent.com/31824852/208282049-0a2a53b9-eea7-4e6e-ac7e-870815f67297.jpeg)

### 10文字 (iPad mini 2)
![509532BC-DB95-47ED-9C89-FBC8AB36EDBD_1_101_o](https://user-images.githubusercontent.com/31824852/208282052-b6c9c1e9-3524-442c-acd0-edbf0cc70539.jpeg)
