### PR TITLE
マーカー/LocationServiceのカスタマイズを実装

### DIFF
--- a/TRViS/App.xaml.cs
+++ b/TRViS/App.xaml.cs
@@ -4,13 +4,13 @@ public partial class App : Application
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-	public App(AppShell mainPage)
+	public App()
 	{
 		logger.Trace("App Creating");
 
 		InitializeComponent();
 
-		MainPage = mainPage;
+		MainPage = new AppShell();
 
 		logger.Trace("App Created");
 	}

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -11,10 +11,12 @@ public partial class AppShell : Shell
 	static public string AppVersionString
 		=> $"Version: {AppInfo.Current.VersionString}-{AppInfo.Current.BuildString}";
 
-	public AppShell(EasterEggPageViewModel easterEggPageViewModel)
+	public AppShell()
 	{
 		logger.Trace("AppShell Creating");
 		logger.Info("Application Version: {0}", AppVersionString);
+
+		EasterEggPageViewModel easterEggPageViewModel = InstanceManager.EasterEggPageViewModel;
 
 		InitializeComponent();
 

--- a/TRViS/DTAC/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/MarkerButton.xaml.cs
@@ -1,35 +1,28 @@
 using CommunityToolkit.Maui.Views;
-
-using DependencyPropertyGenerator;
-
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
-[DependencyProperty<DTACMarkerViewModel>("MarkerSettings")]
 public partial class MarkerButton : Frame
 {
+	DTACMarkerViewModel MarkerSettings { get; }
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	public MarkerButton()
 	{
 		logger.Trace("Creating...");
 
+		MarkerSettings = InstanceManager.DTACMarkerViewModel;
+		BindingContext = MarkerSettings;
 		InitializeComponent();
 
 		logger.Trace("Created");
 	}
 
-	partial void OnMarkerSettingsChanged(DTACMarkerViewModel? newValue)
-	{
-		logger.Trace("OnMarkerSettingsChanged({0})", newValue?.GetType().Name ?? "null");
-		BindingContext = newValue;
-	}
-
 	async void TapGestureRecognizer_Tapped(object sender, EventArgs e)
 	{
-		if (Shell.Current.CurrentPage is not ViewHost page || MarkerSettings is null)
+		if (Shell.Current.CurrentPage is not ViewHost page)
 		{
-			logger.Warn("Shell.Current.CurrentPage is not ViewHost or MarkerSettings is null");
+			logger.Warn("Shell.Current.CurrentPage is not ViewHost");
 			return;
 		}
 

--- a/TRViS/DTAC/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml.cs
@@ -6,20 +6,15 @@ namespace TRViS.DTAC;
 public partial class SelectMarkerPopup : Popup
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-	public SelectMarkerPopup()
+	public SelectMarkerPopup() : this(InstanceManager.DTACMarkerViewModel) { }
+
+	public SelectMarkerPopup(DTACMarkerViewModel viewModel)
 	{
 		logger.Trace("Creating...");
 
+		BindingContext = viewModel;
+
 		InitializeComponent();
-
-		logger.Trace("Created");
-	}
-
-	public SelectMarkerPopup(DTACMarkerViewModel vm) : this()
-	{
-		logger.Trace("SelectMarkerPopup(DTACMarkerViewModel: {0})", vm);
-
-		BindingContext = vm;
 
 		logger.Trace("Created");
 	}

--- a/TRViS/DTAC/TimetableHeader.xaml.cs
+++ b/TRViS/DTAC/TimetableHeader.xaml.cs
@@ -1,10 +1,8 @@
 using DependencyPropertyGenerator;
-using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
 [DependencyProperty<double>("FontSize_Large")]
-[DependencyProperty<DTACMarkerViewModel>("MarkerSettings")]
 public partial class TimetableHeader : Grid
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -15,12 +13,5 @@ public partial class TimetableHeader : Grid
 		InitializeComponent();
 
 		logger.Trace("Created");
-	}
-
-	partial void OnMarkerSettingsChanged(DTACMarkerViewModel? newValue)
-	{
-		logger.Trace("OnMarkerSettingsChanged({0})", newValue?.GetType().Name ?? "null");
-
-		MarkerBtn.MarkerSettings = newValue;
 	}
 }

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -45,8 +45,6 @@ public partial class VerticalStylePage : ContentView
 			new(new(1, GridUnitType.Star))
 		);
 
-		this.TimetableHeader.MarkerSettings = TimetableView.MarkerViewModel;
-
 		if (DeviceInfo.Current.Idiom == DeviceIdiom.Phone || DeviceInfo.Current.Idiom == DeviceIdiom.Unknown)
 		{
 			logger.Info("Device is Phone or Unknown -> make it to fill-scrollable");

--- a/TRViS/DTAC/VerticalTimetableView.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableView.Init.cs
@@ -50,8 +50,6 @@ public partial class VerticalTimetableView
 			MainThread.BeginInvokeOnMainThread(() => Shell.Current.DisplayAlert("Location Service Error", e.ToString(), "OK"));
 		};
 
