### PR TITLE
Support Dark Mode

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -19,14 +19,14 @@ env:
   CSPROJ_PATH: ./TRViS/TRViS.csproj
   THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
   THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net7.0-ios
+  TARGET_FRAMEWORK: net8.0-ios
   TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_ANDROID: net7.0-android
+  TARGET_FRAMEWORK_ANDROID: net8.0-android
   OUTPUT_DIR: ./out
   IPA_PATH: ./out/TRViS.ipa
   AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
   APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  SDK_VERSION: '7.0.x'
+  SDK_VERSION: '8.0.100-preview.4.23260.5'
 
 jobs:
   generate-bundle-version:

--- a/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
+++ b/TRViS/DTAC/BeforeDeparture_AfterArrive.cs
@@ -12,7 +12,6 @@ public class BeforeDeparture_AfterArrive
 	{
 		IsVisible = false,
 		Margin = new(0),
-		Color = DTACElementStyles.HeaderBackgroundColor,
 	};
 	readonly Label HeaderLabel = DTACElementStyles.HeaderLabelStyle<Label>();
 
@@ -43,6 +42,9 @@ public class BeforeDeparture_AfterArrive
 
 		Grid.SetColumn(Label_OnStationTrackColumn, 4);
 		Grid.SetColumnSpan(Label_OnStationTrackColumn, 4);
+
+		DTACElementStyles.HeaderTextColor.Apply(HeaderLabel, Microsoft.Maui.Controls.Label.TextColorProperty);
+		DTACElementStyles.HeaderBackgroundColor.Apply(HeaderBoxView, BoxView.ColorProperty);
 
 		HeaderLabel.Text = HeaderLabelText;
 

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -47,6 +47,8 @@ public static class DTACElementStyles
 	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideTextColor = genColor(0xFF, 0xDD);
 	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideBaseColor = genColor(0xFF, 0xE8);
 
+	public static readonly AppThemeColorBindingExtension StartEndRunButtonTextColor = genColor(0xFF, 0xE0);
+
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;
 

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -13,7 +13,7 @@ public static class DTACElementStyles
 
 	public static readonly AppThemeColorBindingExtension DefaultTextColor = genColor(0x33, 0xFF);
 	public static readonly AppThemeColorBindingExtension HeaderTextColor = genColor(0x55, 0xFF);
