### PR TITLE
HTMLAutoDetectLabelとAppThemeが競合していたバグを修正

### DIFF
--- a/TRViS/Controls/HtmlAutoDetectLabel.cs
+++ b/TRViS/Controls/HtmlAutoDetectLabel.cs
@@ -4,6 +4,8 @@ namespace TRViS.Controls;
 
 public class HtmlAutoDetectLabel : Label
 {
+	public AppThemeColorBindingExtension? CurrentAppThemeColorBindingExtension { get; set; }
+
 	protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
 	{
 		base.OnPropertyChanged(propertyName);
@@ -18,7 +20,20 @@ public class HtmlAutoDetectLabel : Label
 
 				try
 				{
-					TextType = (text.StartsWith('<') && text.EndsWith('>')) ? TextType.Html : TextType.Text;
+					TextType _textType = (text.StartsWith('<') && text.EndsWith('>')) ? TextType.Html : TextType.Text;
+					if (CurrentAppThemeColorBindingExtension is not null)
+					{
+						if (_textType == TextType.Html
+							&& text.Contains("color:"))
+						{
+							this.SetAppThemeColor(TextColorProperty, null, null);
+						}
+						else
+						{
+							CurrentAppThemeColorBindingExtension.Apply(this, TextColorProperty);
+						}
+					}
+					TextType = _textType;
 				}
 				catch (Exception ex)
 				{

--- a/TRViS/Controls/HtmlAutoDetectLabel.cs
+++ b/TRViS/Controls/HtmlAutoDetectLabel.cs
@@ -5,6 +5,7 @@ namespace TRViS.Controls;
 public class HtmlAutoDetectLabel : Label
 {
 	public AppThemeColorBindingExtension? CurrentAppThemeColorBindingExtension { get; set; }
+	public Color? LastTextColor {get; private set; }
 
 	protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
 	{
@@ -17,20 +18,32 @@ public class HtmlAutoDetectLabel : Label
 			else
 			{
 				string text = Text.Trim();
+				bool isColoredString = text.Contains("color:");
 
 				try
 				{
 					TextType _textType = (text.StartsWith('<') && text.EndsWith('>')) ? TextType.Html : TextType.Text;
 					if (CurrentAppThemeColorBindingExtension is not null)
 					{
-						if (_textType == TextType.Html
-							&& text.Contains("color:"))
+						if (_textType == TextType.Html && isColoredString)
 						{
 							this.SetAppThemeColor(TextColorProperty, null, null);
 						}
 						else
 						{
 							CurrentAppThemeColorBindingExtension.Apply(this, TextColorProperty);
+						}
+					}
+					else
+					{
+						if (_textType == TextType.Html && isColoredString)
+						{
+							LastTextColor = TextColor;
+							TextColor = null;
+						}
+						else if (TextColor is null && LastTextColor is not null)
+						{
+							TextColor = LastTextColor;
 						}
 					}
 					TextType = _textType;

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -190,6 +190,7 @@ public partial class VerticalTimetableRow
 			TrackName.Margin = TrackName.Padding = new(0);
 			TrackName.HorizontalOptions = TrackName.VerticalOptions = LayoutOptions.Center;
 			TrackName.TextColor = Colors.Red;
+			TrackName.CurrentAppThemeColorBindingExtension = null;
 			TrackName.Text = rowData.TrackName;
 			parent.Add(TrackName, 4, rowIndex);
 		}

--- a/TRViS/Platforms/iOS/AppDelegate.cs
+++ b/TRViS/Platforms/iOS/AppDelegate.cs
@@ -1,6 +1,4 @@
 using Foundation;
-using Microsoft.Maui.Handlers;
-using UIKit;
 
 namespace TRViS;
 
@@ -8,65 +6,4 @@ namespace TRViS;
 public class AppDelegate : MauiUIApplicationDelegate
 {
 	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
-
-	//ref: https://github.com/dotnet/maui/issues/4230#issuecomment-1143228199
-	public AppDelegate() : base()
-	{
-		LabelHandler.Mapper.AppendToMapping(nameof(Label.Text), UpdateHtmlText);
-		LabelHandler.Mapper.AppendToMapping(nameof(Label.FontFamily), UpdateHtmlText);
-		LabelHandler.Mapper.AppendToMapping(nameof(Label.FontSize), UpdateHtmlText);
-		LabelHandler.Mapper.AppendToMapping(nameof(Label.TextType), UpdateHtmlText);
-	}
-
-	static void UpdateHtmlText(ILabelHandler handler, ILabel _label)
-	{
-		if (_label is not Label label || label.TextType != TextType.Html)
-			return;
-
-		Microsoft.Maui.Font font = label.ToFont();
-		IFontRegistrar? registrar = handler.MauiContext!.Services.GetService<IFontRegistrar>();
-
-		string? fontName = CleanseFontName(font.Family, registrar);
-		double fontSize = label.FontSize != 0 ? label.FontSize : UIFont.SystemFontSize;
-
-		NSError? nsError = null;
-		handler.PlatformView.AttributedText = new(
-			$"<span style=\"font-family: '{fontName}'; font-size: {fontSize};\">{label.Text}</span>",
-			new()
-			{
-				DocumentType = NSDocumentType.HTML,
-				StringEncoding = NSStringEncoding.UTF8,
-			},
-			#pragma warning disable CS8601
-			ref nsError);
-			#pragma warning restore CS8601
-	}
-
-	static string? CleanseFontName(string? fontName, IFontRegistrar? fontRegistrar)
-	{
-		if (fontName is null || fontRegistrar is null)
-			return null;
-
-		if (fontRegistrar.GetFont(fontName) is string fontPostScriptName)
-			return fontPostScriptName;
-
-		var fontFile = FontFile.FromString(fontName);
-
-		if (!string.IsNullOrWhiteSpace(fontFile.Extension))
-		{
-			if (fontRegistrar.GetFont(fontFile.FileNameWithExtension()) is string filePath)
-				return filePath ?? fontFile.PostScriptName;
-		}
-		else
-		{
-			foreach (var ext in FontFile.Extensions)
-			{
-				var formatted = fontFile.FileNameWithExtension(ext);
-				if (fontRegistrar.GetFont(formatted) is string filePath)
-					return filePath;
-			}
-		}
-
-		return fontFile.PostScriptName;
-	}
 }

--- a/TRViS/Utils/AppThemeColorBindingExtension.cs
+++ b/TRViS/Utils/AppThemeColorBindingExtension.cs
@@ -1,3 +1,5 @@
+using TRViS.Controls;
+
 namespace TRViS;
 
 public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension where T : class
@@ -15,7 +17,11 @@ public class AppThemeGenericsBindingExtension<T> : AppThemeBindingExtension wher
 	}
 
 	public virtual void Apply(BindableObject? elem, BindableProperty prop)
-		=> elem?.SetAppTheme(prop, this.Light, this.Dark);
+	{
+		elem?.SetAppTheme(prop, this.Light, this.Dark);
+		if (elem is HtmlAutoDetectLabel label && prop == HtmlAutoDetectLabel.TextColorProperty)
+			label.CurrentAppThemeColorBindingExtension = this as AppThemeColorBindingExtension;
+	}
 }
 
 public class AppThemeColorBindingExtension : AppThemeGenericsBindingExtension<Color>
@@ -23,5 +29,9 @@ public class AppThemeColorBindingExtension : AppThemeGenericsBindingExtension<Co
 	public AppThemeColorBindingExtension(Color Default, Color Dark) : base(Default, Dark) { }
 
 	public override void Apply(BindableObject? elem, BindableProperty prop)
-		=> elem?.SetAppThemeColor(prop, this.Light, this.Dark);
+	{
+		elem?.SetAppThemeColor(prop, this.Light, this.Dark);
+		if (elem is HtmlAutoDetectLabel label && prop == HtmlAutoDetectLabel.TextColorProperty)
+			label.CurrentAppThemeColorBindingExtension = this;
+	}
 }

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -114,7 +114,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 				IsLastStop: false,
 				ArriveTime: new(1,23,45,null),
 				DepartureTime: new(1,25,null, null),
-				TrackName: "1",
+				TrackName: """<span style="color: aqua">1</span>""",
 				RunInLimit: null,
 				RunOutLimit: null,
 				Remarks: "記事"


### PR DESCRIPTION
ライトモード / ダークモードの変更を行うと、HTMLラベル部分のテキスト色がそれにつられて変わってしまう状態だった。
そこで、`color` css設定が存在する場合にAppThemeを無効化することにより、AppThemeにつられないようにした。

なお、HTMLでcolorを指定しつつLight/Dark対応を行うことはできない。この点については、要望があれば検討する。
(通常は　`@media (prefers-color-scheme: dark) { }` で設定できるらしいが、HTMLLabelでは使用できなかった)

![Screenshot 2023-09-27 at 1 23 18](https://github.com/TetsuOtter/TRViS/assets/31824852/a4c677e0-33b7-4345-800d-edd244a39c89)
