### PR TITLE
運転時分の「秒」のみを表示できるようにした

### DIFF
--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -87,7 +87,7 @@ public partial class VerticalTimetableRow
 
 		#region Drive Time
 		bool isDriveTimeMMVisible = rowData.DriveTimeMM is not null and > 0;
-		bool isDriveTimeSSVisible = rowData.DriveTimeMM is not null and > 0;
+		bool isDriveTimeSSVisible = rowData.DriveTimeSS is not null and > 0;
 
 		if (isDriveTimeMMVisible || isDriveTimeSSVisible)
 		{

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -114,7 +114,10 @@ public partial class VerticalTimetableRow
 			if (isDriveTimeSSVisible)
 			{
 				DriveTimeSS = DTACElementStyles.TimetableDriveTimeSSLabel<Label>();
-				DriveTimeSS.Text = rowData.DriveTimeSS.ToString();
+				string? text = rowData.DriveTimeSS.ToString();
+				if (text is not null and { Length: 1 })
+					text = "  " + text;
+				DriveTimeSS.Text = text;
 				DriveTimeGrid.Add(DriveTimeSS, column: 1);
 			}
 

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -86,8 +86,8 @@ public partial class VerticalTimetableRow
 		parent.Add(BackgroundBoxView, row: rowIndex);
 
 		#region Drive Time
-		bool isDriveTimeMMVisible = rowData.DriveTimeMM is not null and >= 0;
-		bool isDriveTimeSSVisible = rowData.DriveTimeSS is not null and >= 0;
+		bool isDriveTimeMMVisible = rowData.DriveTimeMM is not null and >= 0 and < 100;
+		bool isDriveTimeSSVisible = rowData.DriveTimeSS is not null and >= 0 and < 100;
 
 		if (isDriveTimeMMVisible || isDriveTimeSSVisible)
 		{

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -86,8 +86,8 @@ public partial class VerticalTimetableRow
 		parent.Add(BackgroundBoxView, row: rowIndex);
 
 		#region Drive Time
-		bool isDriveTimeMMVisible = rowData.DriveTimeMM is not null and > 0;
-		bool isDriveTimeSSVisible = rowData.DriveTimeSS is not null and > 0;
+		bool isDriveTimeMMVisible = rowData.DriveTimeMM is not null and >= 0;
+		bool isDriveTimeSSVisible = rowData.DriveTimeSS is not null and >= 0;
 
 		if (isDriveTimeMMVisible || isDriveTimeSSVisible)
 		{

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -57,8 +57,8 @@ public class SampleDataLoader : TRViS.IO.ILoader
 		{
 			new TimetableRow(
 				Location: new(1),
-				DriveTimeMM: 1,
-				DriveTimeSS: 5,
+				DriveTimeMM: 0,
+				DriveTimeSS: 0,
 				StationName: "駅１",
 				IsOperationOnlyStop: false,
 				IsPass: false,
@@ -73,8 +73,8 @@ public class SampleDataLoader : TRViS.IO.ILoader
 			),
 			new TimetableRow(
 				Location: new(2),
-				DriveTimeMM: 1,
-				DriveTimeSS: 5,
+				DriveTimeMM: 10,
+				DriveTimeSS: 50,
 				StationName: "駅２",
 				IsOperationOnlyStop: false,
 				IsPass: false,
@@ -89,8 +89,8 @@ public class SampleDataLoader : TRViS.IO.ILoader
 			),
 			new TimetableRow(
 				Location: new(3),
-				DriveTimeMM: 1,
-				DriveTimeSS: 5,
+				DriveTimeMM: 100,
+				DriveTimeSS: 50,
 				StationName: "駅３",
 				IsOperationOnlyStop: true,
 				IsPass: false,
@@ -106,7 +106,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 			new TimetableRow(
 				Location: new(4),
 				DriveTimeMM: 1,
-				DriveTimeSS: 5,
+				DriveTimeSS: null,
 				StationName: "東京",
 				IsOperationOnlyStop: false,
 				IsPass: false,
@@ -121,7 +121,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 			),
 			new TimetableRow(
 				Location: new(5),
-				DriveTimeMM: 1,
+				DriveTimeMM: null,
 				DriveTimeSS: 5,
 				StationName: "津",
 				IsOperationOnlyStop: false,


### PR DESCRIPTION
DriveTimeMM / SSいずれについても、

- `null` ではない
- `0 <= value < 100`

上記両方の条件に合致する場合に表示するようにした。
(自由度を持たせるため、60秒とかもあえて表示できるようにしている)

例えば、下記画像では表のように設定している
![Screenshot 2023-09-26 at 3 47 36](https://github.com/TetsuOtter/TRViS/assets/31824852/4819fb1d-bd2a-4431-bec9-ac4e65a16979)

|StationName|DriveTimeMM|DriveTimeSS|
|---:|---:|---:|
|駅1|0|0|
|駅2|10|50|
|駅3|100|50|
|東京|1|NULL|
|津|NULL|5|