-	public static readonly AppThemeColorBindingExtension TimetableTextColor = genColor(0x00, 0xEE);
+	public static readonly AppThemeColorBindingExtension TimetableTextColor = genColor(0x00, 0xDD);
 	public static readonly AppThemeColorBindingExtension TimetableTextInvColor = genColor(0xFF, 0xFF);
 	public static readonly AppThemeColorBindingExtension TrainNumNextDayTextColor = new(
 		new(0x33, 0x33, 0xDD),
@@ -45,7 +45,7 @@ public static class DTACElementStyles
 
 	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideFrameColor = genColor(0xFF, 0xAA);
 	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideTextColor = genColor(0xFF, 0xDD);
-	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideBaseColor = genColor(0xFF, 0xE8);
+	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideBaseColor = genColor(0xFF, 0xDD);
 
 	public static readonly AppThemeColorBindingExtension StartEndRunButtonTextColor = genColor(0xFF, 0xE0);
 

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -4,13 +4,44 @@ namespace TRViS.DTAC;
 
 public static class DTACElementStyles
 {
-	public static readonly Color DefaultTextColor = new(0x33, 0x33, 0x33);
-	public static readonly Color HeaderTextColor = new(0x55, 0x55, 0x55);
-	public static readonly Color HeaderBackgroundColor = new(0xdd, 0xdd, 0xdd);
-	public static readonly Color SeparatorLineColor = new(0xaa, 0xaa, 0xaa);
+	static Color genColor(byte value)
+		=> new(value, value, value);
+	static AppThemeColorBindingExtension genColor(byte defaultColorValue, byte darkColorValue)
+		=> new(genColor(defaultColorValue), genColor(darkColorValue));
 
-	public static readonly Color DefaultGreen = new(0x00, 0x80, 0x00);
-	public static readonly Color DarkGreen = new(0x00, 0x44, 0x00);
+	const byte baseDarkColor = 0x25;
+
+	public static readonly AppThemeColorBindingExtension DefaultTextColor = genColor(0x33, 0xFF);
+	public static readonly AppThemeColorBindingExtension HeaderTextColor = genColor(0x55, 0xFF);
+	public static readonly AppThemeColorBindingExtension TimetableTextColor = genColor(0x00, 0xEE);
+	public static readonly AppThemeColorBindingExtension TimetableTextInvColor = genColor(0xFF, 0xFF);
+	public static readonly AppThemeColorBindingExtension TrainNumNextDayTextColor = new(
+		new(0x33, 0x33, 0xDD),
+		new(0x44, 0x99, 0xFF)
+	);
+	public static readonly AppThemeColorBindingExtension HeaderBackgroundColor = genColor(0xDD, baseDarkColor + 0x18);
+	public static readonly AppThemeColorBindingExtension SeparatorLineColor = genColor(0xDD, baseDarkColor + 0x33);
+	public static readonly AppThemeColorBindingExtension DefaultBGColor = genColor(0xFF, baseDarkColor);
+	public static readonly AppThemeColorBindingExtension CarCountBGColor = genColor(0xFE, baseDarkColor + 0x11);
+	public static readonly AppThemeColorBindingExtension TabAreaBGColor = genColor(0xEE, baseDarkColor - 0x20);
+	public static readonly AppThemeColorBindingExtension TabButtonBGColor = genColor(0xDD, baseDarkColor - 0x11);
+
+	public static readonly AppThemeColorBindingExtension OpenCloseButtonBGColor = genColor(0xFE, 0x4A);
+	public static readonly AppThemeColorBindingExtension OpenCloseButtonTextColor = genColor(0xAA, 0x99);
+	public static readonly AppThemeColorBindingExtension MarkerButtonIconColor = new(
+		new(0x00, 0x44, 0x00),
+		new(0x00, 0x99, 0x00)
+	);
+	public static readonly AppThemeColorBindingExtension MarkerMarkButtonBGColor = genColor(0xFA, 0x4A);
+
+	public static readonly AppThemeColorBindingExtension DefaultGreen = new(
+		new(0x00, 0x80, 0x00),
+		new(0x00, 0x80, 0x00)
+	);
+	public static readonly AppThemeColorBindingExtension DarkGreen = new(
+		new(0x00, 0x44, 0x00),
+		new(0x00, 0x44, 0x00)
+	);
 
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;
@@ -47,7 +78,7 @@ public static class DTACElementStyles
 
 		v.HorizontalOptions = LayoutOptions.Center;
 		v.VerticalOptions = LayoutOptions.Center;
-		v.TextColor = DefaultTextColor;
+		DefaultTextColor.Apply(v, Label.TextColorProperty);
 		v.FontSize = DefaultTextSize;
 		v.FontFamily = DefaultFontFamily;
 		v.Margin = new(4);
@@ -62,7 +93,7 @@ public static class DTACElementStyles
 	{
 		T v = LabelStyle<T>();
 
-		v.TextColor = HeaderTextColor;
+		HeaderTextColor.Apply(v, Label.TextColorProperty);
 
 		return v;
 	}
@@ -80,7 +111,7 @@ public static class DTACElementStyles
 	{
 		T v = LabelStyle<T>();
 
-		v.TextColor = Colors.Black;
+		TimetableTextColor.Apply(v, Label.TextColorProperty);
 		v.FontSize = DeviceInfo.Current.Platform == DevicePlatform.iOS ? 28 : 26;
 		v.FontAttributes = FontAttributes.Bold;
 		v.InputTransparent = true;
@@ -148,7 +179,7 @@ public static class DTACElementStyles
 		Line v = new();
 
 		v.VerticalOptions = LayoutOptions.End;
-		v.BackgroundColor = SeparatorLineColor;
+		SeparatorLineColor.Apply(v, Line.BackgroundColorProperty);
 		v.StrokeThickness = 0.5;
 		v.HeightRequest = 0.5;
 
@@ -192,7 +223,6 @@ public static class DTACElementStyles
 	{
 		Line v = new()
 		{
-			BackgroundColor = Colors.Black,
 			StrokeThickness = 4,
 			HeightRequest = 4,
 			X1 = 22,
@@ -202,6 +232,8 @@ public static class DTACElementStyles
 			VerticalOptions = LayoutOptions.Center,
 			HorizontalOptions = LayoutOptions.Center,
 		};
+
+		TimetableTextColor.Apply(v, Line.BackgroundColorProperty);
 
 		return v;
 	}

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -40,8 +40,12 @@ public static class DTACElementStyles
 	);
 	public static readonly AppThemeColorBindingExtension DarkGreen = new(
 		new(0x00, 0x44, 0x00),
-		new(0x00, 0x44, 0x00)
+		new(0x00, 0x33, 0x00)
 	);
+
+	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideFrameColor = genColor(0xFF, 0xAA);
+	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideTextColor = genColor(0xFF, 0xDD);
+	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideBaseColor = genColor(0xFF, 0xE8);
 
 	public static readonly int DefaultTextSize = 14;
 	public static readonly int LargeTextSize = 24;

--- a/TRViS/DTAC/Hako.xaml
+++ b/TRViS/DTAC/Hako.xaml
@@ -2,6 +2,7 @@
 <ContentView
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	BackgroundColor="White"
+	xmlns:local="clr-namespace:TRViS.DTAC"
+	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}"
 	x:Class="TRViS.DTAC.Hako">
 </ContentView>

--- a/TRViS/DTAC/LocationServiceButton.cs
+++ b/TRViS/DTAC/LocationServiceButton.cs
@@ -25,7 +25,6 @@ public class LocationServiceButton : ToggleButton
 		{
 			Margin = new(SelectedRectThickness),
 			CornerRadius = CornerRadius - SelectedRectMargin - SelectedRectThickness,
-			Color = DTACElementStyles.DarkGreen,
 		}
 	};
 	readonly Frame NotSelectedSideBase = new()
@@ -54,7 +53,6 @@ public class LocationServiceButton : ToggleButton
 			Margin = new(0),
 			Padding = new(0),
 			CornerRadius = CornerRadius,
-			BackgroundColor = DTACElementStyles.DarkGreen,
 			BorderColor = Colors.Transparent,
 			HasShadow = true,
 			Shadow = DTACElementStyles.DefaultShadow,
@@ -62,6 +60,9 @@ public class LocationServiceButton : ToggleButton
 		Grid.SetColumnSpan(baseFrame, 2);
 
 		InitElements();
