### PR TITLE
列車情報と「発前」の表示機能を実装

### DIFF
--- a/TRViS/Controls/ToggleButton.cs
+++ b/TRViS/Controls/ToggleButton.cs
@@ -5,6 +5,8 @@ namespace TRViS.Controls;
 [DependencyProperty<bool>("IsChecked", DefaultBindingMode = DefaultBindingMode.TwoWay)]
 public partial class ToggleButton : ContentView
 {
+	public EventHandler<ValueChangedEventArgs<bool>>? IsCheckedChanged;
+
 	public ToggleButton()
 	{
 		TapGestureRecognizer gestureRecognizer = new();
@@ -16,4 +18,7 @@ public partial class ToggleButton : ContentView
 
 		this.GestureRecognizers.Add(gestureRecognizer);
 	}
+
+	partial void OnIsCheckedChanged(bool oldValue, bool newValue)
+		=> IsCheckedChanged?.Invoke(this, new(oldValue, newValue));
 }

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -1,0 +1,61 @@
+using Microsoft.Maui.Controls.Shapes;
+
+namespace TRViS.DTAC;
+
+public static class DTACElementStyles
+{
+	public static readonly Color DefaultTextColor = new(0x33, 0x33, 0x33);
+	public static readonly Color HeaderTextColor = new(0x55, 0x55, 0x55);
+	public static readonly Color HeaderBackgroundColor = new(0xdd, 0xdd, 0xdd);
+	public static readonly Color SeparatorLineColor = new(0xaa, 0xaa, 0xaa);
+
+	public static readonly int DefaultTextSize = 14;
+	public static readonly int LargeTextSize = 24;
+
+	public static T LabelStyle<T>() where T : Label, new()
+	{
+		T v = new();
+
+		v.HorizontalOptions = LayoutOptions.Center;
+		v.VerticalOptions = LayoutOptions.Center;
+		v.TextColor = DefaultTextColor;
+		v.FontSize = DefaultTextSize;
+		v.FontFamily = "Hiragino Sans";
+		v.Margin = new(4);
+		v.LineBreakMode = LineBreakMode.CharacterWrap;
+
+		v.LineHeight = DeviceInfo.Platform == DevicePlatform.Android ? 0.9 : 1;
+
+		return v;
+	}
+
+	public static T HeaderLabelStyle<T>() where T : Label, new()
+	{
+		T v = LabelStyle<T>();
+
+		v.TextColor = HeaderTextColor;
+
+		return v;
+	}
+
+	public static T LargeLabelStyle<T>() where T : Label, new()
+	{
+		T v = LabelStyle<T>();
+
+		v.FontSize = LargeTextSize;
+
+		return v;
+	}
+
+	public static Line HorizontalSeparatorLineStyle()
+	{
+		Line v = new();
+
+		v.VerticalOptions = LayoutOptions.End;
+		v.BackgroundColor = SeparatorLineColor;
+		v.StrokeThickness = 0.5;
+		v.HeightRequest = 0.5;
+
+		return v;
+	}
+}

