### PR TITLE
`(翌)`表示の実装

### DIFF
--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -142,6 +142,17 @@
 			Grid.Row="3"
 			ColumnDefinitions="{x:Static dtac:VerticalStylePage.TimetableColumnWidthCollection}"
 			BackgroundColor="White">
+			<Label
+				x:Name="IsNextDayLabel"
+				IsVisible="False"
+				Style="{StaticResource LabelStyle}"
+				Text="(翌)"
+				FontSize="24"
+				Grid.Column="0"
+				HorizontalOptions="Center"
+				VerticalOptions="Center"
+				TextColor="#33d"/>
+
 			<Line
 				Style="{StaticResource SeparatorLine}"
 				Grid.Column="0"/>

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -104,9 +104,12 @@ public partial class VerticalStylePage : ContentView
 		BindingContext = newValue;
 		TimetableView.SelectedTrainData = newValue;
 
-		// TODO: https://github.com/TetsuOtter/TRViS/issues/10
-		// 「翌」表示を実装したら、ここも適切な日付を表示するようにする。
-		AffectDate = (newValue?.AffectDate ?? DateOnly.FromDateTime(DateTime.Now)).ToString("yyyy年M月d日");
+		int dayCount = newValue?.DayCount ?? 0;
+		this.IsNextDayLabel.IsVisible = dayCount > 0;
+		AffectDate = (
+			newValue?.AffectDate
+			?? DateOnly.FromDateTime(DateTime.Now).AddDays(-dayCount)
+		).ToString("yyyy年M月d日");
 	}
 
 	private async void VerticalTimetableView_ScrollRequested(object? sender, VerticalTimetableView.ScrollRequestedEventArgs e)

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -9,6 +9,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 	const int WORK_1_1 = 1;
 	const int TRAIN_1_1_1 = 1;
 	const int TRAIN_1_1_2 = 2;
+	const int TRAIN_1_1_3 = 3;
 
 	static readonly List<WorkGroup> WorkGroupList = new()
 	{
@@ -24,6 +25,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 	{
 		new(){ Id = TRAIN_1_1_1, TrainNumber = "Train01" },
 		new(){ Id = TRAIN_1_1_2, TrainNumber = "Train02" },
+		new(){ Id = TRAIN_1_1_3, TrainNumber = "Train03" },
 	};
 
 	static readonly List<TrainDataGroup> TrainDataGroupList = new()
@@ -391,6 +393,58 @@ public class SampleDataLoader : TRViS.IO.ILoader
 	1
 	);
 
+	static readonly IO.Models.TrainData SampleTrainData3 = new(
+	WorkName: "Work1-1",
+	AffectDate: null,
+	TrainNumber: "試単9093",
+	MaxSpeed: null,
+	SpeedType: null,
+	NominalTractiveCapacity: null,
+	CarCount: null,
+	Destination: null,
+	BeginRemarks: null,
+	AfterRemarks: null,
+	Remarks: null,
+	BeforeDeparture: null,
+	TrainInfo: null,
+	Rows: new[]
+	{
+			new TimetableRow(
+				Location: new(1),
+				DriveTimeMM: 1,
+				DriveTimeSS: 5,
+				StationName: "駅１",
+				IsOperationOnlyStop: false,
+				IsPass: false,
+				HasBracket: true,
+				IsLastStop: false,
+				ArriveTime: new(1,23,45,null),
+				DepartureTime: new(1,25,null, null),
+				TrackName: "1",
+				RunInLimit: null,
+				RunOutLimit: 30,
+				Remarks: "記事"
+			),
+			new TimetableRow(
+				Location: new(2),
+				DriveTimeMM: 1,
+				DriveTimeSS: 5,
+				StationName: "駅２",
+				IsOperationOnlyStop: false,
+				IsPass: false,
+				HasBracket: false,
+				IsLastStop: false,
+				ArriveTime: new(null,null,null,null),
+				DepartureTime: new(null,26,10, null),
+				TrackName: "10",
+				RunInLimit: 30,
+				RunOutLimit: 30,
+				Remarks: "<b>記事</b>"
+			),
+	},
+	Direction: 1
+	);
+
 	public void Dispose() { }
 
 	public IO.Models.TrainData? GetTrainData(int trainId)
@@ -398,6 +452,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 		{
 			TRAIN_1_1_1 => SampleTrainData,
 			TRAIN_1_1_2 => SampleTrainData2,
+			TRAIN_1_1_3 => SampleTrainData3,
 			_ => null
 		};
 

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -407,6 +407,9 @@ public class SampleDataLoader : TRViS.IO.ILoader
 	Remarks: null,
 	BeforeDeparture: null,
 	TrainInfo: null,
+
+	DayCount: 1,
+
 	Rows: new[]
 	{
 			new TimetableRow(


### PR DESCRIPTION
泊まり勤務など、間に仮眠を挟むタイプの行路では、翌日分の行路 (明け行路?) にて「(翌)」という表示がなされる。

今回は、それを再現した。

表示のロジックは、「各列車の`DayCount`が0よりも大きいかどうか」である。
なお、施行日(`AffectDate`)が`null`の場合は、実行日から`DayCount`分引かれた日付が表示される仕組みになっている。
ちなみに、`DayCount`が負の数になると、「翌」表示はなされず、また未来の日付が表示されてしまう点に注意が必要である。

![Screenshot 2023-01-20 at 2 06 32](https://user-images.githubusercontent.com/31824852/213513702-20d6a1c7-bfdd-4685-ab5a-010e39d9c098.png)