-		LocationService.Interval = new TimeSpan(0, 0, 1);
-
 		logger.Trace("Created");
 	}
 

--- a/TRViS/DTAC/VerticalTimetableView.cs
+++ b/TRViS/DTAC/VerticalTimetableView.cs
@@ -21,7 +21,7 @@ public partial class VerticalTimetableView : Grid
 
 	public event EventHandler<ScrollRequestedEventArgs>? ScrollRequested;
 
-	public DTACMarkerViewModel MarkerViewModel { get; init; } = new();
+	public DTACMarkerViewModel MarkerViewModel { get; } = InstanceManager.DTACMarkerViewModel;
 
 	partial void OnSelectedTrainDataChanged(TrainData? newValue)
 	{

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -15,9 +15,12 @@ public partial class ViewHost : ContentPage
 	readonly GradientStop TitleBG_MidBottom = new(Colors.White.WithAlpha(0.1f), 0.8f);
 	readonly GradientStop TitleBG_Bottom = new(Colors.White.WithAlpha(0), 1);
 
-	public ViewHost(AppViewModel vm, EasterEggPageViewModel eevm)
+	public ViewHost()
 	{
 		logger.Trace("Creating...");
+
+		AppViewModel vm = InstanceManager.AppViewModel;
+		EasterEggPageViewModel eevm = InstanceManager.EasterEggPageViewModel;
 
 		Shell.SetNavBarIsVisible(this, false);
 

--- a/TRViS/EasterEggPage.xaml
+++ b/TRViS/EasterEggPage.xaml
@@ -20,11 +20,40 @@
 			<Style TargetType="Frame">
 				<Setter Property="Margin" Value="8"/>
 			</Style>
+
+			<Style TargetType="Button">
+				<Setter Property="Margin" Value="8"/>
+				<Setter Property="Padding" Value="8"/>
+				<Setter Property="LineBreakMode" Value="WordWrap" />
+			</Style>
 		</ResourceDictionary>
 	</ContentPage.Resources>
 
 	<ScrollView>
-		<VerticalStackLayout>
+		<VerticalStackLayout Margin="4,8">
+			<HorizontalStackLayout
+				IsVisible="false"
+				HorizontalOptions="Start">
+				<Button
+					Text="Load from..."
+					Clicked="OnLoadFromPickerClicked"
+				/>
+				<Button
+					Text="Save to..."
+					Clicked="OnSaveToPickerClicked"
+				/>
+			</HorizontalStackLayout>
+			<HorizontalStackLayout
+				HorizontalOptions="End">
+				<Button
+					Text="Reload Saved"
+					Clicked="OnReloadSavedClicked"
+				/>
+				<Button
+					Text="Save"
+					Clicked="OnSaveClicked"
+				/>
+			</HorizontalStackLayout>
 			<Frame>
 				<Grid>
 					<Grid.RowDefinitions>

--- a/TRViS/EasterEggPage.xaml
+++ b/TRViS/EasterEggPage.xaml
@@ -102,6 +102,20 @@
 			<Frame>
 				<VerticalStackLayout>
 					<Label
+						x:Name="LocationServiceIntervalSettingHeaderLabel"
+						Text="{Binding LocationServiceIntervalSettingHeaderLabel, Mode=OneWay}"
+						FontSize="Header"
+						/>
+					<ListView
+						VerticalScrollBarVisibility="Never"
+						ItemsSource="{Binding LocationServiceIntervalItems, Mode=OneTime}"
+						SelectedItem="{Binding LocationServiceInterval_Seconds, Mode=TwoWay}"
+					/>
+				</VerticalStackLayout>
+			</Frame>
+			<Frame>
+				<VerticalStackLayout>
+					<Label
 						Text="Log File Path"
 						FontSize="Header"
 						/>

--- a/TRViS/EasterEggPage.xaml.cs
+++ b/TRViS/EasterEggPage.xaml.cs
@@ -1,3 +1,4 @@
+using TRViS.MyAppCustomizables;
 using TRViS.ViewModels;
 
 namespace TRViS;
@@ -5,6 +6,7 @@ namespace TRViS;
 public partial class EasterEggPage : ContentPage
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	EasterEggPageViewModel ViewModel { get; }
 
 	public EasterEggPage(EasterEggPageViewModel vm)
 	{
@@ -13,9 +15,38 @@ public partial class EasterEggPage : ContentPage
 		InitializeComponent();
 
 		BindingContext = vm;
+		ViewModel = vm;
 
 		LogFilePathLabel.Text = DirectoryPathProvider.NormalLogFileDirectory.FullName;
 
 		logger.Trace("EasterEggPage Created");
+	}
+
+	private void OnLoadFromPickerClicked(object sender, EventArgs e)
+	{
+		logger.Warn("Not Implemented");
+	}
+	private void OnSaveToPickerClicked(object sender, EventArgs e)
+	{
+		logger.Trace("Not Implemented");
+	}
+
+	private async void OnReloadSavedClicked(object sender, EventArgs e)
+	{
+		logger.Trace("Executing...");
+
+		await ViewModel.LoadFromFileAsync();
+
+		logger.Info("Reload Complete");
+	}
+
+	private async void OnSaveClicked(object sender, EventArgs e)
+	{
+		logger.Trace("Executing...");
+
+		await ViewModel.SaveAsync();
+
+		logger.Info("Saved");
+		await DisplayAlert("Success!", "Successfully saved", "OK");
 	}
 }

--- a/TRViS/EasterEggPage.xaml.cs
+++ b/TRViS/EasterEggPage.xaml.cs
@@ -14,7 +14,7 @@ public partial class EasterEggPage : ContentPage
 
 		BindingContext = vm;
 
-		LogFilePathLabel.Text = MauiProgram.NormalLogFileDirectory.FullName;
+		LogFilePathLabel.Text = DirectoryPathProvider.NormalLogFileDirectory.FullName;
 
 		logger.Trace("EasterEggPage Created");
 	}

