### PR TITLE
AfterRemarks / AfterArrive

### DIFF
--- a/TRViS/DTAC/BeforeAfterRemarks.cs
+++ b/TRViS/DTAC/BeforeAfterRemarks.cs
@@ -1,0 +1,71 @@
+using Microsoft.Maui.Controls.Shapes;
+
+using TRViS.Controls;
+
+namespace TRViS.DTAC;
+
+public class BeforeAfterRemarks
+{
+	Grid Parent;
+
+	public BeforeAfterRemarks(Grid Parent)
+	{
+		this.Parent = Parent;
+
+		IsVisible = false;
+
+		Grid.SetColumn(Label, 2);
+		Grid.SetColumnSpan(Label, 6);
+
+		Label.Margin = new(32, 0);
+		Label.HorizontalOptions = LayoutOptions.Start;
+		Label.LineHeight = 1.4;
+	}
+
+	readonly HtmlAutoDetectLabel Label = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
+	readonly Line Separator = DTACElementStyles.HorizontalSeparatorLineStyle();
+
+	public string Text
+	{
+		get => Label.Text;
+		set
+		{
+			if (Label.Text == value)
+				return;
+
+			IsVisible = !string.IsNullOrWhiteSpace(value);
+
+			Label.Text = value;
+		}
+	}
+
+	public void AddToParent()
+	{
+		Parent.Add(Label);
+		Parent.Add(Separator);
+	}
+
+	bool _IsVisible = false;
+	public bool IsVisible
+	{
+		get => _IsVisible;
+		set
+		{
+			_IsVisible = value;
+			Label.IsVisible = value;
+			Separator.IsVisible = value;
+		}
+	}
+
+	public void IsElementUnderThisVisible(in bool isVisible)
+	{
+		Separator.IsVisible = _IsVisible || isVisible;
+	}
+
+	public void SetRow(in int row)
+	{
+		Grid.SetRow(Label, row);
+		Grid.SetRow(Separator, row);
+	}
+}
+

--- a/TRViS/DTAC/BeforeAfterRemarks.cs
+++ b/TRViS/DTAC/BeforeAfterRemarks.cs
@@ -23,7 +23,6 @@ public class BeforeAfterRemarks
 	}
 
 	readonly HtmlAutoDetectLabel Label = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
-	readonly Line Separator = DTACElementStyles.HorizontalSeparatorLineStyle();
 
 	public string Text
 	{
@@ -42,7 +41,6 @@ public class BeforeAfterRemarks
 	public void AddToParent()
 	{
 		Parent.Add(Label);
-		Parent.Add(Separator);
 	}
 
 	bool _IsVisible = false;
@@ -53,19 +51,12 @@ public class BeforeAfterRemarks
 		{
 			_IsVisible = value;
 			Label.IsVisible = value;
-			Separator.IsVisible = value;
 		}
-	}
-
-	public void IsElementUnderThisVisible(in bool isVisible)
-	{
-		Separator.IsVisible = _IsVisible || isVisible;
 	}
 
 	public void SetRow(in int row)
 	{
 		Grid.SetRow(Label, row);
-		Grid.SetRow(Separator, row);
 	}
 }
 

--- a/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
+++ b/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
@@ -16,7 +16,8 @@ public class BeforeDeparture_AfterArrive
 	};
 	readonly Label HeaderLabel = DTACElementStyles.HeaderLabelStyle<Label>();
 
-	readonly Line Separator = DTACElementStyles.HorizontalSeparatorLineStyle();
+	readonly Line UpperSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
+	readonly Line LowerSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
 
 	readonly HtmlAutoDetectLabel Label = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
 	readonly HtmlAutoDetectLabel Label_OnStationTrackColumn = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
