### PR TITLE
Improve performance

### DIFF
--- a/TRViS/AppShell.xaml
+++ b/TRViS/AppShell.xaml
@@ -48,7 +48,7 @@
 	<FlyoutItem Title="Privacy Policy">
 		<ShellContent>
 			<pages:ShowMarkdownPage
-				FileName="PrivacyPolicy.md"
+				FileName="PrivacyPolicy_md"
 				Title="Privacy Policy"
 			/>
 		</ShellContent>

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -1,5 +1,7 @@
 using DependencyPropertyGenerator;
+
 using TRViS.IO.Models;
+using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
@@ -28,10 +30,24 @@ public partial class VerticalStylePage : ContentView
 	public static double TimetableViewActivityIndicatorFrameMaxOpacity { get; } = 0.6;
 
 	VerticalTimetableView TimetableView { get; } = new();
+	DTACViewHostViewModel DTACViewHostViewModel { get; }
+	TrainData? CurrentShowingTrainData { get; set; }
 
 	public VerticalStylePage()
 	{
 		logger.Trace("Creating...");
+
+		DTACViewHostViewModel = InstanceManager.DTACViewHostViewModel;
+		DTACViewHostViewModel.PropertyChanged += (_, e) =>
+		{
+			switch (e.PropertyName)
+			{
+				case nameof(DTACViewHostViewModel.IsViewHostVisible):
+				case nameof(DTACViewHostViewModel.IsVerticalViewMode):
+					OnSelectedTrainDataChanged(SelectedTrainData);
+					break;
+			}
+		};
 
 		InitializeComponent();
 
@@ -121,6 +137,20 @@ public partial class VerticalStylePage : ContentView
 
 	partial void OnSelectedTrainDataChanged(TrainData? newValue)
 	{
+		if (CurrentShowingTrainData == newValue)
+		{
+			logger.Debug("CurrentShowingTrainData == newValue -> do nothing");
+			return;
+		}
+		if (!DTACViewHostViewModel.IsViewHostVisible || !DTACViewHostViewModel.IsVerticalViewMode)
+		{
+			logger.Debug("IsViewHostVisible: {0}, IsVerticalViewMode: {1} -> lazy load",
+				DTACViewHostViewModel.IsViewHostVisible,
+				DTACViewHostViewModel.IsVerticalViewMode
+			);
+			return;
+		}
+		CurrentShowingTrainData = newValue;
 		logger.Info("SelectedTrainDataChanged: {0}", newValue);
 		BindingContext = newValue;
 		TimetableView.SelectedTrainData = newValue;

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -64,6 +64,7 @@ public partial class VerticalStylePage : ContentView
 		if (DeviceInfo.Current.Idiom == DeviceIdiom.Phone || DeviceInfo.Current.Idiom == DeviceIdiom.Unknown)
 		{
 			logger.Info("Device is Phone or Unknown -> make it to fill-scrollable");
+			this.Content.VerticalOptions = LayoutOptions.Start;
 			Content = new ScrollView()
 			{
 				Content = this.Content,

--- a/TRViS/DTAC/ViewHost.xaml
+++ b/TRViS/DTAC/ViewHost.xaml
@@ -6,8 +6,7 @@
 	xmlns:viewmodels="clr-namespace:TRViS.ViewModels"
 	x:Class="TRViS.DTAC.ViewHost"
 	x:DataType="viewmodels:DTACViewHostViewModel"
-	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}"
-	Title="{Binding AppViewModel.SelectedTrainData.WorkName}">
+	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}">
 	<Grid
 		IgnoreSafeArea="True">
 		<Grid.RowDefinitions>

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -55,6 +55,11 @@ public partial class ViewHost : ContentPage
 
 		ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
+		Shell.Current.Navigated += (s, e) =>
+		{
+			ViewModel.IsViewHostVisible = Shell.Current.CurrentPage is ViewHost;
+		};
+
 		VerticalStylePageView.SetBinding(VerticalStylePage.SelectedTrainDataProperty, new Binding()
 		{
 			Source = vm,

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -50,7 +50,7 @@ public partial class ViewHost : ContentPage
 		vm.PropertyChanged += Vm_PropertyChanged;
 		eevm.PropertyChanged += Eevm_PropertyChanged;
 
-		ViewModel = new(vm);
+		ViewModel = InstanceManager.DTACViewHostViewModel;
 		BindingContext = ViewModel;
 
 		ViewModel.PropertyChanged += ViewModel_PropertyChanged;
@@ -133,6 +133,7 @@ public partial class ViewHost : ContentPage
 			string title = (sender as AppViewModel)?.SelectedWork?.Name ?? "";
 			logger.Info("SelectedWork is changed to {0}", title);
 			TitleLabel.Text = title;
+			Title = title;
 		}
 	}
 

--- a/TRViS/InstanceManager.cs
+++ b/TRViS/InstanceManager.cs
@@ -13,6 +13,9 @@ internal static class InstanceManager
 	private static DTACMarkerViewModel? _DTACMarkerViewModel = null;
 	public static DTACMarkerViewModel DTACMarkerViewModel { get => _DTACMarkerViewModel ??= new(); }
 
+	private static DTACViewHostViewModel? _DTACViewHostViewModel = null;
+	public static DTACViewHostViewModel DTACViewHostViewModel { get => _DTACViewHostViewModel ??= new(); }
+
 	private static EasterEggPageViewModel? _EasterEggPageViewModel = null;
 	public static EasterEggPageViewModel EasterEggPageViewModel { get => _EasterEggPageViewModel ??= new(); }
 }

--- a/TRViS/ResourceManager.cs
+++ b/TRViS/ResourceManager.cs
@@ -1,0 +1,50 @@
+namespace TRViS;
+
+public class ResourceManager
+{
+	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	public static ResourceManager Current { get; } = new();
+
+	public enum AssetName
+	{
+		UNKNOWN,
+		PrivacyPolicy_md,
+	}
+
+	static string ToFileName(AssetName assetName)
+		=> assetName switch
+		{
+			AssetName.PrivacyPolicy_md => "PrivacyPolicy.md",
+			_ => throw new NotImplementedException(),
+		};
+
+	readonly Dictionary<AssetName, string> Resources = new();
+
+	public async Task<string> LoadAssetAsync(AssetName assetName)
+	{
+		if (Resources.TryGetValue(assetName, out string? value))
+			return value;
+
+		string fileName = ToFileName(assetName);
+		bool isExist = await FileSystem.AppPackageFileExistsAsync(fileName);
+		if (!isExist)
+		{
+			logger.Warn("File not found: '{0}'", fileName);
+			return string.Empty;
+		}
+
+		try
+		{
+			using Stream stream = await FileSystem.OpenAppPackageFileAsync(fileName);
+			using StreamReader reader = new(stream);
+			string fileContent = await reader.ReadToEndAsync();
+			Resources[assetName] = fileContent;
+			return fileContent;
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "Open file failed: '{0}'", fileName);
+			return string.Empty;
+		}
+	}
+}

