### PR TITLE
Lock MAUI version

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -19,14 +19,14 @@ env:
   CSPROJ_PATH: ./TRViS/TRViS.csproj
   THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
   THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net7.0-ios
+  TARGET_FRAMEWORK: net8.0-ios
   TARGET_RUNTIME: ios-arm64
   TARGET_FRAMEWORK_ANDROID: net7.0-android
   OUTPUT_DIR: ./out
   IPA_PATH: ./out/TRViS.ipa
   AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
   APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  SDK_VERSION: '7.0.x'
+  SDK_VERSION: '8.0.100-preview.5.23303.2'
 
 jobs:
   generate-bundle-version:

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -26,7 +26,7 @@ env:
   IPA_PATH: ./out/TRViS.ipa
   AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
   APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  SDK_VERSION: '8.0.100-preview.5.23303.2'
+  SDK_VERSION: '8.0.100-preview.4.23260.5'
 
 jobs:
   generate-bundle-version:

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -21,7 +21,7 @@ env:
   THIRD_PARTY_LICENSE_LIST_NAME: license_list
   TARGET_FRAMEWORK: net8.0-ios
   TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_ANDROID: net7.0-android
+  TARGET_FRAMEWORK_ANDROID: net8.0-android
   OUTPUT_DIR: ./out
   IPA_PATH: ./out/TRViS.ipa
   AAB_PATH: ./out/dev.t0r.trvis-Signed.aab

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net7.0-android;</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TRViS</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net7.0-android;</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<UseMauiNuGets>true</UseMauiNuGets>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TRViS</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -46,6 +47,9 @@
 			LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference
+			Include="Microsoft.Maui.Controls"
+			Version="8.0.0-preview.2.7871" />
 		<PackageReference
 			Include="CommunityToolkit.Mvvm"
 			Version="8.1.0" />

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net7.0-android;</TargetFrameworks>
+		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net8.0-android;</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<UseMauiNuGets>true</UseMauiNuGets>

--- a/iosSim.sh
+++ b/iosSim.sh
@@ -3,7 +3,7 @@
 cd `dirname $0`
 
 TARGET_PROJ="TRViS/TRViS.csproj"
-TARGET_FRAMEWORK="net7.0-ios"
+TARGET_FRAMEWORK="net8.0-ios"
 
 UDID_PATTERN="[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}"
 


### PR DESCRIPTION
現状のMAUIの最新バージョンでは、Grid周りにさまざまなバグがある。
(ColumnSpanが効かなくなったり、GridとScrollViewの組み合わせでレイアウト計算がおかしくなったり)

なので、正常に動作していた時のバージョンで固定してしまうことにした。