--- a/TRViS/EasterEggPage.xaml.cs
+++ b/TRViS/EasterEggPage.xaml.cs
@@ -1,4 +1,3 @@
-using TRViS.MyAppCustomizables;
 using TRViS.ViewModels;
 
 namespace TRViS;
@@ -8,14 +7,14 @@ public partial class EasterEggPage : ContentPage
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	EasterEggPageViewModel ViewModel { get; }
 
-	public EasterEggPage(EasterEggPageViewModel vm)
+	public EasterEggPage()
 	{
-		logger.Trace("EasterEggPage Creating (EasterEggPageViewModel: {0})", vm);
+		logger.Trace("EasterEggPage Creating");
 
 		InitializeComponent();
 
-		BindingContext = vm;
-		ViewModel = vm;
+		ViewModel = InstanceManager.EasterEggPageViewModel;
+		BindingContext = ViewModel;
 
 		LogFilePathLabel.Text = DirectoryPathProvider.NormalLogFileDirectory.FullName;
 

--- a/TRViS/InstanceManager.cs
+++ b/TRViS/InstanceManager.cs
@@ -1,0 +1,15 @@
+using TRViS.ViewModels;
+
+namespace TRViS;
+
+internal static class InstanceManager
+{
+	private static AppViewModel? _AppViewModel = null;
+	public static AppViewModel AppViewModel { get => _AppViewModel ??= new(); }
+
+	private static DTACMarkerViewModel? _DTACMarkerViewModel = null;
+	public static DTACMarkerViewModel DTACMarkerViewModel { get => _DTACMarkerViewModel ??= new(); }
+
+	private static EasterEggPageViewModel? _EasterEggPageViewModel = null;
+	public static EasterEggPageViewModel EasterEggPageViewModel { get => _EasterEggPageViewModel ??= new(); }
+}

--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -14,9 +14,7 @@ namespace TRViS;
 public static class MauiProgram
 {
 	static readonly string CrashLogFilePath;
-	public static readonly DirectoryInfo CrashLogFileDirectory;
 	static readonly string CrashLogFileName;
-	public static readonly DirectoryInfo NormalLogFileDirectory;
 
 	static readonly Logger logger;
 	const string logFormat = "${longdate} [${threadid:padding=3}] [${uppercase:${level:padding=-5}}] ${callsite}() ${message} ${exception:format=tostring}";
@@ -25,29 +23,17 @@ public static class MauiProgram
 	{
 		CrashLogFileName = $"{DateTime.Now:yyyyMMdd_HHmmss}.crashlog.trvis.txt";
 
-		string baseDirPath;
-		if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
-		{
-			baseDirPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-		}
-		else
-		{
-			baseDirPath = FileSystem.Current.AppDataDirectory;
-		}
+		CrashLogFilePath = Path.Combine(DirectoryPathProvider.CrashLogFileDirectory.FullName, CrashLogFileName);
 
-		CrashLogFileDirectory = new(Path.Combine(baseDirPath, "TRViS.InternalFiles", "crashlogs"));
-		CrashLogFilePath = Path.Combine(CrashLogFileDirectory.FullName, CrashLogFileName);
-
-		NormalLogFileDirectory = new(Path.Combine(baseDirPath, "TRViS.InternalFiles", "logs"));
 		logger = SetupLogger();
 	}
 
 	static Logger SetupLogger()
 	{
-		bool isNormalLogFileDirectoryExists = NormalLogFileDirectory.Exists;
+		bool isNormalLogFileDirectoryExists = DirectoryPathProvider.NormalLogFileDirectory.Exists;
 		if (!isNormalLogFileDirectoryExists)
 		{
-			NormalLogFileDirectory.Create();
+			DirectoryPathProvider.NormalLogFileDirectory.Create();
 		}
 
 #if DEBUG
@@ -61,8 +47,8 @@ public static class MauiProgram
 
 		FileTarget fileTarget = new("file")
 		{
-			FileName = Path.Combine(NormalLogFileDirectory.FullName, "logs_current.trvis.log"),
-			ArchiveFileName = Path.Combine(NormalLogFileDirectory.FullName, "logs.{#}.trvis.log"),
+			FileName = Path.Combine(DirectoryPathProvider.NormalLogFileDirectory.FullName, "logs_current.trvis.log"),
+			ArchiveFileName = Path.Combine(DirectoryPathProvider.NormalLogFileDirectory.FullName, "logs.{#}.trvis.log"),
 			ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
 			ArchiveEvery = FileArchivePeriod.Day,
 			MaxArchiveFiles = 14,
@@ -144,9 +130,9 @@ public static class MauiProgram
 
 		logger.Fatal(ex, "UnhandledException");
 
-		if (!CrashLogFileDirectory.Exists)
+		if (!DirectoryPathProvider.CrashLogFileDirectory.Exists)
 		{
-			CrashLogFileDirectory.Create();
+			DirectoryPathProvider.CrashLogFileDirectory.Create();
 		}
 
 		await File.AppendAllTextAsync(CrashLogFilePath, $"{DateTime.Now:[yyyy/MM/dd HH:mm:ss]} {ex.Message}\n{ex.StackTrace}\n---\n(InnerException: {ex.InnerException})\n\n");

--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -7,8 +7,6 @@ using NLog.Config;
 using NLog.Targets;
 using NLog.Targets.Wrappers;
 
-using TRViS.ViewModels;
-
 namespace TRViS;
 
 public static class MauiProgram
@@ -109,14 +107,6 @@ public static class MauiProgram
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 				fonts.AddFont("MaterialIcons-Regular.ttf", "MaterialIconsRegular");
 			});
-
-		builder.Services
-			.AddSingleton(typeof(AppShell))
-			.AddSingleton(typeof(SelectTrainPage))
-			.AddSingleton(typeof(EasterEggPage))
-			.AddSingleton(typeof(DTAC.ViewHost))
-			.AddSingleton(typeof(EasterEggPageViewModel))
-			.AddSingleton(typeof(AppViewModel));
 
 		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 

--- a/TRViS/MyAppCustomizables/ColorSetting.cs
+++ b/TRViS/MyAppCustomizables/ColorSetting.cs
@@ -1,0 +1,93 @@
+namespace TRViS.MyAppCustomizables;
+
+/// <summary>
+/// 色情報の設定
+/// </summary>
+/// <param name="red">赤色成分</param>
+/// <param name="green">緑色成分</param>
+/// <param name="blue">青色成分</param>
+public class ColorSetting(byte red, byte green, byte blue)
+{
+	/// <summary>
+	/// 赤色成分
+	/// </summary>
+	public byte Red { get; set; } = red;
+	/// <summary>
+	/// 緑色成分
+	/// </summary>
+	public byte Green { get; set; } = green;
+	/// <summary>
+	/// 青色成分
+	/// </summary>
+	public byte Blue { get; set; } = blue;
+
+	/// <summary>
+	/// 色情報を黒で初期化する
+	/// </summary>
+	public ColorSetting() : this(0, 0, 0) { }
+
+	/// <summary>
+	/// 色情報を指定したMAUIColorで初期化する
+	/// </summary>
+	/// <param name="color">色情報</param>
+	public ColorSetting(Color color) : this(
+		(byte)(color.Red * 255.99999),
+		(byte)(color.Green * 255.99999),
+		(byte)(color.Blue * 255.99999)
+	) { }
+
+	/// <summary>
+	/// 色情報を指定したMAUIColorに変換する
+	/// </summary>
+	/// <returns>MAUI Color</returns>
+	public Color ToColor()
+		=> new(Red, Green, Blue);
+
+	/// <summary>
+	/// 色情報をHEX文字列化する (#RRGGBB形式)
+	/// </summary>
+	/// <returns>色情報文字列</returns>
+	public override string ToString()
+	{
+		return $"#{Red:X2}{Green:X2}{Blue:X2}";
+	}
+
+	/// <summary>
+	/// 指定した色とこの色情報が等しいかどうかを判断する
+	/// </summary>
+	/// <param name="other">比較相手</param>
+	/// <returns>等しいかどうか</returns>
+	public bool Equals(ColorSetting? other)
+	{
+		if (other is null)
+			return false;
+
+		return (
+			Red == other.Red
+			&& Green == other.Green
+			&& Blue == other.Blue
+		);
+	}
+	/// <summary>
+	/// 指定した色とこの色情報が等しいかどうかを判断する
+	/// </summary>
+	/// <param name="other">比較相手</param>
+	/// <returns>等しいかどうか</returns>
+	public override bool Equals(object? obj)
+	{
+		return this.Equals(obj as ColorSetting);
+	}
+
+	/// <summary>
+	/// ハッシュコードを取得する
+	/// </summary>
+	/// <returns>HashCode</returns>
+	public override int GetHashCode()
+	{
+		return (
+			(Red << 16)
+			| (Green << 8)
+			| Blue
+		);
+	}
+}

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -159,7 +159,12 @@ public class SettingFileStructure
 		=> JsonSerializer.SerializeAsync(dst, this);
 	public Task SaveToJsonFileAsync()
 	{
-		using FileStream jsonStream = File.OpenWrite(settingFileInfo.FullName);
+		if (!settingFileInfo.Exists)
+		{
+			logger.Info("Creating setting file... (path: {0})", settingFileInfo.FullName);
+			settingFileInfo.Create();
+		}
+		using FileStream jsonStream = File.Open(settingFileInfo.FullName, FileMode.Truncate);
 		return SaveToJsonFileAsync(jsonStream);
 	}
 

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -31,6 +31,7 @@ public class SettingFileStructure
 	/// この値は、0.1 (秒) 以上である必要があります。
 	/// </remarks>
 	public double LocationServiceInterval_Seconds { get; set; } = 1;
+	public static readonly double MinimumLocationServiceIntervalValue = 0.1;
 
 	public override string ToString()
 	{

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+
+namespace TRViS.MyAppCustomizables;
+
+/// <summary>
+/// カスタマイズ設定ファイルの構造が定義されたクラスです。
+/// </summary>
+public class SettingFileStructure
+{
+	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+	/// <summary>
+	/// タイトルバーの背景色
+	/// </summary>
+	public ColorSetting TitleColor { get; set; } = new();
+
+	/// <summary>
+	/// マーカーの色一覧
+	/// </summary>
+	public Dictionary<string, ColorSetting> MarkerColors { get; set; } = new();
+
+	/// <summary>
+	/// マーカーのテキスト一覧
+	/// </summary>
+	public string[] MarkerTexts { get; set; } = Array.Empty<string>();
+
+	/// <summary>
+	/// 位置情報サービスの位置情報サービスの位置測位間隔 (秒)
+	/// </summary>
+	/// <remarks
+	/// この値は、0.1 (秒) 以上である必要があります。
+	/// </remarks>
+	public double LocationServiceInterval_Seconds { get; set; } = 1;
+
+	public override string ToString()
+	{
+		return
+			$"TitleColor: {TitleColor},"
+			+ $"MarkerColors: {MarkerColors},"
+			+ $"MarkerTexts: {MarkerTexts},"
+			+ $"LocationServiceInterval: {LocationServiceInterval_Seconds}[s]"
+		;
+	}
+
+	public bool Equals(SettingFileStructure? v)
+	{
+		if (v is null)
+			return false;
+
+		return
+			TitleColor.Equals(v.TitleColor)
+			&& MarkerColors.Equals(v.MarkerColors)
+			&& MarkerTexts.Equals(v.MarkerTexts)
+			&& LocationServiceInterval_Seconds.Equals(v.LocationServiceInterval_Seconds)
+		;
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as SettingFileStructure);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(TitleColor, MarkerColors, MarkerTexts, LocationServiceInterval_Seconds);
+
+	#region Loaders
+
+	public static readonly string SettingFileName = "MyAppCustomizables.json";
+	static readonly DirectoryInfo settingFileDirectoryInfo = DirectoryPathProvider.InternalFilesDirectory;
+	static readonly FileInfo settingFileInfo = new(Path.Combine(DirectoryPathProvider.InternalFilesDirectory.FullName, SettingFileName));
+	public static readonly string settingFileCreatedMsg = "created";
+	public static async Task<(SettingFileStructure, string?)> LoadFromJsonFileOrCreateAsync()
+	{
+		if (!settingFileDirectoryInfo.Exists)
+		{
+			logger.Info("Creating InternalFiles directory... (path: {0})", settingFileDirectoryInfo.FullName);
+			settingFileDirectoryInfo.Create();
+		}
+
+		if (!settingFileInfo.Exists)
+		{
+			logger.Info("Creating setting file... (path: {0})", settingFileInfo.FullName);
+			SettingFileStructure setting = new();
+			using FileStream jsonStream = File.Create(settingFileInfo.FullName);
+			await setting.SaveToJsonFileAsync(jsonStream);
+			return (setting, settingFileCreatedMsg);
+		}
+
+		try
+		{
+			logger.Info("Loading setting file... (path: {0})", settingFileInfo.FullName);
+			using FileStream jsonStream = File.OpenRead(settingFileInfo.FullName);
+			return await LoadFromJsonAsync(jsonStream);
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "Failed to load setting file.");
+			return (new(), "設定ファイルの読み込みに失敗しました。" + ex.Message);
+		}
+	}
+
+	public static async Task<(SettingFileStructure, string?)> LoadFromJsonAsync(Stream jsonStream)
+	{
+		SettingFileStructure? settingFileStructure;
+
+		try
+		{
+			logger.Info("Loading setting file...");
+			settingFileStructure = await JsonSerializer.DeserializeAsync<SettingFileStructure>(jsonStream);
+			logger.Trace("Loaded setting file.");
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "Failed to load setting file.");
+			return (new(), "設定ファイルの読み込みに失敗しました。" + ex.Message);
+		}
+
+		if (settingFileStructure is null)
+		{
+			logger.Warn("Failed to load setting file. (result is null)");
+			return (new(), "設定ファイルの読み込みに失敗しました。(結果がnullです)");
+		}
+
+		return (settingFileStructure, null);
+	}
+
+	public static (SettingFileStructure, string?) LoadFromJson(string jsonString)
+	{
+		SettingFileStructure? settingFileStructure;
+
+		if (string.IsNullOrWhiteSpace(jsonString))
+		{
+			logger.Warn("Empty JSON string.");
+			return (new(), "JSONファイル文字列が空です");
+		}
+
+		try
+		{
+			logger.Info("Loading setting file...");
+			settingFileStructure = JsonSerializer.Deserialize<SettingFileStructure>(jsonString);
+			logger.Trace("Loaded setting file.");
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "Failed to load setting file.");
+			return (new(), "設定ファイルの読み込みに失敗しました。" + ex.Message);
+		}
+
+		if (settingFileStructure is null)
+		{
+			logger.Warn("Failed to load setting file. (result is null)");
+			return (new(), "設定ファイルの読み込みに失敗しました。(結果がnullです)");
+		}
+
+		return (settingFileStructure, null);
+	}
+
+	public string ToJsonString()
+		=> JsonSerializer.Serialize(this);
+	public Task SaveToJsonFileAsync(Stream dst)
+		=> JsonSerializer.SerializeAsync(dst, this);
+	public Task SaveToJsonFileAsync()
+	{
+		using FileStream jsonStream = File.OpenWrite(settingFileInfo.FullName);
+		return SaveToJsonFileAsync(jsonStream);
+	}
+
+	#endregion Loaders
+}