+
+		DTACElementStyles.DarkGreen.Apply(baseFrame, BackgroundColorProperty);
+		DTACElementStyles.DarkGreen.Apply(SelectedSideBase.Content, BoxView.ColorProperty);
 
 		HorizontalStackLayout on_group = new()
 		{

--- a/TRViS/DTAC/LocationServiceButton.cs
+++ b/TRViS/DTAC/LocationServiceButton.cs
@@ -18,7 +18,6 @@ public class LocationServiceButton : ToggleButton
 		Margin = new(SelectedRectMargin),
 		Padding = new(0),
 		CornerRadius = CornerRadius - SelectedRectMargin,
-		BackgroundColor = Colors.White,
 		BorderColor = Colors.Transparent,
 		HasShadow = false,
 		Content = new BoxView()
@@ -31,7 +30,6 @@ public class LocationServiceButton : ToggleButton
 	{
 		Margin = new(NotSelectedRectMargin),
 		CornerRadius = CornerRadius - NotSelectedRectMargin,
-		BackgroundColor = Colors.White,
 		Shadow = DTACElementStyles.DefaultShadow,
 	};
 
@@ -63,6 +61,8 @@ public class LocationServiceButton : ToggleButton
 
 		DTACElementStyles.DarkGreen.Apply(baseFrame, BackgroundColorProperty);
 		DTACElementStyles.DarkGreen.Apply(SelectedSideBase.Content, BoxView.ColorProperty);
+		DTACElementStyles.LocationServiceSelectedSideFrameColor.Apply(SelectedSideBase, BackgroundColorProperty);
+		DTACElementStyles.LocationServiceNotSelectedSideBaseColor.Apply(NotSelectedSideBase, BackgroundColorProperty);
 
 		HorizontalStackLayout on_group = new()
 		{
@@ -122,11 +122,18 @@ public class LocationServiceButton : ToggleButton
 
 	void OnIsCheckedChanged(bool isLocationServiceEnabled)
 	{
-		Label_ON.TextColor
-			= Label_Location.TextColor
-			= isLocationServiceEnabled ? Colors.White : Colors.Black;
-		Label_OFF.TextColor
-			= !isLocationServiceEnabled ? Colors.White : Colors.Black;
+		if (isLocationServiceEnabled)
+		{
+			DTACElementStyles.LocationServiceSelectedSideTextColor.Apply(Label_ON, Label.TextColorProperty);
+			DTACElementStyles.LocationServiceSelectedSideTextColor.Apply(Label_Location, Label.TextColorProperty);
+			Label_OFF.TextColor = Colors.Black;
+		}
+		else
+		{
+			DTACElementStyles.LocationServiceSelectedSideTextColor.Apply(Label_OFF, Label.TextColorProperty);
+			Label_ON.TextColor = Colors.Black;
+			Label_Location.TextColor = Colors.Black;
+		}
 
 		Grid.SetColumn(SelectedSideBase, isLocationServiceEnabled ? 0 : 1);
 		Grid.SetColumn(NotSelectedSideBase, !isLocationServiceEnabled ? 0 : 1);

--- a/TRViS/DTAC/MarkerButton.xaml
+++ b/TRViS/DTAC/MarkerButton.xaml
@@ -3,6 +3,7 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:vm="clr-namespace:TRViS.ViewModels"
+	xmlns:local="clr-namespace:TRViS.DTAC"
 	x:Class="TRViS.DTAC.MarkerButton"
 	x:DataType="vm:DTACMarkerViewModel"
 	x:Name="this"
@@ -14,7 +15,7 @@
 	VerticalOptions="Center"
 	BorderColor="{x:Null}"
 	HasShadow="False"
-	BackgroundColor="White">
+	BackgroundColor="{x:Static local:DTACElementStyles.OpenCloseButtonBGColor}">
 	<Frame.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
@@ -49,7 +50,7 @@
 			FontSize="44"
 			ScaleX="0.5"
 			AnchorX="1"
-			TextColor="{StaticResource DarkerGreen}"
+			TextColor="{x:Static local:DTACElementStyles.MarkerButtonIconColor}"
 			Text="&#xe9a2;">
 			<Label.Triggers>
 				<DataTrigger

--- a/TRViS/DTAC/OpenCloseButton.cs
+++ b/TRViS/DTAC/OpenCloseButton.cs
@@ -41,11 +41,11 @@ public partial class OpenCloseButton : Button
 
 		CornerRadius = 4;
 		Padding = 0;
-		BackgroundColor = Colors.White;
 		BorderWidth = 0;
-		TextColor = new(0xAA, 0xAA, 0xAA);
 		FontFamily = "MaterialIconsRegular";
 		FontSize = 40;
+		DTACElementStyles.OpenCloseButtonBGColor.Apply(this, BackgroundColorProperty);
+		DTACElementStyles.OpenCloseButtonTextColor.Apply(this, TextColorProperty);
 
 		Shadow = new()
 		{

--- a/TRViS/DTAC/Remarks.xaml
+++ b/TRViS/DTAC/Remarks.xaml
@@ -3,6 +3,7 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:local="clr-namespace:TRViS.DTAC"
+	xmlns:dtac="clr-namespace:TRViS.DTAC"
 	xmlns:ctrls="clr-namespace:TRViS.Controls"
 	x:DataType="local:Remarks"
 	BackgroundColor="#333"
@@ -42,7 +43,8 @@
 		VerticalOptions="Center"/>
 
 	<ScrollView
-		BackgroundColor="White"
+		x:Name="RemarksTextScrollView"
+		BackgroundColor="{x:Static dtac:DTACElementStyles.DefaultBGColor}"
 		Grid.Row="1"
 		Padding="2"
 		Margin="8">

--- a/TRViS/DTAC/Remarks.xaml.cs
+++ b/TRViS/DTAC/Remarks.xaml.cs
@@ -24,6 +24,8 @@ public partial class Remarks : Grid
 		BindingContext = this;
 
 		ContentAreaHeight = new(DEFAULT_CONTENT_AREA_HEIGHT);
+
+		DTACElementStyles.DefaultBGColor.Apply(RemarksTextScrollView, BackgroundColorProperty);
 	}
 
 	partial void OnIsOpenChanged(bool newValue)

--- a/TRViS/DTAC/StartEndRunButton.xaml
+++ b/TRViS/DTAC/StartEndRunButton.xaml
@@ -4,6 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	x:Name="this"
 	xmlns:ctrls="clr-namespace:TRViS.Controls"
+	xmlns:local="clr-namespace:TRViS.DTAC"
 	x:Class="TRViS.DTAC.StartEndRunButton">
 	<Frame
 		x:Name="BaseFrame"
@@ -18,7 +19,7 @@
 			VerticalOptions="Center">
 			<Label
 				Text="&#xe039;"
-				TextColor="White"
+				TextColor="{x:Static local:DTACElementStyles.StartEndRunButtonTextColor}"
 				FontFamily="MaterialIconsRegular"
 				FontSize="32"
 				VerticalOptions="Center"
@@ -38,7 +39,7 @@
 
 			<Label
 				Text="運行開始"
-				TextColor="White"
+				TextColor="{x:Static local:DTACElementStyles.StartEndRunButtonTextColor}"
 				FontFamily="Hiragino Sans"
 				FontSize="24"
 				FontAttributes="Bold"

--- a/TRViS/DTAC/StartEndRunButton.xaml.cs
+++ b/TRViS/DTAC/StartEndRunButton.xaml.cs
@@ -5,7 +5,17 @@ namespace TRViS.DTAC;
 public partial class StartEndRunButton : ToggleButton
 {
 	static readonly Color GREEN = new(0, 0x80, 0);
+	static readonly Color GREEN_DARK = new(0, 0x70, 0);
 	const float BUTTON_LUMINOUS_DELTA = 0.05f;
+
+	static readonly AppThemeColorBindingExtension Color_Up = new(
+		GREEN.AddLuminosity(BUTTON_LUMINOUS_DELTA),
+		GREEN_DARK.AddLuminosity(BUTTON_LUMINOUS_DELTA)
+	);
+	static readonly AppThemeColorBindingExtension Color_Down = new(
+		GREEN.AddLuminosity(-BUTTON_LUMINOUS_DELTA),
+		GREEN_DARK.AddLuminosity(-BUTTON_LUMINOUS_DELTA)
+	);
 
 	public StartEndRunButton()
 	{
@@ -17,8 +27,20 @@ public partial class StartEndRunButton : ToggleButton
 			EndPoint = new(0, 1)
 		};
 
-		brush.GradientStops.Add(new(GREEN.AddLuminosity(BUTTON_LUMINOUS_DELTA), 0.1f));
-		brush.GradientStops.Add(new(GREEN.AddLuminosity(-BUTTON_LUMINOUS_DELTA), 1.0f));
+		GradientStop gradientStop_Up = new()
+		{
+			Offset = 0.1f,
+		};
+		GradientStop gradientStop_Down = new()
+		{
+			Offset = 1.0f,
+		};
+
+		Color_Up.Apply(gradientStop_Up, GradientStop.ColorProperty);
+		Color_Down.Apply(gradientStop_Down, GradientStop.ColorProperty);
+
+		brush.GradientStops.Add(gradientStop_Up);
+		brush.GradientStops.Add(gradientStop_Down);
 
 		BaseFrame.Background = brush;
 	}

--- a/TRViS/DTAC/Style_VerticalView.xaml
+++ b/TRViS/DTAC/Style_VerticalView.xaml
@@ -26,7 +26,7 @@
 	<Style x:Key="LabelStyle" TargetType="Label">
 		<Setter Property="HorizontalOptions" Value="Center"/>
 		<Setter Property="VerticalOptions" Value="Center"/>
-		<Setter Property="TextColor" Value="#333"/>
+		<Setter Property="TextColor" Value="{x:Static dtac:DTACElementStyles.DefaultTextColor}"/>
 		<Setter Property="FontSize" Value="14"/>
 		<Setter Property="FontFamily" Value="Hiragino Sans"/>
 		<Setter Property="Margin" Value="1"/>
@@ -37,10 +37,10 @@
 		<Setter Property="Margin" Value="4"/>
 	</Style>
 	<Style x:Key="HeaderLabel" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
-		<Setter Property="TextColor" Value="#555"/>
+		<Setter Property="TextColor" Value="{x:Static dtac:DTACElementStyles.HeaderTextColor}"/>
 	</Style>
 	<Style x:Key="TimetableLabel" TargetType="Label" BasedOn="{StaticResource LabelStyle}">
-		<Setter Property="TextColor" Value="Black"/>
+		<Setter Property="TextColor" Value="{x:Static dtac:DTACElementStyles.TimetableTextColor}"/>
 		<Setter Property="FontSize" Value="{OnPlatform iOS=28, Default=26}"/>
 		<Setter Property="FontAttributes" Value="Bold"/>
 	</Style>
@@ -69,14 +69,14 @@
 	<Style x:Key="SeparatorLine" TargetType="Line">
 		<Setter Property="HorizontalOptions" Value="End"/>
 		<Setter Property="Margin" Value="0,6"/>
-		<Setter Property="BackgroundColor" Value="#aaa"/>
+		<Setter Property="BackgroundColor" Value="{x:Static dtac:DTACElementStyles.SeparatorLineColor}"/>
 		<Setter Property="StrokeThickness" Value="1"/>
 		<Setter Property="WidthRequest" Value="1"/>
 	</Style>
 
 	<Style x:Key="TimetableSeparatorLine" TargetType="Line">
 		<Setter Property="VerticalOptions" Value="End"/>
-		<Setter Property="BackgroundColor" Value="#aaa"/>
+		<Setter Property="BackgroundColor" Value="{x:Static dtac:DTACElementStyles.SeparatorLineColor}"/>
 		<Setter Property="Grid.ColumnSpan" Value="8"/>
 		<Setter Property="StrokeThickness" Value="0.5"/>
 		<Setter Property="HeightRequest" Value="0.5"/>
@@ -88,7 +88,7 @@
 	</Style>
 
 	<Style x:Key="LastStopLine" TargetType="Line">
-		<Setter Property="BackgroundColor" Value="Black"/>
+		<Setter Property="BackgroundColor" Value="{x:Static dtac:DTACElementStyles.TimetableTextColor}"/>
 		<Setter Property="StrokeThickness" Value="4"/>
 		<Setter Property="HeightRequest" Value="4"/>
 		<Setter Property="X1" Value="22"/>

--- a/TRViS/DTAC/TabButton.xaml
+++ b/TRViS/DTAC/TabButton.xaml
@@ -30,7 +30,6 @@
 
 			<Label
 				x:Name="ButtonLabel"
-				TextColor="Black"
 				FontFamily="Hiragino Sans"
 				FontSize="18"
 				FontAttributes="Bold"

--- a/TRViS/DTAC/TabButton.xaml.cs
+++ b/TRViS/DTAC/TabButton.xaml.cs
@@ -17,6 +17,7 @@ public partial class TabButton : ContentView
 		InitializeComponent();
 
 		UpdateIsSelectedProperty();
+		DTACElementStyles.TimetableTextColor.Apply(ButtonLabel, Label.TextColorProperty);
 	}
 
 	partial void OnCurrentModeChanged()
@@ -36,12 +37,12 @@ public partial class TabButton : ContentView
 
 		if (newValue)
 		{
-			BaseBox.Color = Colors.White;
+			DTACElementStyles.DefaultBGColor.Apply(BaseBox, BoxView.ColorProperty);
 			BaseBox.Shadow.Opacity = 0.2f;
 		}
 		else
 		{
-			BaseBox.Color = BASE_COLOR_DISABLED;
+			DTACElementStyles.TabButtonBGColor.Apply(BaseBox, BoxView.ColorProperty);
 			BaseBox.Shadow.Opacity = 0;
 		}
 	}

--- a/TRViS/DTAC/TimeCell.xaml.cs
+++ b/TRViS/DTAC/TimeCell.xaml.cs
@@ -21,7 +21,12 @@ public partial class TimeCell : Grid
 	}
 
 	partial void OnIsPassChanged(bool newValue)
