### PR TITLE
Mac向けのビルド設定を追加

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -131,7 +131,7 @@ jobs:
       )
 
     runs-on: macos-13
-    timeout-minutes: 360
+    timeout-minutes: 30
     needs:
       - get-version
     
@@ -308,7 +308,7 @@ jobs:
       )
 
     runs-on: macos-13
-    timeout-minutes: 30
+    timeout-minutes: 360
     needs:
       - get-version
     
@@ -473,7 +473,7 @@ jobs:
       )
 
     runs-on: macos-13
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs:
       - build-mac
 

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -131,7 +131,7 @@ jobs:
       )
 
     runs-on: macos-13
-    timeout-minutes: 30
+    timeout-minutes: 360
     needs:
       - get-version
     

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -397,8 +397,10 @@ jobs:
         /p:CodesignEntitlements='Platforms/MacCatalyst/Entitlements.plist'
 
     - name: Change pkg file name
-      working-directory: ${{ env.OUTPUT_DIR }}
-      run: mv TRViS-${{ needs.get-version.outputs.display_version }}.pkg ${{ env.PKG_PATH }}
+      run: >
+        mv
+        ${{ env.OUTPUT_DIR }}/TRViS-${{ needs.get-version.outputs.display_version }}.pkg
+        ${{ env.PKG_PATH }}
 
     - name: Upload PKG
       uses: actions/upload-artifact@v3

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -130,7 +130,7 @@ jobs:
         || github.event.pull_request.draft == false
       )
 
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 30
     needs:
       - get-version
@@ -307,7 +307,7 @@ jobs:
         || github.event.pull_request.draft == false
       )
 
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 30
     needs:
       - get-version
@@ -420,7 +420,7 @@ jobs:
         || github.event.pull_request.draft == false
       )
 
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 10
     needs:
       - build-ios
@@ -472,7 +472,7 @@ jobs:
         || github.event.pull_request.draft == false
       )
 
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 10
     needs:
       - build-mac

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -21,9 +21,12 @@ env:
   THIRD_PARTY_LICENSE_LIST_NAME: license_list
   TARGET_FRAMEWORK: net8.0-ios
   TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net8.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
   TARGET_FRAMEWORK_ANDROID: net8.0-android
   OUTPUT_DIR: ./out
   IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
   AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
   APK_PATH: ./out/dev.t0r.trvis-Signed.apk
   SDK_VERSION: '8.0.100-preview.4.23260.5'
@@ -295,6 +298,119 @@ jobs:
         path: ${{ env.APK_PATH }}
         retention-days: 3
 
+  build-mac:
+    if: |
+      !failure()
+      && !cancelled()
+      && (
+        github.event_name != 'pull_request'
+        || github.event.pull_request.draft == false
+      )
+
+    runs-on: macos-12
+    timeout-minutes: 30
+    needs:
+      - get-version
+    
+    env:
+      WITHOUT_ANDROID: true
+
+    steps:
+    - name: Import Provisioning Profile
+      run: |
+        mkdir -p ${{ env.TARGET_DIR }}
+
+        if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
+          echo -n ${{ secrets.PROVISIONING_PROFILE_MAC }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+          ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+        fi
+      env:
+        TARGET_DIR: ~/Library/MobileDevice/Provisioning\ Profiles
+        TARGET_FILE: distribution.provisionprofile
+
+    - name: Generate Keychain Name
+      id: gen-keychain-name
+      run: echo "keychain-name=${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+    
+    # ref: https://github.com/Apple-Actions/import-codesign-certs/pull/27#issuecomment-1298231619
+    - name: Build keychain
+      run: |
+        echo "${{ secrets.P12_FILE_MAC_BASE64 }}" | base64 --decode > certificate.p12
+        security create-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+        security default-keychain -s "${{ env.KEYCHAIN_NAME }}"
+        security unlock-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+        security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
+        security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P '${{ secrets.P12_PASSWORD_MAC }}' -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/xcrun
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+      env:
+        KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
+
+    - uses: actions/checkout@v3
+
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@v1.5.1
+      with:
+        xcode-version: latest-stable
+
+    - uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: ${{ env.SDK_VERSION }}
+    - name: Install dotnet workloads
+      run: dotnet workload install maui-ios maccatalyst
+
+    - name: Install dependencies
+      run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME_MAC }}
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Prapare Python Package
+      run: |
+        python --version
+        python -m pip install aiofiles aiohttp
+    - name: Dump Third Party License Info
+      id: dump-third-party-license-info
+      continue-on-error: true
+      run: |
+        python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+        ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+    - name: Dump Third Party License Info (Retry)
+      if: steps.dump-third-party-license-info.outcome == 'failure'
+      run: |
+        python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+        ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+    - name: Print Third Party License Info Files
+      run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+
+    - name: Build
+      run: >
+        dotnet publish ${{ env.CSPROJ_PATH }}
+        -f ${{ env.TARGET_FRAMEWORK_MAC }}
+        -c Release
+        -o "${{ env.OUTPUT_DIR }}"
+        /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
+        /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
+        /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_MAC }}"
+        /p:CodesignProvision="${{ secrets.CODESIGN_PROVISION_NAME_MAC }}"
+        /p:EnablePackageSigning=true
+        /p:PackageSigningKey='${{ secrets.PACKAGE_SIGN_KEY_NAME_MAC }}'
+        /p:CodesignEntitlements='Platforms/MacCatalyst/Entitlements.plist'
+
+    - name: Change pkg file name
+      working-directory: ${{ env.OUTPUT_DIR }}
+      run: mv TRViS-${{ needs.get-version.outputs.display_version }}.pkg ${{ env.PKG_PATH }}
+
+    - name: Upload PKG
+      uses: actions/upload-artifact@v3.0.0
+      with:
+        name: pkg
+        path: ${{ env.PKG_PATH }}
+        retention-days: 3
+
+    - name: Post 'Import Code Sign Certificates'
+      if: always() && steps.import-code-sign-cert.conclusion == 'success'
+      run: /usr/bin/security delete-keychain ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
+
   publish-ios:
     if: |
       !failure()