@@ -26,6 +27,8 @@ public class BeforeDeparture_AfterArrive
 	public BeforeDeparture_AfterArrive(Grid Parent, string HeaderLabelText)
 	{
 		this.Parent = Parent;
+
+		UpperSeparator.VerticalOptions = LayoutOptions.Start;
 
 		Label.HorizontalOptions = LayoutOptions.Start;
 		Label_OnStationTrackColumn.HorizontalOptions = LayoutOptions.Start;
@@ -65,7 +68,8 @@ public class BeforeDeparture_AfterArrive
 		Parent.Add(HeaderLabel);
 		Parent.Add(Label);
 		Parent.Add(Label_OnStationTrackColumn);
-		Parent.Add(Separator);
+		Parent.Add(LowerSeparator);
+		Parent.Add(UpperSeparator);
 	}
 
 	bool _IsVisible = false;
@@ -81,7 +85,8 @@ public class BeforeDeparture_AfterArrive
 
 			HeaderBoxView.IsVisible
 				= HeaderLabel.IsVisible
-				= Separator.IsVisible
+				= LowerSeparator.IsVisible
+				= UpperSeparator.IsVisible
 				= Label.IsVisible
 				= Label_OnStationTrackColumn.IsVisible
 				= value;
@@ -92,7 +97,8 @@ public class BeforeDeparture_AfterArrive
 	{
 		Grid.SetRow(HeaderBoxView, row);
 		Grid.SetRow(HeaderLabel, row);
-		Grid.SetRow(Separator, row);
+		Grid.SetRow(LowerSeparator, row);
+		Grid.SetRow(UpperSeparator, row);
 		Grid.SetRow(Label, row);
 		Grid.SetRow(Label_OnStationTrackColumn, row);
 	}

--- a/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
+++ b/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
@@ -1,0 +1,100 @@
+using Microsoft.Maui.Controls.Shapes;
+
+using TRViS.Controls;
+
+namespace TRViS.DTAC;
+
+public class BeforeDeparture_AfterArrive
+{
+	public readonly RowDefinition RowDefinition = new(DTACElementStyles.BeforeDeparture_AfterArrive_Height);
+
+	readonly BoxView HeaderBoxView = new()
+	{
+		IsVisible = false,
+		Margin = new(0),
+		Color = DTACElementStyles.HeaderBackgroundColor,
+	};
+	readonly Label HeaderLabel = DTACElementStyles.HeaderLabelStyle<Label>();
+
+	readonly Line Separator = DTACElementStyles.HorizontalSeparatorLineStyle();
+
+	readonly HtmlAutoDetectLabel Label = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
+	readonly HtmlAutoDetectLabel Label_OnStationTrackColumn = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
+
+	Grid Parent { get; }
+
+	public BeforeDeparture_AfterArrive(Grid Parent, string HeaderLabelText)
+	{
+		this.Parent = Parent;
+
+		Label.HorizontalOptions = LayoutOptions.Start;
+		Label_OnStationTrackColumn.HorizontalOptions = LayoutOptions.Start;
+
+		Grid.SetColumn(Label, 1);
+		Grid.SetColumnSpan(Label, 7);
+
+		Grid.SetColumn(Label_OnStationTrackColumn, 4);
+		Grid.SetColumnSpan(Label_OnStationTrackColumn, 4);
+
+		HeaderLabel.Text = HeaderLabelText;
+	}
+
+	public string Text
+	{
+		get => Label.Text;
+		set
+		{
+			if (Label.Text == value)
+				return;
+
+			IsVisible = !string.IsNullOrWhiteSpace(value);
+
+			Label.Text = value;
+		}
+	}
+
+	public string Text_OnStationTrackColumn
+	{
+		get => Label_OnStationTrackColumn.Text;
+		set => Label_OnStationTrackColumn.Text = value;
+	}
+
+	public void AddToParent()
+	{
+		Parent.Add(HeaderBoxView);
+		Parent.Add(HeaderLabel);
+		Parent.Add(Label);
+		Parent.Add(Label_OnStationTrackColumn);
+		Parent.Add(Separator);
+	}
+
+	bool _IsVisible = false;
+	public bool IsVisible
+	{
+		get => _IsVisible;
+		set
+		{
+			if (_IsVisible == value)
+				return;
+
+			_IsVisible = value;
+
+			HeaderBoxView.IsVisible
+				= HeaderLabel.IsVisible
+				= Separator.IsVisible
+				= Label.IsVisible
+				= Label_OnStationTrackColumn.IsVisible
+				= value;
+		}
+	}
+
+	public void SetRow(in int row)
+	{
+		Grid.SetRow(HeaderBoxView, row);
+		Grid.SetRow(HeaderLabel, row);
+		Grid.SetRow(Separator, row);
+		Grid.SetRow(Label, row);
+		Grid.SetRow(Label_OnStationTrackColumn, row);
+	}
+}
+