-		=> TextColor = newValue ? Colors.Red : Colors.Black;
+	{
+		if (newValue)
+			TextColor = Colors.Red;
+		else
+			DTACElementStyles.TimetableTextColor.Apply(this, TextColorPropertyKey.BindableProperty);
+	}
 
 	partial void OnTimeDataChanged(TimeData? newValue)
 	{

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -26,12 +26,12 @@
 			x:Name="PageHeaderArea"
 			Grid.Row="0"
 			IsOpenChanged="BeforeRemarks_TrainInfo_OpenCloseChanged"
-			BackgroundColor="White"/>
+			BackgroundColor="{x:Static dtac:DTACElementStyles.DefaultBGColor}"/>
 
 		<Grid
 			Grid.Row="1"
 			ColumnDefinitions="{StaticResource TrainInfoColumnWidthCollection}"
-			BackgroundColor="#ddd">
+			BackgroundColor="{x:Static dtac:DTACElementStyles.HeaderBackgroundColor}">
 			<Label
 				Style="{StaticResource HeaderLabel}"
 				Text="列　車"
@@ -66,11 +66,11 @@
 		<Grid
 			Grid.Row="2"
 			ColumnDefinitions="{StaticResource TrainInfoColumnWidthCollection}"
-			BackgroundColor="White">
+			BackgroundColor="{x:Static dtac:DTACElementStyles.DefaultBGColor}">
 			<Label
 				Style="{StaticResource LabelStyle}"
 				Text="{Binding TrainNumber, Converter={StaticResource TrainNumberConverter}}"
-				TextColor="#33d"
+				TextColor="{x:Static dtac:DTACElementStyles.TrainNumNextDayTextColor}"
 				FontSize="28"
 				FontAttributes="Bold"
 				Grid.Column="0"/>
@@ -118,7 +118,7 @@
 		<Grid
 			Grid.Row="4"
 			ColumnDefinitions="{x:Static dtac:DTACElementStyles.TimetableColumnWidthCollection}"
-			BackgroundColor="White">
+			BackgroundColor="{x:Static dtac:DTACElementStyles.DefaultBGColor}">
 			<Label
 				x:Name="IsNextDayLabel"
 				IsVisible="False"
@@ -137,7 +137,7 @@
 			<Frame
 				IsVisible="{Binding CarCount, Converter={x:Static conv:IsOneOrMoreIntConverter.Default}}"
 				Grid.Column="1"
-				BackgroundColor="#FEFEFE"
+				BackgroundColor="{x:Static dtac:DTACElementStyles.CarCountBGColor}"
 				BorderColor="Transparent"
 				CornerRadius="4"
 				Padding="0"
@@ -183,7 +183,7 @@
 
 		<dtac:TimetableHeader
 			x:Name="TimetableHeader"
-			BackgroundColor="#ddd"
+			BackgroundColor="{x:Static dtac:DTACElementStyles.HeaderBackgroundColor}"
 			FontSize_Large="28"
 			Grid.Row="5"/>
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -47,11 +47,13 @@ public partial class VerticalStylePage : ContentView
 		this.TimetableHeader.MarkerSettings = TimetableView.MarkerViewModel;
 
 		if (DeviceInfo.Current.Idiom == DeviceIdiom.Phone || DeviceInfo.Current.Idiom == DeviceIdiom.Unknown)
+		{
 			Content = new ScrollView()
 			{
 				Content = this.Content,
-				BackgroundColor = Colors.White
 			};
+			DTACElementStyles.DefaultBGColor.Apply(Content, BackgroundColorProperty);
+		}
 
 		TimetableView.IsBusyChanged += (s, _) =>
 		{

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -21,6 +21,9 @@ public partial class VerticalTimetableRow
 		}
 	}
 