--- a/TRViS/DTAC/OpenCloseButton.cs
+++ b/TRViS/DTAC/OpenCloseButton.cs
@@ -7,6 +7,8 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("TextWhenClosed")]
 public partial class OpenCloseButton : Button
 {
+	public event EventHandler<ValueChangedEventArgs<bool>>? IsOpenChanged;
+
 	public OpenCloseButton()
 	{
 		this.SetBinding(TextProperty, new Binding()
@@ -55,4 +57,7 @@ public partial class OpenCloseButton : Button
 
 		Clicked += (_, _) => IsOpen = !IsOpen;
 	}
+
+	partial void OnIsOpenChanged(bool oldValue, bool newValue)
+		=> IsOpenChanged?.Invoke(this, new(oldValue, newValue));
 }

--- a/TRViS/DTAC/PageHeader.cs
+++ b/TRViS/DTAC/PageHeader.cs
@@ -1,0 +1,95 @@
+using DependencyPropertyGenerator;
+
+namespace TRViS.DTAC;
+
+[DependencyProperty<bool>("IsOpen")]
+[DependencyProperty<bool>("IsRunning")]
+public partial class PageHeader : Grid
+{
+	static readonly ColumnDefinitionCollection DefaultColumnDefinitions = new()
+	{
+		new ColumnDefinition(new GridLength(1, GridUnitType.Star)),
+		new ColumnDefinition(160),
+		new ColumnDefinition(120),
+		new ColumnDefinition(80),
+	};
+
+	#region Affect Date Label
+	const string AffectDateLabelTextPrefix = "行路施行日\n";
+
+	readonly Label AffectDateLabel = DTACElementStyles.LabelStyle<Label>();
+
+	string _AffectDateLabelText = "";
+	public string AffectDateLabelText
+	{
+		get => _AffectDateLabelText;
+		set
+		{
+			if (_AffectDateLabelText == value)
+				return;
+
+			_AffectDateLabelText = value;
+
+			AffectDateLabel.Text = AffectDateLabelTextPrefix + value;
+		}
+	}
+	#endregion
+
+	#region Start / End Run Button
+	readonly StartEndRunButton StartEndRunButton = new();
+
+	partial void OnIsRunningChanged(bool newValue)
+		=> StartEndRunButton.IsChecked = newValue;
+	#endregion
+
+	#region Open / Close Button
+	readonly OpenCloseButton OpenCloseButton = new();
+
+	public event EventHandler<ValueChangedEventArgs<bool>>? IsOpenChanged
+	{
+		add => OpenCloseButton.IsOpenChanged += value;
+		remove => OpenCloseButton.IsOpenChanged -= value;
+	}
+
+	partial void OnIsOpenChanged(bool newValue)
+		=> OpenCloseButton.IsOpen = newValue;
+
+	private void OpenCloseButton_IsOpenChanged(object? sender, ValueChangedEventArgs<bool> e)
+	{
+		IsOpen = e.NewValue;
+	}
+	#endregion
+
+	public PageHeader()
+	{
+		ColumnDefinitions = DefaultColumnDefinitions;
+
+		AffectDateLabel.Margin = new(18, 4);
+		AffectDateLabel.FontSize = 18;
+		AffectDateLabel.HorizontalOptions = LayoutOptions.Start;
+		AffectDateLabel.Text = AffectDateLabelTextPrefix;
+
+		StartEndRunButton.VerticalOptions = LayoutOptions.Center;
+		StartEndRunButton.HorizontalOptions = LayoutOptions.End;
+		StartEndRunButton.Margin = new(2);
+		StartEndRunButton.IsCheckedChanged += (_, e) => this.IsRunning = e.NewValue;
+
+		OpenCloseButton.TextWhenOpen = "\xe5ce";
+		OpenCloseButton.TextWhenClosed = "\xe5cf";
+		OpenCloseButton.IsOpenChanged += OpenCloseButton_IsOpenChanged;
+		OpenCloseButton.HorizontalOptions = LayoutOptions.Center;
+		OpenCloseButton.VerticalOptions = LayoutOptions.Center;
+
+		this.Add(
+			AffectDateLabel,
+			column: 0
+		);
+		this.Add(StartEndRunButton,
+			column: 1
+		);
+		this.Add(
+			OpenCloseButton,
+			column: 3
+		);
+	}
+}

--- a/TRViS/DTAC/Remarks.xaml
+++ b/TRViS/DTAC/Remarks.xaml
@@ -36,7 +36,7 @@
 		Grid.Row="0"
 		TextWhenOpen="&#xe5cf;"
 		TextWhenClosed="&#xe5ce;"
-		IsOpen="{Binding IsOpen}"
+		IsOpenChanged="OpenCloseButton_IsOpenChanged"
 		Margin="16,0"
 		HorizontalOptions="End"
 		VerticalOptions="Center"/>

--- a/TRViS/DTAC/Remarks.xaml.cs
+++ b/TRViS/DTAC/Remarks.xaml.cs
@@ -6,7 +6,7 @@ using TRViS.IO.Models;
 
 namespace TRViS.DTAC;
 
-[DependencyProperty<bool>("IsOpen", DefaultBindingMode = DefaultBindingMode.TwoWay)]
+[DependencyProperty<bool>("IsOpen", DefaultBindingMode = DefaultBindingMode.TwoWay, IsReadOnly = true)]
 [DependencyProperty<IHasRemarksProperty>("RemarksData", DefaultBindingMode = DefaultBindingMode.TwoWay)]
 [DependencyProperty<GridLength>("ContentAreaHeight", IsReadOnly = true)]
 [DependencyProperty<double>("BottomSafeAreaHeight")]
@@ -61,4 +61,7 @@ public partial class Remarks : Grid
 
 		base.OnSizeAllocated(width, height);
 	}