--- a/TRViS/SelectTrainPage.xaml.cs
+++ b/TRViS/SelectTrainPage.xaml.cs
@@ -8,13 +8,13 @@ public partial class SelectTrainPage : ContentPage
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	AppViewModel viewModel { get; }
 
-	public SelectTrainPage(AppViewModel viewModel)
+	public SelectTrainPage()
 	{
 		logger.Trace("Creating (AppViewModel: {0})", viewModel);
 
 		InitializeComponent();
 
-		this.viewModel = viewModel;
+		this.viewModel = InstanceManager.AppViewModel;
 		this.BindingContext = viewModel;
 
 		viewModel.Loader ??= new SampleDataLoader();

--- a/TRViS/Services/LocationService.cs
+++ b/TRViS/Services/LocationService.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using TRViS.Controls;
+using TRViS.MyAppCustomizables;
+using TRViS.ViewModels;
 
 namespace TRViS.Services;
 
@@ -20,9 +22,6 @@ public partial class LocationService : ObservableObject, IDisposable
 
 	[ObservableProperty]
 	bool _IsEnabled;
-
-	[ObservableProperty]
-	TimeSpan _Interval;
 
 	[ObservableProperty]
 	Location? _NearbyCenter;
@@ -141,6 +140,22 @@ public partial class LocationService : ObservableObject, IDisposable
 		setIsNearby(LastLocation);
 	}
 