+	void setMarkerBoxDefaultColor()
+		=> DTACElementStyles.MarkerMarkButtonBGColor.Apply(MarkerBox, VisualElement.BackgroundColorProperty);
+
 	Color? _MarkedColor = null;
 	public Color? MarkedColor
 	{
@@ -36,12 +39,12 @@ public partial class VerticalTimetableRow
 
 			if (value is null)
 			{
-				BackgroundBoxView.Color = Colors.White;
-				MarkerBox.BackgroundColor = DefaultMarkButtonColor;
+				BackgroundBoxView.BackgroundColor = Colors.Transparent;
+				setMarkerBoxDefaultColor();
 			}
 			else
 			{
-				BackgroundBoxView.Color = value.WithAlpha(BG_ALPHA);
+				BackgroundBoxView.Color = value;
 				MarkerBox.BackgroundColor = value;
 				MarkerBox.TextColor = Utils.GetTextColorFromBGColor(value);
 			}
@@ -75,8 +78,9 @@ public partial class VerticalTimetableRow
 		BackgroundBoxView = new()
 		{
 			IsVisible = true,
-			Color = Colors.White,
+			Color = Colors.Transparent,
 			BindingContext = this,
+			Opacity = BG_ALPHA,
 		};
 		Grid.SetColumnSpan(BackgroundBoxView, 8);
 		parent.Add(BackgroundBoxView, row: rowIndex);
@@ -235,21 +239,12 @@ public partial class VerticalTimetableRow
 			parent.Add(Remarks, 6, rowIndex);
 		}
 