@@ -347,10 +463,65 @@ jobs:
         --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
         --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
 
+  publish-mac:
+    if: |
+      !failure()
+      && !cancelled()
+      && (
+        github.event_name != 'pull_request'
+        || github.event.pull_request.draft == false
+      )
+
+    runs-on: macos-12
+    timeout-minutes: 10
+    needs:
+      - build-mac
+
+    steps:
+    - name: Import App Store Connect API Private Key
+      run: |
+        mkdir -p ${{ env.TARGET_DIR }}
+
+        if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
+          echo -n ${{ secrets.APPSTORECONNECT_API_PRIVATE_KEY }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+          chmod 400 ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+          ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+        fi
+      env:
+        TARGET_DIR: ~/.appstoreconnect/private_keys
+        TARGET_FILE: AuthKey_${{ secrets.APPSTORECONNECT_API_KEY }}.p8
+
+    - name: Download PKG
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: pkg
+        path: ${{ env.OUTPUT_DIR }}
+
+    - name: validate
+      run: >
+        xcrun altool
+        --validate-app
+        --type mac
+        -f ${{ env.PKG_PATH }}
+        --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
+        --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
+
+    - name: upload
+      run: >
+        xcrun altool
+        --upload-app
+        --type mac
+        -f ${{ env.PKG_PATH }}
+        --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
+        --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
+
   set-tag:
     if: |
       needs.generate-bundle-version.result == 'success'
-      && needs.publish-ios.result == 'success'
+      && (
+        needs.publish-ios.result == 'success'
+        || needs.publish-mac.result == 'success'
+      )
       && !cancelled()
 
     runs-on: ubuntu-latest
@@ -358,6 +529,7 @@ jobs:
     needs:
       - generate-bundle-version
       - publish-ios
+      - publish-mac
     
     outputs:
       tag-name: ${{ steps.tag-name.outputs.tag-name }}
@@ -393,6 +565,7 @@ jobs:
       run: >
         echo Tag \`${{ steps.tag-name.outputs.tag-name }}\` was automatically created and pushed with
         ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+        ' (Publish Status iOS: ${{ needs.publish-ios.result }} / macOS: ${{ needs.publish-mac.result }})'
         | gh pr comment ${{ github.event.number }} -F -
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -522,7 +522,7 @@ jobs:
         needs.publish-ios.result == 'success'
         || needs.publish-mac.result == 'success'
       )
-      && !cancelled()
+      && !failure()
 
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -308,7 +308,7 @@ jobs:
       )
 
     runs-on: macos-13
-    timeout-minutes: 360
+    timeout-minutes: 30
     needs:
       - get-version
     

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -340,8 +340,8 @@ jobs:
         security default-keychain -d user -s "${{ env.KEYCHAIN_NAME }}"
         security unlock-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
         security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
-        security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P '${{ secrets.P12_PASSWORD_MAC }}' -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/xcrun
-        security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+        security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P '${{ secrets.P12_PASSWORD_MAC }}' -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/xcrun
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
       env:
         KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
 

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -337,11 +337,11 @@ jobs:
       run: |
         echo "${{ secrets.P12_FILE_MAC_BASE64 }}" | base64 --decode > certificate.p12
         security create-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
-        security default-keychain -s "${{ env.KEYCHAIN_NAME }}"
+        security default-keychain -d user -s "${{ env.KEYCHAIN_NAME }}"
         security unlock-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
         security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
         security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P '${{ secrets.P12_PASSWORD_MAC }}' -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/xcrun
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+        security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
       env:
         KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
 

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -49,7 +49,7 @@ jobs:
       build_number: ${{ steps.build_number.outputs.version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{github.head_ref}}
 
@@ -168,14 +168,14 @@ jobs:
       env:
         KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.5.1
+      uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: latest-stable
 
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.SDK_VERSION }}
     - name: Install dotnet workloads
@@ -218,7 +218,7 @@ jobs:
         /p:CodesignProvision="${{ secrets.CODESIGN_PROVISION_NAME_IOS }}"
 
     - name: Upload IPA
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: ipa
         path: ${{ env.IPA_PATH }}
@@ -243,9 +243,9 @@ jobs:
       - get-version
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.SDK_VERSION }}
     - name: Install dotnet workloads
@@ -285,14 +285,14 @@ jobs:
         /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
 
     - name: Upload AAB
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: aab
         path: ${{ env.AAB_PATH }}
         retention-days: 3
 
     - name: Upload APK
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: apk
         path: ${{ env.APK_PATH }}
@@ -345,14 +345,14 @@ jobs:
       env:
         KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.5.1
+      uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: latest-stable
 
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.SDK_VERSION }}
     - name: Install dotnet workloads
@@ -401,7 +401,7 @@ jobs:
       run: mv TRViS-${{ needs.get-version.outputs.display_version }}.pkg ${{ env.PKG_PATH }}
 
     - name: Upload PKG
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: pkg
         path: ${{ env.PKG_PATH }}
@@ -440,7 +440,7 @@ jobs:
         TARGET_FILE: AuthKey_${{ secrets.APPSTORECONNECT_API_KEY }}.p8
 
     - name: Download IPA
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@v3
       with:
         name: ipa
         path: ${{ env.OUTPUT_DIR }}
@@ -492,7 +492,7 @@ jobs:
         TARGET_FILE: AuthKey_${{ secrets.APPSTORECONNECT_API_KEY }}.p8
 
     - name: Download PKG
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@v3
       with:
         name: pkg
         path: ${{ env.OUTPUT_DIR }}
@@ -535,7 +535,7 @@ jobs:
       tag-name: ${{ steps.tag-name.outputs.tag-name }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: fetch all history to assign tag
       if: ${{ github.event_name == 'pull_request' }}
       run: git fetch --unshallow --no-tags --no-recurse-submodules origin +${{ github.sha }}:${{ github.ref }}
@@ -582,7 +582,7 @@ jobs:
 
     steps:
     - name: Download APK
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@v3
       with:
         name: apk
         path: ${{ env.OUTPUT_DIR }}

--- a/TRViS/Platforms/MacCatalyst/Entitlements.plist
+++ b/TRViS/Platforms/MacCatalyst/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+  </dict>
+</plist>

--- a/TRViS/Platforms/MacCatalyst/Info.plist
+++ b/TRViS/Platforms/MacCatalyst/Info.plist
@@ -2,9 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIDeviceFamily</key>
 	<array>
-		<integer>1</integer>
 		<integer>2</integer>
 	</array>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -28,5 +29,9 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Check whether you are near a station or not.</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2023 Tetsu Otter</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 </dict>
 </plist>


### PR DESCRIPTION
各種Secretについては、Wikiにまとめた
[(自分用) CD Tips](https://github.com/TetsuOtter/TRViS/wiki/(%E8%87%AA%E5%88%86%E7%94%A8)-CD-Tips)

なお、Apple Siliconを搭載したMacでは、下図のように上部に「macOS」と「iOS」を選択するタブが出現する。
mac版をインストールするには、既存のiOS版アプリをアンインストールしたうえで、この上部タブから「macOS」を選択してインストールすることになる。
![Screenshot 2023-09-28 at 3 17 40](https://github.com/TetsuOtter/TRViS/assets/31824852/b926f33d-5f38-4b9f-9945-1bc5ec855eb8)

UIについてはあまりテストしきれていないため、あくまでおまけ程度の感覚での提供になる。