+	static EasterEggPageViewModel EasterEggPageViewModel { get; } = InstanceManager.EasterEggPageViewModel;
+	static double lastInterval = 1;
+	static TimeSpan lastIntervalTimeSpan = TimeSpan.FromSeconds(lastInterval);
+	static TimeSpan Interval
+	{
+		get
+		{
+			if (lastInterval == EasterEggPageViewModel.LocationServiceInterval_Seconds)
+				return lastIntervalTimeSpan;
+
+			logger.Info("Interval is changed to {0}[s]", EasterEggPageViewModel.LocationServiceInterval_Seconds);
+			lastInterval = EasterEggPageViewModel.LocationServiceInterval_Seconds;
+			lastIntervalTimeSpan = TimeSpan.FromSeconds(lastInterval);
+			return lastIntervalTimeSpan;
+		}
+	}
 	public Task StartGPS()
 	{
 		logger.Trace("Starting...");

--- a/TRViS/Utils/DirectoryPathProvider.cs
+++ b/TRViS/Utils/DirectoryPathProvider.cs
@@ -1,0 +1,26 @@
+namespace TRViS;
+
+public static class DirectoryPathProvider
+{
+  static DirectoryPathProvider()
+  {
+		string baseDirPath;
+		if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
+		{
+			baseDirPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+		}
+		else
+		{
+			baseDirPath = FileSystem.Current.AppDataDirectory;
+		}
+
+		InternalFilesDirectory = new(Path.Combine(baseDirPath, "TRViS.InternalFiles"));
+
+		CrashLogFileDirectory = new(Path.Combine(InternalFilesDirectory.FullName, "crashlogs"));
+		NormalLogFileDirectory = new(Path.Combine(InternalFilesDirectory.FullName, "logs"));
+  }
+
+	public static readonly DirectoryInfo InternalFilesDirectory;
+	public static readonly DirectoryInfo CrashLogFileDirectory;
+	public static readonly DirectoryInfo NormalLogFileDirectory;
+}

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -32,6 +32,7 @@ public partial class DTACMarkerViewModel : ObservableObject
 		"両数",
 		"規制",
 		"時変",
+		"合図",
 	};
 
 	[ObservableProperty]

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -1,9 +1,12 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using TRViS.MyAppCustomizables;
 
 namespace TRViS.ViewModels;
 
 public partial class EasterEggPageViewModel : ObservableObject
 {
+	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
 	[ObservableProperty]
 	Color _ShellBackgroundColor = Colors.Black;
 
@@ -19,26 +22,68 @@ public partial class EasterEggPageViewModel : ObservableObject
 
 	public EasterEggPageViewModel()
 	{
-		if (Preferences.Default.ContainsKey(nameof(ShellBackgroundColor)))
+		logger.Trace("EasterEggPageViewModel Creating (with Task.Run)");
+
+		Task.Run(LoadFromFileAsync);
+	}
+
+	public async Task LoadFromFileAsync()
+	{
+		logger.Info("Loading SettingFileStructure from default setting file");
+		(SettingFileStructure settingFile, string? msg) = await SettingFileStructure.LoadFromJsonFileOrCreateAsync();
+
+		await InitAsync(settingFile, msg == SettingFileStructure.settingFileCreatedMsg);
+	}
+
+	public async Task LoadFromFileAsync(string path)
+	{
+		(SettingFileStructure settingFile, string? msg) tmp;
+
+		logger.Info("Loading SettingFileStructure from setting file (path: {0})", path);
+		using (FileStream stream = File.OpenRead(path))
+		{
+			tmp = await SettingFileStructure.LoadFromJsonAsync(stream);
+		}
+
+		await InitAsync(tmp.settingFile, tmp.msg == SettingFileStructure.settingFileCreatedMsg);
+	}
+
+	async Task InitAsync(SettingFileStructure settingFile, bool isNewlyCreated)
+	{
+		logger.Debug("InitAsync (setting: {0}, isNewlyCreated: {1})", settingFile, isNewlyCreated);
+		if (isNewlyCreated && Preferences.Default.ContainsKey(nameof(ShellBackgroundColor)))
 		{
 			int value = Preferences.Default.Get<int>(nameof(ShellBackgroundColor), 0);
 
-			_ShellBackgroundColor = Color.FromInt(value);
-
-			_Color_Red = (int)(ShellBackgroundColor.Red * 255);
-			_Color_Green = (int)(ShellBackgroundColor.Green * 255);
-			_Color_Blue = (int)(ShellBackgroundColor.Blue * 255);
-
-			SetTitleTextColor();
+			logger.Info("Setting title color stored in AppPreference (value: {0:X6})", value);
+			settingFile.TitleColor = new(Color.FromInt(value));
+			await settingFile.SaveToJsonFileAsync();
 		}
+
+		ShellBackgroundColor = settingFile.TitleColor.ToColor();
+		Color_Red = settingFile.TitleColor.Red;
+		Color_Green = settingFile.TitleColor.Green;
+		Color_Blue = settingFile.TitleColor.Blue;
+
+		SetTitleTextColor();
+		logger.Trace("InitAsync Completed");
+	}
+
+	public async Task SaveAsync()
+	{
+		logger.Info("Saving setting to file...");
+		SettingFileStructure settingFile = new()
+		{
+			TitleColor = new(ShellBackgroundColor),
+		};
+
+		await settingFile.SaveToJsonFileAsync();
 	}
 
 	partial void OnShellBackgroundColorChanged(Color value)
 	{
 		if (value is not null)
 		{
-			Preferences.Default.Set<int>(nameof(ShellBackgroundColor), value.ToInt());
-
 			SetTitleTextColor();
 		}
 	}

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -60,6 +60,20 @@ public partial class EasterEggPageViewModel : ObservableObject
 			await settingFile.SaveToJsonFileAsync();
 		}
 