-		BoxView RowSeparator = new()
-		{
-			HeightRequest = 0.5,
-			Color = DTACElementStyles.SeparatorLineColor,
-			HorizontalOptions = LayoutOptions.Fill,
-			VerticalOptions = LayoutOptions.End,
-		};
-		Grid.SetColumnSpan(RowSeparator, 8);
-		parent.Add(RowSeparator, row: rowIndex);
+		parent.Add(DTACElementStyles.HorizontalSeparatorLineStyle(), row: rowIndex);
 
 		MarkerBox = new()
 		{
 			IsVisible = false,
 			IsEnabled = false,
-			BackgroundColor = DefaultMarkButtonColor,
 			FontFamily = "Hiragino Sans",
 			FontSize = 18,
 			BorderColor = Colors.Transparent,
@@ -261,7 +256,9 @@ public partial class VerticalTimetableRow
 			HeightRequest = 40,
 			WidthRequest = 40,
 			Shadow = DTACElementStyles.DefaultShadow,
+			Opacity = 0.9,
 		};
+		setMarkerBoxDefaultColor();
 		MarkerBox.Shadow.Offset = new(2, 2);
 		MarkerBox.Shadow.Radius = 2;
 		MarkerBox.Clicked += MarkerBoxClicked;

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -39,7 +39,7 @@ public partial class VerticalTimetableRow
 
 			if (value is null)
 			{
-				BackgroundBoxView.BackgroundColor = Colors.Transparent;
+				BackgroundBoxView.Color = Colors.Transparent;
 				setMarkerBoxDefaultColor();
 			}
 			else