+
+	void OpenCloseButton_IsOpenChanged(object sender, ValueChangedEventArgs<bool> e)
+		=> this.IsOpen = e.NewValue;
 }

--- a/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
@@ -1,0 +1,109 @@
+using Microsoft.Maui.Controls.Shapes;
+
+using TRViS.Controls;
+
+namespace TRViS.DTAC;
+
+public partial class TrainInfo_BeforeDeparture : Grid
+{
+	public const int DEFAULT_ROW_HEIGHT = 48;
+	static readonly RowDefinitionCollection DefaultRowDefinitions = new()
+	{
+		new RowDefinition(DEFAULT_ROW_HEIGHT),
+		new RowDefinition(DEFAULT_ROW_HEIGHT)
+	};
+
+	static readonly ColumnDefinitionCollection DefaultColumnDefinitions = new()
+	{
+		new ColumnDefinition(VerticalStylePage.RUN_TIME_COLUMN_WIDTH),
+		new ColumnDefinition(140 * 3),
+		new ColumnDefinition(new(1, GridUnitType.Star)),
+	};
+
+	#region TrainInfo Area
+	readonly HtmlAutoDetectLabel TrainInfoArea = DTACElementStyles.LargeLabelStyle<HtmlAutoDetectLabel>();
+
+	public string TrainInfoText
+	{
+		get => TrainInfoArea.Text;
+		set => TrainInfoArea.Text = value;
+	}
+	#endregion
+
+	#region TrainInfo Area
+	readonly HtmlAutoDetectLabel BeforeDepartureArea = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
+	readonly HtmlAutoDetectLabel BeforeDepartureArea_OnStationTrackColumn = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
+
+	public string BeforeDepartureText
+	{
+		get => BeforeDepartureArea.Text;
+		set => BeforeDepartureArea.Text = value;
+	}
+
+	public string BeforeDepartureText_OnStationTrackColumn
+	{
+		get => BeforeDepartureArea_OnStationTrackColumn.Text;
+		set => BeforeDepartureArea_OnStationTrackColumn.Text = value;
+	}
+	#endregion
+
+	public TrainInfo_BeforeDeparture()
+	{
+		RowDefinitions = DefaultRowDefinitions;
+		ColumnDefinitions = DefaultColumnDefinitions;
+
+		Line trainInfoAreaSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
+		TrainInfoArea.HorizontalOptions = LayoutOptions.Start;
+
+		// BeforeDepartureArea
+		Line beforeDepartureAreaSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
+		BoxView beforeDepartureHeaderBoxView = new()
+		{
+			BackgroundColor = DTACElementStyles.HeaderBackgroundColor,
+			Color = DTACElementStyles.HeaderBackgroundColor,
+			Margin = new(0),
+		};
+		Label beforeDepartureHeaderLabel = DTACElementStyles.HeaderLabelStyle<Label>();
+		beforeDepartureHeaderLabel.HorizontalOptions = LayoutOptions.Center;
+		beforeDepartureHeaderLabel.Text = "発前";
+
+		BeforeDepartureArea.HorizontalOptions = LayoutOptions.Start;
+		BeforeDepartureArea_OnStationTrackColumn.HorizontalOptions = LayoutOptions.Start;
+
+		Grid.SetColumnSpan(trainInfoAreaSeparator, 3);
+		Grid.SetColumnSpan(TrainInfoArea, 3);
+		this.Add(
+			trainInfoAreaSeparator,
+			row: 0
+		);
+		this.Add(
+			TrainInfoArea,
+			row: 0
+		);
+
+		Grid.SetColumnSpan(beforeDepartureAreaSeparator, 3);
+		Grid.SetColumnSpan(BeforeDepartureArea, 2);
+		this.Add(
+			beforeDepartureAreaSeparator,
+			row: 1
+		);
+		this.Add(
+			beforeDepartureHeaderBoxView,
+			row: 1
+		);
+		this.Add(
+			beforeDepartureHeaderLabel,
+			row: 1
+		);
+		this.Add(
+			BeforeDepartureArea,
+			column: 1,
+			row: 1
+		);
+		this.Add(
+			BeforeDepartureArea_OnStationTrackColumn,
+			column: 2,
+			row: 1
+		);
+	}
+}

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -22,45 +22,11 @@
 		IgnoreSafeArea="True"
 		MinimumWidthRequest="740">
 
