### PR TITLE
MarkerButtonの色が変化しないバグを修正 + BeforeRemarks/TrainInfoのアニメーションを正常化

### DIFF
--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -33,6 +33,8 @@ public static class DTACElementStyles
 		new(0x00, 0x99, 0x00)
 	);
 	public static readonly AppThemeColorBindingExtension MarkerMarkButtonBGColor = genColor(0xFA, 0x4A);
+	public static readonly AppThemeGenericsBindingExtension<Brush> MarkerMarkButtonBGColorBrush
+		= MarkerMarkButtonBGColor.ToBrushTheme();
 
 	public static readonly AppThemeColorBindingExtension DefaultGreen = new(
 		new(0x00, 0x80, 0x00),

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -25,6 +25,7 @@
 		<dtac:PageHeader
 			x:Name="PageHeaderArea"
 			Grid.Row="0"
+			IsOpen="False"
 			IsOpenChanged="BeforeRemarks_TrainInfo_OpenCloseChanged"
 			BackgroundColor="{x:Static dtac:DTACElementStyles.DefaultBGColor}"/>
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -133,9 +133,11 @@ public partial class VerticalStylePage : ContentView
 	{
 		bool isToOpen = e.NewValue;
 		(double start, double end) = isToOpen
-			? (0d, TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT)
-			: (TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT, 0d);
+			? (TrainInfo_BeforeDepature_RowDefinition.Height.Value, TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT)
+			: (TrainInfo_BeforeDepature_RowDefinition.Height.Value, 0d);
 
+		if (this.AnimationIsRunning(DateAndStartButton_AnimationName))
+			this.AbortAnimation(DateAndStartButton_AnimationName);
 		new Animation(
 			v => {
 				if (!TrainInfo_BeforeDepartureArea.IsVisible)

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -138,6 +138,8 @@ public partial class VerticalStylePage : ContentView
 
 		new Animation(
 			v => {
+				if (!TrainInfo_BeforeDepartureArea.IsVisible)
+					TrainInfo_BeforeDepartureArea.IsVisible = true;
 				TrainInfo_BeforeDepature_RowDefinition.Height = v;
 				TrainInfo_BeforeDepartureArea.HeightRequest = v;
 			},
@@ -147,7 +149,11 @@ public partial class VerticalStylePage : ContentView
 		)
 			.Commit(
 				this,
-				DateAndStartButton_AnimationName
+				DateAndStartButton_AnimationName,
+				finished: (_, canceled) => {
+					if (!isToOpen && !canceled)
+						TrainInfo_BeforeDepartureArea.IsVisible = false;
+				}
 			);
 	}
 }

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -1,7 +1,5 @@
 using DependencyPropertyGenerator;
-
 using TRViS.IO.Models;
-using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
@@ -133,9 +131,23 @@ public partial class VerticalStylePage : ContentView
 	const string DateAndStartButton_AnimationName = nameof(DateAndStartButton_AnimationName);
 	void BeforeRemarks_TrainInfo_OpenCloseChanged(object sender, ValueChangedEventArgs<bool> e)
 	{
-		(double start, double end) = e.NewValue ? (TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT, 0d) : (0d, TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT);
+		bool isToOpen = e.NewValue;
+		(double start, double end) = isToOpen
+			? (0d, TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT)
+			: (TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT, 0d);
 
-		new Animation(v => TrainInfo_BeforeDepature_RowDefinition.Height = v, start, end, Easing.SinInOut)
-			.Commit(this, DateAndStartButton_AnimationName, length: 250, finished: (v, _) => TrainInfo_BeforeDepature_RowDefinition.Height = v);
+		new Animation(
+			v => {
+				TrainInfo_BeforeDepature_RowDefinition.Height = v;
+				TrainInfo_BeforeDepartureArea.HeightRequest = v;
+			},
+			start,
+			end,
+			Easing.SinInOut
+		)
+			.Commit(
+				this,
+				DateAndStartButton_AnimationName
+			);
 	}
 }

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -22,7 +22,7 @@ public partial class VerticalTimetableRow
 	}
 
 	void setMarkerBoxDefaultColor()
-		=> DTACElementStyles.MarkerMarkButtonBGColor.Apply(MarkerBox, VisualElement.BackgroundColorProperty);
+		=> DTACElementStyles.MarkerMarkButtonBGColorBrush.Apply(MarkerBox, VisualElement.BackgroundProperty);
 
 	Color? _MarkedColor = null;
 	public Color? MarkedColor
@@ -45,7 +45,7 @@ public partial class VerticalTimetableRow
 			else
 			{
 				BackgroundBoxView.Color = value;
-				MarkerBox.BackgroundColor = value;
+				MarkerBox.Background = new SolidColorBrush(value);
 				MarkerBox.TextColor = Utils.GetTextColorFromBGColor(value);
 			}
 		}

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -250,6 +250,7 @@ public partial class VerticalTimetableRow
 			IsEnabled = false,
 			FontFamily = "Hiragino Sans",
 			FontSize = 18,
+			FontAttributes = FontAttributes.Bold,
 			BorderColor = Colors.Transparent,
 			CornerRadius = 4,
 			Padding = new(0),

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -30,4 +30,7 @@ public class AppThemeColorBindingExtension : AppThemeGenericsBindingExtension<Co
 
 	public override void Apply(BindableObject? elem, BindableProperty prop)
 		=> elem?.SetAppThemeColor(prop, this.Light, this.Dark);
+	
+	public AppThemeGenericsBindingExtension<Brush> ToBrushTheme()
+		=> new(new SolidColorBrush(this.Default), new SolidColorBrush(this.Dark));
 }

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -2,8 +2,8 @@ namespace TRViS;
 
 public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension where T : class
 {
-	private T _Dark;
-	private T _Default;
+	private readonly T _Dark;
+	private readonly T _Default;
 	public new T Dark => base.Dark as T ?? _Dark;
 	public new T Light => base.Light as T ?? _Default;
 	public new T Default => base.Default as T ?? _Default;

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -2,16 +2,22 @@ namespace TRViS;
 
 public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension where T : class
 {
-	public new T? Dark => base.Dark as T;
-	public new T? Light => base.Light as T;
-	public new T? Default => base.Default as T;
-	public new T? Value => base.Value as T;
+	private T _Dark;
+	private T _Default;
+	public new T Dark => base.Dark as T ?? _Dark;
+	public new T Light => base.Light as T ?? _Default;
+	public new T Default => base.Default as T ?? _Default;
+	public new T Value => base.Value as T ?? _Default;
 
 	public AppThemeGenericsBindingExtension(T Default, T Dark)
 	{
-		base.Default = Default;
-		base.Light = Default;
-		base.Dark = Dark;
+		base.Default
+			= base.Light
+			= _Default
+			= Default
+			;
+
+		base.Dark = _Dark = Dark;
 	}
 
 	public virtual void Apply(BindableObject? elem, BindableProperty prop)


### PR DESCRIPTION
マーカーボタンを押下した際、ボタン背景色がマーカーの色に変化することが期待される。

しかし、なぜか色が変化しない (Theme色から変わらない) 状態だったため、これを修正した。

ついでに、MarkerButtonの文字スタイルを太字に変更した。

---

BeforeRemarks / TrainInfo部分のアニメーションが正常に再生されない状態であったため、ここで修正している。