--- a/TRViS/DTAC/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.cs
@@ -5,7 +5,6 @@ namespace TRViS.DTAC;
 
 public partial class VerticalTimetableRow
 {
-	static readonly Color DefaultMarkButtonColor = new(0xFA, 0xFA, 0xFA);
 	const float BG_ALPHA = 0.3f;
 
 	public enum LocationStates
@@ -27,17 +26,13 @@ public partial class VerticalTimetableRow
 			if (!IsEnabled || value == LocationStates.Undefined)
 			{
 				_LocationState = LocationStates.Undefined;
-				if (DriveTimeMM is not null)
-					DriveTimeMM.TextColor = Colors.Black;
-				if (DriveTimeSS is not null)
-					DriveTimeSS.TextColor = Colors.Black;
+				DTACElementStyles.TimetableTextColor.Apply(DriveTimeMM, Label.TextColorProperty);
+				DTACElementStyles.TimetableTextColor.Apply(DriveTimeSS, Label.TextColorProperty);
 				return;
 			}
 
-			if (DriveTimeMM is not null)
-				DriveTimeMM.TextColor = Colors.White;
-			if (DriveTimeSS is not null)
-				DriveTimeSS.TextColor = Colors.White;
+			DTACElementStyles.TimetableTextInvColor.Apply(DriveTimeMM, Label.TextColorProperty);
+			DTACElementStyles.TimetableTextInvColor.Apply(DriveTimeSS, Label.TextColorProperty);
 
 			// 最終行の場合は、次の駅に進まないようにする。
 			if (IsLastRow && value == LocationStates.RunningToNextStation)

--- a/TRViS/DTAC/ViewHost.xaml
+++ b/TRViS/DTAC/ViewHost.xaml
@@ -6,7 +6,7 @@
 	xmlns:viewmodels="clr-namespace:TRViS.ViewModels"
 	x:Class="TRViS.DTAC.ViewHost"
 	x:DataType="viewmodels:DTACViewHostViewModel"
-	BackgroundColor="White"
+	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}"
 	Title="{Binding AppViewModel.SelectedTrainData.WorkName}">
 	<Grid
 		IgnoreSafeArea="True">
@@ -52,7 +52,7 @@
 			Grid.Row="1"
 			Margin="0"
 			Padding="4,0"
-			BackgroundColor="#eee">
+			BackgroundColor="{x:Static local:DTACElementStyles.TabAreaBGColor}">
 			<local:TabButton
 				Text="ハ　コ"
 				CurrentMode="{Binding TabMode}"

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -68,6 +68,8 @@ public partial class ViewHost : ContentPage
 			appShell.SafeAreaMarginChanged += AppShell_SafeAreaMarginChanged;
 			AppShell_SafeAreaMarginChanged(appShell, new(), appShell.SafeAreaMargin);
 		}
+
+		DTACElementStyles.DefaultBGColor.Apply(this, BackgroundColorProperty);
 	}
 
 	void SetTitleBGGradientColor(AppTheme v)

--- a/TRViS/DTAC/WorkAffix.cs
+++ b/TRViS/DTAC/WorkAffix.cs
@@ -4,6 +4,6 @@ public class WorkAffix : ContentView
 {
 	public WorkAffix()
 	{
-		BackgroundColor = Colors.White;
+		DTACElementStyles.DefaultBGColor.Apply(this, BackgroundColorProperty);
 	}
 }

--- a/TRViS/RootStyles.cs
+++ b/TRViS/RootStyles.cs
@@ -1,0 +1,9 @@
+namespace TRViS;
+
+public static class RootStyles
+{
+	public static readonly AppThemeColorBindingExtension TableTextColor = new(new(0x11, 0x11, 0x11), new(0xEE, 0xEE, 0xEE));
+	public static readonly AppThemeColorBindingExtension TableDetailColor = new(new(0x55, 0x55, 0x55), new(0xAA, 0xAA, 0xAA));
+	public static readonly AppThemeColorBindingExtension BackgroundColor = new(new(0xDD, 0xDD, 0xDD), new(0x22, 0x22, 0x22));
+	public static readonly AppThemeColorBindingExtension FrameBorderColor = new(new(0x22, 0x22, 0x22), new(0xDD, 0xDD, 0xDD));
+}

--- a/TRViS/SelectTrainPage.xaml
+++ b/TRViS/SelectTrainPage.xaml
@@ -4,7 +4,8 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:models="clr-namespace:TRViS.IO.Models.DB;assembly=TRViS.IO"
 	xmlns:viewmodels="clr-namespace:TRViS.ViewModels"
-	BackgroundColor="{AppThemeBinding Dark=#222, Default=#ddd}"
+	xmlns:local="clr-namespace:TRViS"
+	BackgroundColor="{x:Static local:RootStyles.BackgroundColor}"
 	x:DataType="viewmodels:AppViewModel"
 	x:Class="TRViS.SelectTrainPage"
 	Title="Select Train">
@@ -12,7 +13,7 @@
 		<ResourceDictionary>
 			<Style TargetType="Frame">
 				<Setter Property="HasShadow" Value="True"/>
-				<Setter Property="BorderColor" Value="{AppThemeBinding Dark=#ddd, Default=#222}"/>
+				<Setter Property="BorderColor" Value="{x:Static local:RootStyles.FrameBorderColor}"/>
 				<Setter Property="Margin" Value="8"/>
 				<Setter Property="Padding" Value="8"/>
 				<Setter Property="FlexLayout.Basis" Value="350"/>
@@ -64,8 +65,8 @@
 									<DataTemplate
 										x:DataType="models:WorkGroup">
 										<TextCell
-											TextColor="{AppThemeBinding Dark=#EEE, Default=#111}"
-											DetailColor="{AppThemeBinding Dark=#AAA, Default=#555}"
+											TextColor="{x:Static local:RootStyles.TableTextColor}"
+											DetailColor="{x:Static local:RootStyles.TableDetailColor}"
 											Text="{Binding Name}"/>
 									</DataTemplate>
 								</ListView.ItemTemplate>
@@ -91,8 +92,8 @@
 									<DataTemplate
 										x:DataType="models:Work">
 										<TextCell
