### PR TITLE
位置情報サービスのボタンを追加

### DIFF
--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -9,10 +9,25 @@ public static class DTACElementStyles
 	public static readonly Color HeaderBackgroundColor = new(0xdd, 0xdd, 0xdd);
 	public static readonly Color SeparatorLineColor = new(0xaa, 0xaa, 0xaa);
 
+	public static readonly Color DefaultGreen = new(0x00, 0x80, 0x00);
+	public static readonly Color DarkGreen = new(0x00, 0x44, 0x00);
+
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;
 
 	public const int BeforeDeparture_AfterArrive_Height = 45;
+
+	public const string DefaultFontFamily = "Hiragino Sans";
+	public const string MaterialIconFontFamily = "MaterialIconsRegular";
+	public const string TimetableNumFontFamily = "Helvetica";
+
+	public static readonly Shadow DefaultShadow = new()
+	{
+		Brush = Colors.Black,
+		Offset = new(3, 3),
+		Radius = 3,
+		Opacity = 0.2f
+	};
 
 	public const double RUN_TIME_COLUMN_WIDTH = 60;
 	static public ColumnDefinitionCollection TimetableColumnWidthCollection => new(
@@ -34,7 +49,7 @@ public static class DTACElementStyles
 		v.VerticalOptions = LayoutOptions.Center;
 		v.TextColor = DefaultTextColor;
 		v.FontSize = DefaultTextSize;
-		v.FontFamily = "Hiragino Sans";
+		v.FontFamily = DefaultFontFamily;
 		v.Margin = new(4);
 		v.LineBreakMode = LineBreakMode.CharacterWrap;
 

--- a/TRViS/DTAC/LocationServiceButton.cs
+++ b/TRViS/DTAC/LocationServiceButton.cs
@@ -1,0 +1,133 @@
+using TRViS.Controls;
+
+namespace TRViS.DTAC;
+
+public class LocationServiceButton : ToggleButton
+{
+	const float CornerRadius = 5;
+	const float SelectedRectMargin = 2;
+	const float SelectedRectThickness = 2;
+	const float NotSelectedRectMargin = 1;
+
+	readonly Label Label_Location = DTACElementStyles.LargeLabelStyle<Label>();
+	readonly Label Label_ON = DTACElementStyles.LabelStyle<Label>();
+	readonly Label Label_OFF = DTACElementStyles.LabelStyle<Label>();
+
+	readonly Frame SelectedSideBase = new()
+	{
+		Margin = new(SelectedRectMargin),
+		Padding = new(0),
+		CornerRadius = CornerRadius - SelectedRectMargin,
+		BackgroundColor = Colors.White,
+		BorderColor = Colors.Transparent,
+		HasShadow = false,
+		Content = new BoxView()
+		{
+			Margin = new(SelectedRectThickness),
+			CornerRadius = CornerRadius - SelectedRectMargin - SelectedRectThickness,
+			Color = DTACElementStyles.DarkGreen,
+		}
+	};
+	readonly Frame NotSelectedSideBase = new()
+	{
+		Margin = new(NotSelectedRectMargin),
+		CornerRadius = CornerRadius - NotSelectedRectMargin,
+		BackgroundColor = Colors.White,
+		Shadow = DTACElementStyles.DefaultShadow,
+	};
+
+	public LocationServiceButton()
+	{
+		IsCheckedChanged += OnIsCheckedChanged;
+
+		Grid grid = new()
+		{
+			ColumnDefinitions = new()
+			{
+				new ColumnDefinition(new(1, GridUnitType.Star)),
+				new ColumnDefinition(new(1, GridUnitType.Star))
+			}
+		};
+
+		Frame baseFrame = new()
+		{
+			Margin = new(0),
+			Padding = new(0),
+			CornerRadius = CornerRadius,
+			BackgroundColor = DTACElementStyles.DarkGreen,
+			BorderColor = Colors.Transparent,
+			HasShadow = true,
+			Shadow = DTACElementStyles.DefaultShadow,
+		};
+		Grid.SetColumnSpan(baseFrame, 2);
+
+		InitElements();
+
+		HorizontalStackLayout on_group = new()
+		{
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			Margin = new(0),
+			Padding = new(0),
+		};
+
+		on_group.Add(Label_Location);
+		on_group.Add(Label_ON);
+
+		on_group.ScaleX
+			= Label_OFF.ScaleX
+			= 0.9;
+
+		grid.Add(baseFrame, 0);
+		grid.Add(SelectedSideBase, 0);
+		grid.Add(NotSelectedSideBase, 0);
+
+		grid.Add(on_group, 0);
+		grid.Add(Label_OFF, 1);
+
+		Content = grid;
+
+		OnIsCheckedChanged(false);
+	}
+
+	void InitElements()
+	{
+		Label_Location.Text = "\xe0c8";
+		Label_ON.Text = "ON";
+		Label_OFF.Text = "OFF";
+
+		Label_Location.FontAttributes
+			= Label_ON.FontAttributes
+			= Label_OFF.FontAttributes
+			= FontAttributes.Bold;
+
+		Label_ON.FontSize
+			= Label_OFF.FontSize
+			= DTACElementStyles.DefaultTextSize + 2;
+
+		Label_Location.FontFamily = DTACElementStyles.MaterialIconFontFamily;
+
+		Label_Location.Margin
+			= Label_ON.Margin
+			= Label_OFF.Margin
+			= Label_Location.Padding
+			= Label_ON.Padding
+			= Label_OFF.Padding
+			= new(0);
+	}
+
+	void OnIsCheckedChanged(object? sender, ValueChangedEventArgs<bool> e)
+		=> OnIsCheckedChanged(e.NewValue);
+
+	void OnIsCheckedChanged(bool isLocationServiceEnabled)
+	{
+		Label_ON.TextColor
+			= Label_Location.TextColor
+			= isLocationServiceEnabled ? Colors.White : Colors.Black;
+		Label_OFF.TextColor
+			= !isLocationServiceEnabled ? Colors.White : Colors.Black;
+
+		Grid.SetColumn(SelectedSideBase, isLocationServiceEnabled ? 0 : 1);
+		Grid.SetColumn(NotSelectedSideBase, !isLocationServiceEnabled ? 0 : 1);
+	}
+}

--- a/TRViS/DTAC/PageHeader.cs
+++ b/TRViS/DTAC/PageHeader.cs
@@ -42,6 +42,10 @@ public partial class PageHeader : Grid
 		=> StartEndRunButton.IsChecked = newValue;
 	#endregion
 
+	#region Location Service Button
+	readonly LocationServiceButton LocationServiceButton = new();
+	#endregion
+
 	#region Open / Close Button
 	readonly OpenCloseButton OpenCloseButton = new();
 
@@ -74,6 +78,8 @@ public partial class PageHeader : Grid
 		StartEndRunButton.Margin = new(2);
 		StartEndRunButton.IsCheckedChanged += (_, e) => this.IsRunning = e.NewValue;
 
+		LocationServiceButton.Margin = new(4, 8);
+
 		OpenCloseButton.TextWhenOpen = "\xe5ce";
 		OpenCloseButton.TextWhenClosed = "\xe5cf";
 		OpenCloseButton.IsOpenChanged += OpenCloseButton_IsOpenChanged;
@@ -86,6 +92,9 @@ public partial class PageHeader : Grid
 		);
 		this.Add(StartEndRunButton,
 			column: 1
+		);
+		this.Add(LocationServiceButton,
+			column: 2
 		);
 		this.Add(
 			OpenCloseButton,


### PR DESCRIPTION
位置情報サービスの有効 / 無効を切り替えるボタンを追加した。
なお、表示のみの実装であり、機能との連動は未実装である。

デザイン / サイズは微妙だけど、面倒なのでとりあえず放置で。
良い案が出てきたら、そちらに切り替えます。

## 位置情報サービス OFF状態 (Disabled / Not Checked)

![Screenshot 2023-01-28 at 13 46 08](https://user-images.githubusercontent.com/31824852/215242622-4b05899c-ea66-47a7-827e-79db0031f191.png)

## 位置情報サービス ON状態 (Enabled / Checked)

![Screenshot 2023-01-28 at 13 46 16](https://user-images.githubusercontent.com/31824852/215242626-408c88ea-2f0f-4da7-bab2-7ede0091ef31.png)