+		if (settingFile.LocationServiceInterval_Seconds < SettingFileStructure.MinimumLocationServiceIntervalValue)
+		{
+			logger.Warn("Setting LocationServiceInterval({0}) to default value (value: {1})", settingFile.LocationServiceInterval_Seconds, SettingFileStructure.MinimumLocationServiceIntervalValue);
+
+			// ここでは上書き保存は行わない。警告を出すのみに留める。
+			await Shell.Current.DisplayAlert(
+				"Invalid LocationServiceInterval Value",
+				$"value({settingFile.LocationServiceInterval_Seconds}) must be same or more than {SettingFileStructure.MinimumLocationServiceIntervalValue}",
+				"OK"
+			);
+
+			settingFile.LocationServiceInterval_Seconds = SettingFileStructure.MinimumLocationServiceIntervalValue;
+		}
+
 		ShellBackgroundColor = settingFile.TitleColor.ToColor();
 		Color_Red = settingFile.TitleColor.Red;
 		Color_Green = settingFile.TitleColor.Green;

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -20,7 +20,34 @@ public partial class EasterEggPageViewModel : ObservableObject
 	[ObservableProperty]
 	int _Color_Blue;
 
-	public DTACMarkerViewModel MarkerViewModel { get; }
+	[ObservableProperty]
+	double _LocationServiceInterval_Seconds = 1;
+
+	public IReadOnlyList<double> LocationServiceIntervalItems { get; } = new List<double>()
+	{
+		0.1,
+		0.2,
+		0.25,
+		0.5,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		30,
+		60,
+	};
+
+	[ObservableProperty]
+	string _LocationServiceIntervalSettingHeaderLabel = "";
+	partial void OnLocationServiceInterval_SecondsChanged(double value)
+	{
+		logger.Debug("OnLocationServiceInterval_SecondsChanged (value: {0})", value);
+		LocationServiceIntervalSettingHeaderLabel = $"Location Service Interval: {value:F2} [s]";
+	}
+
+    public DTACMarkerViewModel MarkerViewModel { get; }
 
 	public EasterEggPageViewModel()
 	{
@@ -95,6 +122,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 		Color_Red = settingFile.TitleColor.Red;
 		Color_Green = settingFile.TitleColor.Green;
 		Color_Blue = settingFile.TitleColor.Blue;
+		LocationServiceInterval_Seconds = settingFile.LocationServiceInterval_Seconds;
 
 		MarkerViewModel?.UpdateList(settingFile);
 
@@ -108,6 +136,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 		SettingFileStructure settingFile = new()
 		{
 			TitleColor = new(ShellBackgroundColor),
+			LocationServiceInterval_Seconds = LocationServiceInterval_Seconds
 		};
 
 		MarkerViewModel?.SetToSettings(settingFile);

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -20,9 +20,13 @@ public partial class EasterEggPageViewModel : ObservableObject
 	[ObservableProperty]
 	int _Color_Blue;
 
+	public DTACMarkerViewModel MarkerViewModel { get; }
+
 	public EasterEggPageViewModel()
 	{
 		logger.Trace("EasterEggPageViewModel Creating (with Task.Run)");
+
+		MarkerViewModel = InstanceManager.DTACMarkerViewModel;
 
 		Task.Run(LoadFromFileAsync);
 	}
@@ -58,6 +62,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 
 			logger.Info("Setting title color stored in AppPreference (value: {0:X6})", value);
 			settingFile.TitleColor = new(Color.FromInt(value));
+			MarkerViewModel?.SetToSettings(settingFile);
 			await settingFile.SaveToJsonFileAsync();
 		}
 