-											TextColor="{AppThemeBinding Dark=#EEE, Default=#111}"
-											DetailColor="{AppThemeBinding Dark=#AAA, Default=#555}"
+											TextColor="{x:Static local:RootStyles.TableTextColor}"
+											DetailColor="{x:Static local:RootStyles.TableDetailColor}"
 											Text="{Binding Name}"/>
 									</DataTemplate>
 								</ListView.ItemTemplate>
@@ -118,8 +119,8 @@
 									<DataTemplate
 										x:DataType="models:TrainData">
 										<TextCell
-											TextColor="{AppThemeBinding Dark=#EEE, Default=#111}"
-											DetailColor="{AppThemeBinding Dark=#AAA, Default=#555}"
+											TextColor="{x:Static local:RootStyles.TableTextColor}"
+											DetailColor="{x:Static local:RootStyles.TableDetailColor}"
 											Text="{Binding TrainNumber}"/>
 									</DataTemplate>
 								</ListView.ItemTemplate>

--- a/TRViS/SelectTrainPage.xaml
+++ b/TRViS/SelectTrainPage.xaml
@@ -14,6 +14,7 @@
 			<Style TargetType="Frame">
 				<Setter Property="HasShadow" Value="True"/>
 				<Setter Property="BorderColor" Value="{x:Static local:RootStyles.FrameBorderColor}"/>
+				<Setter Property="BackgroundColor" Value="{x:Static local:RootStyles.BackgroundColor}"/>
 				<Setter Property="Margin" Value="8"/>
 				<Setter Property="Padding" Value="8"/>
 				<Setter Property="FlexLayout.Basis" Value="350"/>

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net7.0-android;</TargetFrameworks>
+		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net8.0-android;</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<UseMauiNuGets>true</UseMauiNuGets>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TRViS</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -46,6 +47,9 @@
 			LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference
+			Include="Microsoft.Maui.Controls"
+			Version="8.0.0-preview.2.7871" />
 		<PackageReference
 			Include="CommunityToolkit.Mvvm"
 			Version="8.1.0" />

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -14,7 +14,7 @@ public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension wher
 		base.Dark = Dark;
 	}
 
-	public virtual void Apply(VisualElement? elem, BindableProperty prop)
+	public virtual void Apply(BindableObject? elem, BindableProperty prop)
 		=> elem?.SetAppTheme(prop, this.Light, this.Dark);
 }
 
@@ -22,6 +22,6 @@ public class AppThemeColorBindingExtension : AppThemeGenericsBindingExtension<Co
 {
 	public AppThemeColorBindingExtension(Color Default, Color Dark) : base(Default, Dark) { }
 
-	public override void Apply(VisualElement? elem, BindableProperty prop)
+	public override void Apply(BindableObject? elem, BindableProperty prop)
 		=> elem?.SetAppThemeColor(prop, this.Light, this.Dark);
 }

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -10,6 +10,7 @@ public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension wher
 	public AppThemeGenericsBindingExtension(T Default, T Dark)
 	{
 		base.Default = Default;
+		base.Light = Default;
 		base.Dark = Dark;
 	}
 

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -1,0 +1,26 @@
+namespace TRViS;
+
+public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension where T : class
+{
+	public new T? Dark => base.Dark as T;
+	public new T? Light => base.Light as T;
+	public new T? Default => base.Default as T;
+	public new T? Value => base.Value as T;
+
+	public AppThemeGenericsBindingExtension(T Default, T Dark)
+	{
+		base.Default = Default;
+		base.Dark = Dark;
+	}
+
+	public virtual void Apply(VisualElement? elem, BindableProperty prop)
+		=> elem?.SetAppTheme(prop, this.Light, this.Dark);
+}
+
+public class AppThemeColorBindingExtension : AppThemeGenericsBindingExtension<Color>
+{
+	public AppThemeColorBindingExtension(Color Default, Color Dark) : base(Default, Dark) { }
+
+	public override void Apply(VisualElement? elem, BindableProperty prop)
+		=> elem?.SetAppThemeColor(prop, this.Light, this.Dark);
+}

--- a/iosSim.sh
+++ b/iosSim.sh
@@ -3,7 +3,7 @@
 cd `dirname $0`
 
 TARGET_PROJ="TRViS/TRViS.csproj"
-TARGET_FRAMEWORK="net7.0-ios"
+TARGET_FRAMEWORK="net8.0-ios"
 
 UDID_PATTERN="[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}"
 


### PR DESCRIPTION
D-TAC風表示にダークモードを実装した


https://github.com/TetsuOtter/TRViS/assets/31824852/c4d225f9-c934-4716-a06f-e9c8e46e7bf3

## TODO

- [x] ~~Light / Dark選択ボタンを追加する~~ -> 綺麗に切り替わらないため、実装しないことにする。
- [x] ~~Light / Darkを固定する設定を追加する~~ -> 綺麗に切り替わらないため、実装しないことにする。
- [x] データ選択ページにてテーマの切り替えに追従していないバグに対応
- [ ] 各行のマーカーボタンに色が反映されてないバグに対応
- [ ] HTMLで色指定がされていた場合にSetAppThemeColorを無効化する
- [ ] Version表記がダークモードに追従していない
- [ ] `Select DB File` ボタンの背景色がダークモードに追従していない
- [ ] タイトルバー(?) のグラデーションが、右1/3だけ少し薄くなっている