--- a/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
+++ b/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
@@ -23,10 +23,15 @@ public class BeforeDeparture_AfterArrive
 	readonly HtmlAutoDetectLabel Label_OnStationTrackColumn = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
 
 	Grid Parent { get; }
+	bool AlwaysShow { get; }
 
 	public BeforeDeparture_AfterArrive(Grid Parent, string HeaderLabelText)
+		: this(Parent, HeaderLabelText, false) { }
+
+	public BeforeDeparture_AfterArrive(Grid Parent, string HeaderLabelText, bool AlwaysShow)
 	{
 		this.Parent = Parent;
+		this.AlwaysShow = AlwaysShow;
 
 		UpperSeparator.VerticalOptions = LayoutOptions.Start;
 
@@ -40,6 +45,8 @@ public class BeforeDeparture_AfterArrive
 		Grid.SetColumnSpan(Label_OnStationTrackColumn, 4);
 
 		HeaderLabel.Text = HeaderLabelText;
+
+		IsVisible = AlwaysShow;
 	}
 
 	public string Text
@@ -50,7 +57,8 @@ public class BeforeDeparture_AfterArrive
 			if (Label.Text == value)
 				return;
 
-			IsVisible = !string.IsNullOrWhiteSpace(value);
+			if (!AlwaysShow)
+				IsVisible = !string.IsNullOrWhiteSpace(value);
 
 			Label.Text = value;
 		}

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -12,6 +12,8 @@ public static class DTACElementStyles
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;
 
+	public static readonly int BeforeDeparture_AfterArrive_Height = 48;
+
 	public const double RUN_TIME_COLUMN_WIDTH = 48;
 	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(
 		new(new(RUN_TIME_COLUMN_WIDTH)),

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -70,6 +70,8 @@ public static class DTACElementStyles
 		v.StrokeThickness = 0.5;
 		v.HeightRequest = 0.5;
 
+		Grid.SetColumnSpan(v, 8);
+
 		return v;
 	}
 }

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -12,6 +12,18 @@ public static class DTACElementStyles
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;
 