@@ -91,6 +96,8 @@ public partial class EasterEggPageViewModel : ObservableObject
 		Color_Green = settingFile.TitleColor.Green;
 		Color_Blue = settingFile.TitleColor.Blue;
 
+		MarkerViewModel?.UpdateList(settingFile);
+
 		SetTitleTextColor();
 		logger.Trace("InitAsync Completed");
 	}
@@ -102,6 +109,8 @@ public partial class EasterEggPageViewModel : ObservableObject
 		{
 			TitleColor = new(ShellBackgroundColor),
 		};
+
+		MarkerViewModel?.SetToSettings(settingFile);
 
 		await settingFile.SaveToJsonFileAsync();
 	}


### PR DESCRIPTION
マーカーの色と文字、そしてLocationServiceの測位間隔を調整できるようにした。

マーカーについては、UIの準備が面倒だったので、とりあえずJSON直打ちでの対応としている。
LocationServiceについては、0.1s未満を無効として扱ったうえで、設定ページのリストにて選択可能にしている。

## 注意点

設定ファイルが存在しない場合、新しく `TRViS.InternalFiles` ディレクトリ以下に `MyAppCustomizables.json` というファイルが作成される。

このファイルにはデフォルトの設定が含まれており、具体的には下のような構造になっている。 (下ではインデントを付けているが、実際はインデント無して出力されている。)