-		<Grid
+		<dtac:PageHeader
+			x:Name="PageHeaderArea"
 			Grid.Row="0"
-			BackgroundColor="White">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*"/>
-				<ColumnDefinition Width="160"/>
-				<ColumnDefinition Width="120"/>
-				<ColumnDefinition Width="80"/>
-			</Grid.ColumnDefinitions>
-
-			<Label
-				Style="{StaticResource LabelStyle}"
-				Margin="18,4"
-				FontSize="18"
-				HorizontalOptions="Start">
-				<Label.FormattedText>
-					<FormattedString>
-						<Span Text="行路施行日&#xa;"/>
-						<Span Text="{Binding AffectDate, Source={x:Reference this}}"/>
-					</FormattedString>
-				</Label.FormattedText>
-			</Label>
-
-			<dtac:StartEndRunButton
-				x:Name="StartEndRunButton"
-				Grid.Column="1"
-				VerticalOptions="Center"
-				HorizontalOptions="End"
-				Margin="2"/>
-
-			<dtac:OpenCloseButton
-				Grid.Column="3"
-				TextWhenOpen="&#xe5ce;"
-				TextWhenClosed="&#xe5cf;"
-				IsOpenChanged="BeforeRemarks_TrainInfo_OpenCloseChanged"
-				Margin="0"
-				HorizontalOptions="Center"
-				VerticalOptions="Center"/>
-		</Grid>
+			IsOpenChanged="BeforeRemarks_TrainInfo_OpenCloseChanged"
+			BackgroundColor="White"/>
 
 		<Grid
 			Grid.Row="1"

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -52,6 +52,14 @@
 				HorizontalOptions="End"
 				Margin="2"/>
 
+			<dtac:OpenCloseButton
+				Grid.Column="3"
+				TextWhenOpen="&#xe5ce;"
+				TextWhenClosed="&#xe5cf;"
+				IsOpenChanged="BeforeRemarks_TrainInfo_OpenCloseChanged"
+				Margin="0"
+				HorizontalOptions="Center"
+				VerticalOptions="Center"/>
 		</Grid>
 
 		<Grid

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -111,8 +111,12 @@
 			Grid.Row="2"
 			Style="{StaticResource TimetableSeparatorLine}"/>
 
+		<dtac:TrainInfo_BeforeDeparture
+			x:Name="TrainInfo_BeforeDepartureArea"
+			Grid.Row="3"/>
+
 		<Grid
-			Grid.Row="3"
+			Grid.Row="4"
 			ColumnDefinitions="{x:Static dtac:VerticalStylePage.TimetableColumnWidthCollection}"
 			BackgroundColor="White">
 			<Line
@@ -170,11 +174,11 @@
 			x:Name="TimetableHeader"
 			BackgroundColor="#ddd"
 			FontSize_Large="28"
-			Grid.Row="4"/>
+			Grid.Row="5"/>
 
 		<ScrollView
 			x:Name="TimetableAreaScrollView"
-			Grid.Row="5"/>
+			Grid.Row="6"/>
 
 		<Frame
 			x:Name="TimetableViewActivityIndicatorFrame"
@@ -185,7 +189,7 @@
 			WidthRequest="50"
 			Margin="8"
 			CornerRadius="25"
-			Grid.Row="5">
+			Grid.Row="6">
 			<ActivityIndicator
 				IsRunning="True"/>
 		</Frame>

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -19,7 +19,6 @@
 
 	<Grid
 		x:Name="MainGrid"
-		RowDefinitions="{x:Static dtac:VerticalStylePage.PageRowDefinitionCollection}"
 		IgnoreSafeArea="True"
 		MinimumWidthRequest="740">
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -24,15 +24,17 @@ public partial class VerticalStylePage : ContentView
 	const double DATE_AND_START_BUTTON_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 60;
+	const double TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT = TrainInfo_BeforeDeparture.DEFAULT_ROW_HEIGHT * 2;
 	const double CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT = 60;
 	const double TIMETABLE_HEADER_ROW_HEIGHT = 60;
 
-	RowDefinition DateAndStartButtonRowDefinition { get; } = new(DATE_AND_START_BUTTON_ROW_HEIGHT);
+	RowDefinition TrainInfo_BeforeDepature_RowDefinition { get; } = new(0);
 
 	const double CONTENT_OTHER_THAN_TIMETABLE_HEIGHT