+	public const double RUN_TIME_COLUMN_WIDTH = 48;
+	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(
+		new(new(RUN_TIME_COLUMN_WIDTH)),
+		new(new(140)),
+		new(new(140)),
+		new(new(140)),
+		new(new(60)),
+		new(new(60)),
+		new(new(1, GridUnitType.Star)),
+		new(new(64))
+		);
+
 	public static T LabelStyle<T>() where T : Label, new()
 	{
 		T v = new();

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -12,7 +12,7 @@ public static class DTACElementStyles
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;
 
-	public static readonly int BeforeDeparture_AfterArrive_Height = 48;
+	public const int BeforeDeparture_AfterArrive_Height = 45;
 
 	public const double RUN_TIME_COLUMN_WIDTH = 60;
 	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -14,7 +14,7 @@ public static class DTACElementStyles
 
 	public static readonly int BeforeDeparture_AfterArrive_Height = 48;
 
-	public const double RUN_TIME_COLUMN_WIDTH = 48;
+	public const double RUN_TIME_COLUMN_WIDTH = 60;
 	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(
 		new(new(RUN_TIME_COLUMN_WIDTH)),
 		new(new(140)),

--- a/TRViS/DTAC/TimetableHeader.xaml
+++ b/TRViS/DTAC/TimetableHeader.xaml
@@ -4,7 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:dtac="clr-namespace:TRViS.DTAC"
 	x:Class="TRViS.DTAC.TimetableHeader"
-	ColumnDefinitions="{x:Static dtac:VerticalStylePage.TimetableColumnWidthCollection}">
+	ColumnDefinitions="{x:Static dtac:DTACElementStyles.TimetableColumnWidthCollection}">
 	<Grid.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>

--- a/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
@@ -44,17 +44,12 @@ public partial class TrainInfo_BeforeDeparture : Grid
 		RowDefinitions = DefaultRowDefinitions;
 		ColumnDefinitions = DTACElementStyles.TimetableColumnWidthCollection;
 
-		Line trainInfoAreaSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
 		TrainInfoArea.HorizontalOptions = LayoutOptions.Start;
 
 		// BeforeDepartureArea
 		BeforeDeparture = new(this, "発前");
 
 		Grid.SetColumnSpan(TrainInfoArea, 8);
-		this.Add(
-			trainInfoAreaSeparator,
-			row: 0
-		);
 		this.Add(
 			TrainInfoArea,
 			row: 0

--- a/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
@@ -13,13 +13,6 @@ public partial class TrainInfo_BeforeDeparture : Grid
 		new RowDefinition(DEFAULT_ROW_HEIGHT)
 	};
 
-	static readonly ColumnDefinitionCollection DefaultColumnDefinitions = new()
-	{
-		new ColumnDefinition(VerticalStylePage.RUN_TIME_COLUMN_WIDTH),
-		new ColumnDefinition(140 * 3),
-		new ColumnDefinition(new(1, GridUnitType.Star)),
-	};
-
 	#region TrainInfo Area
 	readonly HtmlAutoDetectLabel TrainInfoArea = DTACElementStyles.LargeLabelStyle<HtmlAutoDetectLabel>();
 
@@ -30,48 +23,34 @@ public partial class TrainInfo_BeforeDeparture : Grid
 	}
 	#endregion
 
-	#region TrainInfo Area
-	readonly HtmlAutoDetectLabel BeforeDepartureArea = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
-	readonly HtmlAutoDetectLabel BeforeDepartureArea_OnStationTrackColumn = DTACElementStyles.LabelStyle<HtmlAutoDetectLabel>();
+	#region Before Departure Area
+	readonly BeforeDeparture_AfterArrive BeforeDeparture;
 
 	public string BeforeDepartureText
 	{
-		get => BeforeDepartureArea.Text;
-		set => BeforeDepartureArea.Text = value;
+		get => BeforeDeparture.Text;
+		set => BeforeDeparture.Text = value;
 	}
 
 	public string BeforeDepartureText_OnStationTrackColumn
 	{
-		get => BeforeDepartureArea_OnStationTrackColumn.Text;
-		set => BeforeDepartureArea_OnStationTrackColumn.Text = value;
+		get => BeforeDeparture.Text_OnStationTrackColumn;
+		set => BeforeDeparture.Text_OnStationTrackColumn = value;
 	}
 	#endregion
 
 	public TrainInfo_BeforeDeparture()
 	{
 		RowDefinitions = DefaultRowDefinitions;
-		ColumnDefinitions = DefaultColumnDefinitions;
+		ColumnDefinitions = DTACElementStyles.TimetableColumnWidthCollection;
 
 		Line trainInfoAreaSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
 		TrainInfoArea.HorizontalOptions = LayoutOptions.Start;
 
 		// BeforeDepartureArea
-		Line beforeDepartureAreaSeparator = DTACElementStyles.HorizontalSeparatorLineStyle();
-		BoxView beforeDepartureHeaderBoxView = new()
-		{
-			BackgroundColor = DTACElementStyles.HeaderBackgroundColor,
-			Color = DTACElementStyles.HeaderBackgroundColor,
-			Margin = new(0),
-		};
-		Label beforeDepartureHeaderLabel = DTACElementStyles.HeaderLabelStyle<Label>();
-		beforeDepartureHeaderLabel.HorizontalOptions = LayoutOptions.Center;
-		beforeDepartureHeaderLabel.Text = "発前";
+		BeforeDeparture = new(this, "発前");
 
-		BeforeDepartureArea.HorizontalOptions = LayoutOptions.Start;
-		BeforeDepartureArea_OnStationTrackColumn.HorizontalOptions = LayoutOptions.Start;
-
-		Grid.SetColumnSpan(trainInfoAreaSeparator, 3);
-		Grid.SetColumnSpan(TrainInfoArea, 3);
+		Grid.SetColumnSpan(TrainInfoArea, 8);
 		this.Add(
 			trainInfoAreaSeparator,
 			row: 0
@@ -81,29 +60,7 @@ public partial class TrainInfo_BeforeDeparture : Grid
 			row: 0
 		);
 
-		Grid.SetColumnSpan(beforeDepartureAreaSeparator, 3);
-		Grid.SetColumnSpan(BeforeDepartureArea, 2);
-		this.Add(
-			beforeDepartureAreaSeparator,
-			row: 1
-		);
-		this.Add(
-			beforeDepartureHeaderBoxView,
-			row: 1
-		);
-		this.Add(
-			beforeDepartureHeaderLabel,
-			row: 1
-		);
-		this.Add(
-			BeforeDepartureArea,
-			column: 1,
-			row: 1
-		);
-		this.Add(
-			BeforeDepartureArea_OnStationTrackColumn,
-			column: 2,
-			row: 1
-		);
+		BeforeDeparture.AddToParent();
+		BeforeDeparture.SetRow(1);
 	}
 }