```json
{
  "TitleColor": {
    "Red": 0,
    "Green": 0,
    "Blue": 0
  },
  "MarkerColors": {
    "\u8D64": {
      "Red": 240,
      "Green": 64,
      "Blue": 32
    },
    "\u7DD1": {
      "Red": 64,
      "Green": 240,
      "Blue": 32
    },
    "\u9752": {
      "Red": 32,
      "Green": 64,
      "Blue": 240
    },
    "\u9EC4": {
      "Red": 240,
      "Green": 240,
      "Blue": 64
    },
    "\u8336": {
      "Red": 128,
      "Green": 64,
      "Blue": 32
    }
  },
  "MarkerTexts": [
    "",
    "\u505C\u8ECA",
    "\u5F90\u884C",
    "\u4E21\u6570",
    "\u898F\u5236",
    "\u6642\u5909",
    "\u5408\u56F3"
  ],
  "LocationServiceInterval_Seconds": 8
}
```

なお、位置情報サービス以外は入力値のバリデーションを行っていないため、変な入力を入れるとクラッシュする可能性がある。


## Setting Page

![Screenshot 2023-09-30 at 23 14 59](https://github.com/TetsuOtter/TRViS/assets/31824852/e8652936-b88e-438e-85b0-ca1436e60778)

起動時に自動で設定ファイルが読み込まれるが、それ以外のタイミングでも「Reload Saved」ボタン押下でファイルの読み込みを行うことができる。
また、現在の設定値は **自動保存されない**。 保存したい場合は、必ず「Save」ボタンを押下する必要がある。

なお、Reloadボタンではポップアップが表示されないが、「Save」ボタンでは保存成功を通知するようにしている。

本当はReloadでも表示を出すべきなんだろうけど、面倒くさくなった…