### PR TITLE
iOS/Macでグラデーションを適用

### DIFF
--- a/TRViS/DTAC/StartEndRunButton.xaml.cs
+++ b/TRViS/DTAC/StartEndRunButton.xaml.cs
@@ -11,10 +11,6 @@ public partial class StartEndRunButton : ToggleButton
 	{
 		InitializeComponent();
 
-#if !IOS && !MACCATALYST
-		// iOSとMacCatalystでは、MAUI側のバグによりGradientBrushが適用されない
-		// ref: https://github.com/dotnet/maui/pull/7925
-		// TODO: iOS/MacCatalystでもGradientBrushを適用する
 		LinearGradientBrush brush = new()
 		{
 			StartPoint = new(0, 0),
@@ -25,8 +21,5 @@ public partial class StartEndRunButton : ToggleButton
 		brush.GradientStops.Add(new(GREEN.AddLuminosity(-BUTTON_LUMINOUS_DELTA), 1.0f));
 
 		BaseFrame.Background = brush;
-#else
-		BaseFrame.BackgroundColor = GREEN;
-#endif
 	}
 }


### PR DESCRIPTION
[MAUI 7.0.58](https://github.com/dotnet/maui/releases/tag/7.0.58)にてFrame内のグラデーションが正常に表示されるようになったので、iOS/MacでFrameのグラデーションを無効化していた部分を解除した。

![Screenshot 2023-01-19 at 22 05 40](https://user-images.githubusercontent.com/31824852/213450287-e3411f1e-4aeb-4062-83d8-e45b1e18fbde.png)