-		= DATE_AND_START_BUTTON_ROW_HEIGHT * 3
+		= DATE_AND_START_BUTTON_ROW_HEIGHT
 		+ TRAIN_INFO_HEADER_ROW_HEIGHT
 		+ TRAIN_INFO_ROW_HEIGHT
+		+ TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT
 		+ CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT
 		+ TIMETABLE_HEADER_ROW_HEIGHT;
 
@@ -45,9 +47,10 @@ public partial class VerticalStylePage : ContentView
 		InitializeComponent();
 
 		MainGrid.RowDefinitions = new(
-			DateAndStartButtonRowDefinition,
+			new(DATE_AND_START_BUTTON_ROW_HEIGHT),
 			new(new(TRAIN_INFO_HEADER_ROW_HEIGHT)),
 			new(new(TRAIN_INFO_ROW_HEIGHT)),
+			TrainInfo_BeforeDepature_RowDefinition,
 			new(new(CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT)),
 			new(new(TIMETABLE_HEADER_ROW_HEIGHT)),
 			new(new(1, GridUnitType.Star))
@@ -107,6 +110,10 @@ public partial class VerticalStylePage : ContentView
 		BindingContext = newValue;
 		TimetableView.SelectedTrainData = newValue;
 
+		TrainInfo_BeforeDepartureArea.TrainInfoText = newValue?.TrainInfo ?? "";
+		TrainInfo_BeforeDepartureArea.BeforeDepartureText = newValue?.BeforeDeparture ?? "";
+		TrainInfo_BeforeDepartureArea.BeforeDepartureText_OnStationTrackColumn = newValue?.BeforeDepartureOnStationTrackCol ?? "";
+
 		// TODO: https://github.com/TetsuOtter/TRViS/issues/10
 		// 「翌」表示を実装したら、ここも適切な日付を表示するようにする。
 		AffectDate = (newValue?.AffectDate ?? DateOnly.FromDateTime(DateTime.Now)).ToString("yyyy年M月d日");
@@ -124,9 +131,9 @@ public partial class VerticalStylePage : ContentView
 	const string DateAndStartButton_AnimationName = nameof(DateAndStartButton_AnimationName);
 	void BeforeRemarks_TrainInfo_OpenCloseChanged(object sender, ValueChangedEventArgs<bool> e)
 	{
-		(double start, double end) = e.NewValue ? (3, 1) : (1, 3);
+		(double start, double end) = e.NewValue ? (TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT, 0d) : (0d, TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT);
 
-		new Animation(v => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v, start, end, Easing.SinInOut)
-			.Commit(this, DateAndStartButton_AnimationName, length: 250, finished: (v, _) => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v);
+		new Animation(v => TrainInfo_BeforeDepature_RowDefinition.Height = v, start, end, Easing.SinInOut)
+			.Commit(this, DateAndStartButton_AnimationName, length: 250, finished: (v, _) => TrainInfo_BeforeDepature_RowDefinition.Height = v);
 	}
 }

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -86,8 +86,8 @@ public partial class VerticalStylePage : ContentView
 
 		TimetableView.SetBinding(VerticalTimetableView.IsRunStartedProperty, new Binding()
 		{
-			Source = this.StartEndRunButton,
-			Path = nameof(StartEndRunButton.IsChecked)
+			Source = this.PageHeaderArea,
+			Path = nameof(PageHeader.IsRunning)
 		});
 
 		TimetableView.ScrollRequested += VerticalTimetableView_ScrollRequested;
@@ -111,6 +111,9 @@ public partial class VerticalStylePage : ContentView
 		// 「翌」表示を実装したら、ここも適切な日付を表示するようにする。
 		AffectDate = (newValue?.AffectDate ?? DateOnly.FromDateTime(DateTime.Now)).ToString("yyyy年M月d日");
 	}
+
+	partial void OnAffectDateChanged(string? newValue)
+	 => PageHeaderArea.AffectDateLabelText = newValue ?? "";
 
 	private async void VerticalTimetableView_ScrollRequested(object? sender, VerticalTimetableView.ScrollRequestedEventArgs e)
 	{

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -124,6 +124,6 @@ public partial class VerticalStylePage : ContentView
 		(double start, double end) = e.NewValue ? (3, 1) : (1, 3);
 
 		new Animation(v => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v, start, end, Easing.SinInOut)
-			.Commit(this, DateAndStartButton_AnimationName, length: 3000, finished: (v, _) => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v);
+			.Commit(this, DateAndStartButton_AnimationName, length: 250, finished: (v, _) => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v);
 	}
 }

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -26,14 +26,8 @@ public partial class VerticalStylePage : ContentView
 	const double TRAIN_INFO_ROW_HEIGHT = 60;
 	const double CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT = 60;
 	const double TIMETABLE_HEADER_ROW_HEIGHT = 60;