--- a/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
@@ -46,7 +46,7 @@ public partial class TrainInfo_BeforeDeparture : Grid
 		TrainInfoArea.HorizontalOptions = LayoutOptions.Start;
 
 		// BeforeDepartureArea
-		BeforeDeparture = new(this, "発前");
+		BeforeDeparture = new(this, "発前", true);
 
 		Grid.SetColumnSpan(TrainInfoArea, 8);
 		this.Add(

--- a/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TrainInfo_BeforeDeparture.cs
@@ -6,11 +6,10 @@ namespace TRViS.DTAC;
 
 public partial class TrainInfo_BeforeDeparture : Grid
 {
-	public const int DEFAULT_ROW_HEIGHT = 48;
 	static readonly RowDefinitionCollection DefaultRowDefinitions = new()
 	{
-		new RowDefinition(DEFAULT_ROW_HEIGHT),
-		new RowDefinition(DEFAULT_ROW_HEIGHT)
+		new RowDefinition(DTACElementStyles.BeforeDeparture_AfterArrive_Height),
+		new RowDefinition(DTACElementStyles.BeforeDeparture_AfterArrive_Height)
 	};
 
 	#region TrainInfo Area

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -117,7 +117,7 @@
 
 		<Grid
 			Grid.Row="4"
-			ColumnDefinitions="{x:Static dtac:VerticalStylePage.TimetableColumnWidthCollection}"
+			ColumnDefinitions="{x:Static dtac:DTACElementStyles.TimetableColumnWidthCollection}"
 			BackgroundColor="White">
 			<Label
 				x:Name="IsNextDayLabel"

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -9,18 +9,6 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("AffectDate")]
 public partial class VerticalStylePage : ContentView
 {
-	public const double RUN_TIME_COLUMN_WIDTH = 60;
-	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(
-		new(new(RUN_TIME_COLUMN_WIDTH)),
-		new(new(140)),
-		new(new(140)),
-		new(new(140)),
-		new(new(60)),
-		new(new(60)),
-		new(new(1, GridUnitType.Star)),
-		new(new(64))
-		);
-
 	const double DATE_AND_START_BUTTON_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 60;

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -12,7 +12,7 @@ public partial class VerticalStylePage : ContentView
 	const double DATE_AND_START_BUTTON_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 60;
-	const double TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT = TrainInfo_BeforeDeparture.DEFAULT_ROW_HEIGHT * 2;
+	const double TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT = DTACElementStyles.BeforeDeparture_AfterArrive_Height * 2;
 	const double CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT = 60;
 	const double TIMETABLE_HEADER_ROW_HEIGHT = 60;
 

--- a/TRViS/DTAC/VerticalTimetableRow.xaml
+++ b/TRViS/DTAC/VerticalTimetableRow.xaml
@@ -9,7 +9,7 @@
 	x:Class="TRViS.DTAC.VerticalTimetableRow"
 	x:DataType="models:TimetableRow"
 	x:Name="this"
-	ColumnDefinitions="{x:Static dtac:VerticalStylePage.TimetableColumnWidthCollection}"
+	ColumnDefinitions="{x:Static dtac:DTACElementStyles.TimetableColumnWidthCollection}"
 	Margin="0"
 	Padding="0">
 	<Grid.Resources>

--- a/TRViS/DTAC/VerticalTimetableView.cs
+++ b/TRViS/DTAC/VerticalTimetableView.cs
@@ -35,7 +35,7 @@ public partial class VerticalTimetableView : Grid
 	{
 		IsVisible = false,
 		HeightRequest = RowHeight.Value / 2,
-		WidthRequest = VerticalStylePage.RUN_TIME_COLUMN_WIDTH,
+		WidthRequest = DTACElementStyles.RUN_TIME_COLUMN_WIDTH,
 		Margin = new(0),
 		VerticalOptions = LayoutOptions.Start,
 		HorizontalOptions = LayoutOptions.Start,

--- a/TRViS/DTAC/VerticalTimetableView.cs
+++ b/TRViS/DTAC/VerticalTimetableView.cs
@@ -100,9 +100,6 @@ public partial class VerticalTimetableView : Grid
 			AfterArrive.Text = trainData?.AfterArrive ?? string.Empty;
 			AfterArrive.Text_OnStationTrackColumn = trainData?.AfterArriveOnStationTrackCol ?? string.Empty;
 
-			// AfterArriveAreaを表示するなら、AfterRemarksが無くてもAfterRemarksSeparatorを表示する
-			AfterRemarks.IsElementUnderThisVisible(AfterArrive.IsVisible);
-
 			AfterRemarks.AddToParent();
 			AfterArrive.AddToParent();
 

--- a/TRViS/DTAC/VerticalTimetableView.cs
+++ b/TRViS/DTAC/VerticalTimetableView.cs
@@ -2,6 +2,9 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using DependencyPropertyGenerator;
 
+using Microsoft.Maui.Controls.Shapes;
+
+using TRViS.Controls;
 using TRViS.IO.Models;
 using TRViS.ViewModels;
 
@@ -50,15 +53,26 @@ public partial class VerticalTimetableView : Grid
 		Color = CURRENT_LOCATION_MARKER_COLOR,
 	};
 
+	readonly BeforeAfterRemarks AfterRemarks;
+	readonly BeforeDeparture_AfterArrive AfterArrive;
+
+	public VerticalTimetableView()
+	{
+		AfterArrive = new(this, "着後");
+		AfterRemarks = new(this);
+
+		ColumnDefinitions = DTACElementStyles.TimetableColumnWidthCollection;
+	}
+
 	partial void OnSelectedTrainDataChanged(TrainData? newValue)
 	{
-		SetRowViews(newValue?.Rows);
+		SetRowViews(newValue, newValue?.Rows);
 	}
 
 	partial void OnIsBusyChanged()
 		=> IsBusyChanged?.Invoke(this, new());
 
-	async void SetRowViews(TimetableRow[]? newValue)
+	async void SetRowViews(TrainData? trainData, TimetableRow[]? newValue)
 	{
 		await MainThread.InvokeOnMainThreadAsync(() =>
 		{
@@ -71,6 +85,9 @@ public partial class VerticalTimetableView : Grid
 
 		SetRowDefinitions(newCount);
 
+		AfterRemarks.SetRow(newCount);
+		AfterArrive.SetRow(newCount + 1);
+
 		await Task.Run(async () =>
 		{
 			for (int i = 0; i < newCount; i++)
@@ -79,6 +96,16 @@ public partial class VerticalTimetableView : Grid
 
 		await MainThread.InvokeOnMainThreadAsync(() =>
 		{
+			AfterRemarks.Text = trainData?.AfterRemarks ?? string.Empty;
+			AfterArrive.Text = trainData?.AfterArrive ?? string.Empty;
+			AfterArrive.Text_OnStationTrackColumn = trainData?.AfterArriveOnStationTrackCol ?? string.Empty;
+
+			// AfterArriveAreaを表示するなら、AfterRemarksが無くてもAfterRemarksSeparatorを表示する
+			AfterRemarks.IsElementUnderThisVisible(AfterArrive.IsVisible);
+
+			AfterRemarks.AddToParent();
+			AfterArrive.AddToParent();
+
 			Add(CurrentLocationBoxView);
 			Add(CurrentLocationLine);
 			IsBusy = false;
@@ -98,6 +125,7 @@ public partial class VerticalTimetableView : Grid
 
 		await MainThread.InvokeOnMainThreadAsync(() =>
 		{
+			Grid.SetColumnSpan(rowView, 8);
 			Children.Add(rowView);
 
 			Grid.SetRow(rowView, index);
@@ -168,12 +196,21 @@ public partial class VerticalTimetableView : Grid
 		CurrentRunningRow = newValue ? Children.FirstOrDefault(v => v is VerticalTimetableRow) as VerticalTimetableRow : null;
 	}
 
-	void SetRowDefinitions(int? newCount)
+	void SetRowDefinitions(int newCount)
 	{
 		int currentCount = RowDefinitions.Count;
-		HeightRequest = newCount * RowHeight.Value ?? 0;
 
-		if (newCount is null || newCount <= 0)
+		if (newCount < 0)
+			throw new ArgumentOutOfRangeException(nameof(newCount), "count must be 0 or more");
+
+		// After Remarks
+		newCount += 1;
+
+		RowDefinitions.Remove(AfterArrive.RowDefinition);
+
+		HeightRequest = (newCount * RowHeight.Value) + AfterArrive.RowDefinition.Height.Value;
+
+		if (newCount <= 0)
 			RowDefinitions.Clear();
 		else if (currentCount < newCount)
 		{
@@ -185,5 +222,7 @@ public partial class VerticalTimetableView : Grid
 			for (int i = RowDefinitions.Count - 1; i >= newCount; i--)
 				RowDefinitions.RemoveAt(i);
 		}
+
+		RowDefinitions.Add(AfterArrive.RowDefinition);
 	}
 }

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -309,7 +309,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 	CarCount: null,
 	Destination: null,
 	BeginRemarks: null,
-	AfterRemarks: null,
+	AfterRemarks: "(入換)",
 	Remarks: null,
 	BeforeDeparture: null,
 	TrainInfo: null,
@@ -415,6 +415,9 @@ public class SampleDataLoader : TRViS.IO.ILoader
 	TrainInfo: null,
 
 	DayCount: 1,
+
+	AfterArrive: "入換   20分",
+	AfterArriveOnStationTrackCol: "入換",
 
 	Rows: new[]
 	{

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -47,6 +47,12 @@ public class SampleDataLoader : TRViS.IO.ILoader
 		Remarks: "サンプルデータです。\n車掌省略",
 		BeforeDeparture: "転線   10分",
 		TrainInfo: "<span style=\"color:red\">車掌省略</span>",
+
+		BeforeDepartureOnStationTrackCol: "転線",
+
+		AfterArrive: "入換   20分",
+		AfterArriveOnStationTrackCol: "入換",
+
 		Rows: new[]
 		{
 			new TimetableRow(
@@ -290,7 +296,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 				Remarks: "記事"
 			),
 		},
-		1
+		Direction: 1
 		);
 
 	static readonly IO.Models.TrainData SampleTrainData2 = new(


### PR DESCRIPTION
最後の駅の次の行に表示される情報と、「着後」を追加した。

なお、特に「着後」について、実物でどのような表示になるかわからないため、TRViSではAfterRemarksの下に配置することにした
また、「着後」は`AfterArrive`に設定がないと表示されない仕様にした。

![Screenshot 2023-01-22 at 0 18 42](https://user-images.githubusercontent.com/31824852/213873724-8baa3e37-c423-4206-8066-c6427dbee3d9.png)