--- a/TRViS/RootPages/AppCenterSettingPage.xaml
+++ b/TRViS/RootPages/AppCenterSettingPage.xaml
@@ -36,7 +36,7 @@ TRViSでは、アプリの品質向上のため、アプリのクラッシュや
 			CornerRadius="0"
 			HasShadow="False">
 			<ctrls:SimpleMarkdownView
-				FileName="PrivacyPolicy.md"/>
+				FileName="PrivacyPolicy_md"/>
 		</Frame>
 
 		<Frame

--- a/TRViS/RootPages/ShowMarkdownPage.cs
+++ b/TRViS/RootPages/ShowMarkdownPage.cs
@@ -4,7 +4,7 @@ using TRViS.Controls;
 
 namespace TRViS.RootPages;
 
-[DependencyProperty<string>("FileName")]
+[DependencyProperty<ResourceManager.AssetName>("FileName", DefaultValue = ResourceManager.AssetName.UNKNOWN)]
 public partial class ShowMarkdownPage : ContentPage
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -21,11 +21,16 @@ public partial class ShowMarkdownPage : ContentPage
 		scrollView.Content = markdownView;
 		Content = scrollView;
 
+		NavigatedTo += (_, _) => {
+			logger.Info("NavigatedTo executing with FileName: '{0}'", FileName);
+			markdownView.FileName = FileName;
+		};
+
 		logger.Trace("Created.");
 	}
 
-	partial void OnFileNameChanged(string? oldValue, string? newValue)
+	protected override void OnAppearing()
 	{
-		markdownView.FileName = newValue;
+		base.OnAppearing();
 	}
 }

--- a/TRViS/ViewModels/DTACViewHostViewModel.cs
+++ b/TRViS/ViewModels/DTACViewHostViewModel.cs
@@ -20,6 +20,8 @@ public partial class DTACViewHostViewModel : ObservableObject
 	bool _IsHakoMode = false;
 	[ObservableProperty]
 	bool _IsWorkAffixMode = false;
+	[ObservableProperty]
+	bool _IsViewHostVisible = false;
 
 	public DTACViewHostViewModel()
 	{

--- a/TRViS/ViewModels/DTACViewHostViewModel.cs
+++ b/TRViS/ViewModels/DTACViewHostViewModel.cs
@@ -11,8 +11,6 @@ public partial class DTACViewHostViewModel : ObservableObject
 		WorkAffix
 	}
 
-	public AppViewModel AppViewModel { get; }
-
 	[ObservableProperty]
 	Mode _TabMode = Mode.VerticalView;
 
@@ -23,9 +21,8 @@ public partial class DTACViewHostViewModel : ObservableObject
 	[ObservableProperty]
 	bool _IsWorkAffixMode = false;
 
-	public DTACViewHostViewModel(AppViewModel vm)
+	public DTACViewHostViewModel()
 	{
-		AppViewModel = vm;
 	}
 
 	partial void OnTabModeChanged(Mode value)


### PR DESCRIPTION
時刻表データの描画を遅らせたり、Markdownの読み込みを遅らせたりすることで、起動時間の短縮・パフォーマンス改善を図った。

Markdownの読み込み遅延は、結構わかりやすいと思う。
時刻表データについては、一旦D-TACを表示してから再度列車を選択するとわかりやすいと思う。