-	static public RowDefinitionCollection PageRowDefinitionCollection => new(
-		new(new(DATE_AND_START_BUTTON_ROW_HEIGHT)),
-		new(new(TRAIN_INFO_HEADER_ROW_HEIGHT)),
-		new(new(TRAIN_INFO_ROW_HEIGHT)),
-		new(new(CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT)),
-		new(new(TIMETABLE_HEADER_ROW_HEIGHT)),
-		new(new(1, GridUnitType.Star))
-		);
+
+	RowDefinition DateAndStartButtonRowDefinition { get; } = new(DATE_AND_START_BUTTON_ROW_HEIGHT);
 
 	const double CONTENT_OTHER_THAN_TIMETABLE_HEIGHT
 		= DATE_AND_START_BUTTON_ROW_HEIGHT
@@ -49,6 +43,15 @@ public partial class VerticalStylePage : ContentView
 	public VerticalStylePage()
 	{
 		InitializeComponent();
+
+		MainGrid.RowDefinitions = new(
+			DateAndStartButtonRowDefinition,
+			new(new(TRAIN_INFO_HEADER_ROW_HEIGHT)),
+			new(new(TRAIN_INFO_ROW_HEIGHT)),
+			new(new(CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT)),
+			new(new(TIMETABLE_HEADER_ROW_HEIGHT)),
+			new(new(1, GridUnitType.Star))
+		);
 
 		this.TimetableHeader.MarkerSettings = TimetableView.MarkerViewModel;
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -30,7 +30,7 @@ public partial class VerticalStylePage : ContentView
 	RowDefinition DateAndStartButtonRowDefinition { get; } = new(DATE_AND_START_BUTTON_ROW_HEIGHT);
 
 	const double CONTENT_OTHER_THAN_TIMETABLE_HEIGHT
-		= DATE_AND_START_BUTTON_ROW_HEIGHT
+		= DATE_AND_START_BUTTON_ROW_HEIGHT * 3
 		+ TRAIN_INFO_HEADER_ROW_HEIGHT
 		+ TRAIN_INFO_ROW_HEIGHT
 		+ CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT
@@ -116,5 +116,14 @@ public partial class VerticalStylePage : ContentView
 	{
 		if (DeviceInfo.Current.Idiom != DeviceIdiom.Phone && DeviceInfo.Current.Idiom != DeviceIdiom.Unknown)
 			await TimetableAreaScrollView.ScrollToAsync(TimetableAreaScrollView.ScrollX, e.PositionY, true);
+	}
+
+	const string DateAndStartButton_AnimationName = nameof(DateAndStartButton_AnimationName);
+	void BeforeRemarks_TrainInfo_OpenCloseChanged(object sender, ValueChangedEventArgs<bool> e)
+	{
+		(double start, double end) = e.NewValue ? (3, 1) : (1, 3);
+
+		new Animation(v => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v, start, end, Easing.SinInOut)
+			.Commit(this, DateAndStartButton_AnimationName, length: 3000, finished: (v, _) => DateAndStartButtonRowDefinition.Height = DATE_AND_START_BUTTON_ROW_HEIGHT * v);
 	}
 }

--- a/TRViS/Utils/ValueChangedEventArgs.cs
+++ b/TRViS/Utils/ValueChangedEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace TRViS;
+
+public class ValueChangedEventArgs<T> : EventArgs
+{
+	public T OldValue { get; }
+	public T NewValue { get; }
+
+	public ValueChangedEventArgs(in T oldValue, in T newValue)
+	{
+		OldValue = oldValue;
+		NewValue = newValue;
+	}
+}


### PR DESCRIPTION
位置情報ボタン右横の「v」ボタンを押下することで表示される、列車情報(?)と「発前」エリアの表示機能を追加した。

両者とも、HTMLにて書式設定が可能である。
なお、本物がどんな風に内容の表示をするかは不明である。

![Screenshot 2023-01-20 at 4 34 26](https://user-images.githubusercontent.com/31824852/213542497-b83df928-735e-483a-8f5b-c1a2554c33c8.png)
