### PR TITLE
「ハコ」タブを簡易実装

### DIFF
--- a/TRViS.IO/Models/DBStructure.cs
+++ b/TRViS.IO/Models/DBStructure.cs
@@ -33,7 +33,7 @@ public record WorkGroup
 }
 
 [Table("work")]
-public record Work
+public record Work : IHasRemarksProperty
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -111,7 +111,7 @@ public record StationTrack
 }
 
 [Table("train_data")]
-public record TrainData
+public record TrainData : IHasRemarksProperty
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }

--- a/TRViS.IO/Models/DBStructure.cs
+++ b/TRViS.IO/Models/DBStructure.cs
@@ -20,7 +20,7 @@ public enum StationRecordType
 }
 
 [Table("work_group")]
-public record WorkGroup
+public class WorkGroup : IEquatable<WorkGroup>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -30,10 +30,32 @@ public record WorkGroup
 
 	[Column("db_version")]
 	public int? DBVersion { get; set; } = 0;
+
+	public bool Equals(WorkGroup? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			Name == obj.Name
+			&&
+			DBVersion == obj.DBVersion
+		);
+	}
+	public override bool Equals(object? obj)
+		=> Equals(obj as WorkGroup);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(Id, Name, DBVersion);
+
+	public override string ToString()
+		=> $"WorkGroup(Id={Id}, Name={Name}, DBVersion={DBVersion})";
 }
 
 [Table("work")]
-public record Work : IHasRemarksProperty
+public class Work : IHasRemarksProperty, IEquatable<Work>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -64,10 +86,66 @@ public record Work : IHasRemarksProperty
 
 	[Column("e_train_timetable_content")]
 	public byte[]? ETrainTimetableContent { get; set; }
+
+	public bool Equals(Work? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			WorkGroupId == obj.WorkGroupId
+			&&
+			Name == obj.Name
+			&&
+			AffectDate == obj.AffectDate
+			&&
+			AffixContentType == obj.AffixContentType
+			&&
+			Utils.IsArrayEquals(AffixContent, obj.AffixContent)
+			&&
+			Remarks == obj.Remarks
+			&&
+			HasETrainTimetable == obj.HasETrainTimetable
+			&&
+			ETrainTimetableContentType == obj.ETrainTimetableContentType
+			&&
+			Utils.IsArrayEquals(ETrainTimetableContent, obj.ETrainTimetableContent)
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as Work);
+
+	public override int GetHashCode()
+	{
+		HashCode hashCode = new();
+		hashCode.Add(Id);
+		hashCode.Add(WorkGroupId);
+		hashCode.Add(Name);
+		hashCode.Add(AffectDate);
+		hashCode.Add(AffixContentType);
+		if (AffixContent is not null)
+			hashCode.AddBytes(AffixContent.AsSpan());
+		else
+			hashCode.Add(AffixContent);
+		hashCode.Add(Remarks);
+		hashCode.Add(HasETrainTimetable);
+		hashCode.Add(ETrainTimetableContentType);
+		if (AffixContent is not null)
+			hashCode.AddBytes(ETrainTimetableContent.AsSpan());
+		else
+			hashCode.Add(ETrainTimetableContent);
+		return hashCode.ToHashCode();
+	}
+
+	public override string ToString()
+		=> $"Work[{WorkGroupId} / {Id}](Name='{Name}', AffectDate={AffectDate}, AffixContentType={AffixContentType}(len:{AffixContent?.Length}), Remarks='{Remarks}', HasETrainTimetable={HasETrainTimetable}(ContentType={ETrainTimetableContentType}, len={ETrainTimetableContent?.Length}))";
 }
 
 [Table("station")]
-public record Station
+public class Station : IEquatable<Station>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -95,10 +173,57 @@ public record Station
 
 	[Column("record_type")]
 	public int? RecordType { get; set; }
+
+	public bool Equals(Station? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			WorkGroupId == obj.WorkGroupId
+			&&
+			Name == obj.Name
+			&&
+			Location == obj.Location
+			&&
+			Location_Lon_deg == obj.Location_Lon_deg
+			&&
+			Location_Lat_deg == obj.Location_Lat_deg
+			&&
+			OnStationDetectRadius_m == obj.OnStationDetectRadius_m
+			&&
+			FullName == obj.FullName
+			&&
+			RecordType == obj.RecordType
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as Station);
+
+	public override int GetHashCode()
+	{
+		HashCode hashCode = new();
+		hashCode.Add(Id);
+		hashCode.Add(WorkGroupId);
+		hashCode.Add(Name);
+		hashCode.Add(Location);
+		hashCode.Add(Location_Lon_deg);
+		hashCode.Add(Location_Lat_deg);
+		hashCode.Add(OnStationDetectRadius_m);
+		hashCode.Add(FullName);
+		hashCode.Add(RecordType);
+		return hashCode.ToHashCode();
+	}
+
+	public override string ToString()
+		=> $"Station[{WorkGroupId} / {Id}](Name='{Name}'(FullName='{FullName}', RecordType={RecordType}), Location={Location}({Location_Lon_deg}, {Location_Lat_deg}) with {OnStationDetectRadius_m}[m])";
 }
 
 [Table("station_track")]
-public record StationTrack
+public class StationTrack : IEquatable<StationTrack>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -108,10 +233,33 @@ public record StationTrack
 
 	[Column("name"), NotNull]
 	public string Name { get; set; } = "";
+
+	public bool Equals(StationTrack? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			StationId == obj.StationId
+			&&
+			Name == obj.Name
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as StationTrack);
+
+	public override int GetHashCode()
+	 => HashCode.Combine(Id, StationId, Name);
+
+	public override string ToString()
+		=> $"StationTrack[{StationId} / {Id}](Name='{Name}')";
 }
 
 [Table("train_data")]
-public record TrainData : IHasRemarksProperty
+public class TrainData : IHasRemarksProperty, IEquatable<TrainData>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -175,10 +323,93 @@ public record TrainData : IHasRemarksProperty
 
 	[Column("color_id")]
 	public int? ColorId { get; set; }
+
+	public bool Equals(TrainData? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			WorkId == obj.WorkId
+			&&
+			TrainNumber == obj.TrainNumber
+			&&
+			MaxSpeed == obj.MaxSpeed
+			&&
+			SpeedType == obj.SpeedType
+			&&
+			NominalTractiveCapacity == obj.NominalTractiveCapacity
+			&&
+			CarCount == obj.CarCount
+			&&
+			Destination == obj.Destination
+			&&
+			BeginRemarks == obj.BeginRemarks
+			&&
+			AfterRemarks == obj.AfterRemarks
+			&&
+			Remarks == obj.Remarks
+			&&
+			BeforeDeparture == obj.BeforeDeparture
+			&&
+			TrainInfo == obj.TrainInfo
+			&&
+			Direction == obj.Direction
+			&&
+			WorkType == obj.WorkType
+			&&
+			AfterArrive == obj.AfterArrive
+			&&
+			BeforeDeparture_OnStationTrackCol == obj.BeforeDeparture_OnStationTrackCol
+			&&
+			AfterArrive_OnStationTrackCol == obj.AfterArrive_OnStationTrackCol
+			&&
+			DayCount == obj.DayCount
+			&&
+			IsRideOnMoving == obj.IsRideOnMoving
+			&&
+			ColorId == obj.ColorId
+		);
+	}
+	
+	public override bool Equals(object? obj)
+		=> Equals(obj as TrainData);
+
+	public override int GetHashCode()
+	{
+		HashCode hashCode = new();
+		hashCode.Add(Id);
+		hashCode.Add(WorkId);
+		hashCode.Add(TrainNumber);
+		hashCode.Add(MaxSpeed);
+		hashCode.Add(SpeedType);
+		hashCode.Add(NominalTractiveCapacity);
+		hashCode.Add(CarCount);
+		hashCode.Add(Destination);
+		hashCode.Add(BeginRemarks);
+		hashCode.Add(AfterRemarks);
+		hashCode.Add(Remarks);
+		hashCode.Add(BeforeDeparture);
+		hashCode.Add(TrainInfo);
+		hashCode.Add(Direction);
+		hashCode.Add(WorkType);
+		hashCode.Add(AfterArrive);
+		hashCode.Add(BeforeDeparture_OnStationTrackCol);
+		hashCode.Add(AfterArrive_OnStationTrackCol);
+		hashCode.Add(DayCount);
+		hashCode.Add(IsRideOnMoving);
+		hashCode.Add(ColorId);
+		return hashCode.ToHashCode();
+	}
+
+	public override string ToString()
+		=> $"TrainData[{WorkId} / {Id}](TrainNumber='{TrainNumber}', MaxSpeed='{MaxSpeed}', SpeedType='{SpeedType}', NominalTractiveCapacity='{NominalTractiveCapacity}', CarCount={CarCount}, Destination='{Destination}', BeginRemarks='{BeginRemarks}', AfterRemarks='{AfterRemarks}', Remarks='{Remarks}', BeforeDeparture='{BeforeDeparture}', TrainInfo='{TrainInfo}', Direction={Direction}, WorkType={WorkType}, AfterArrive='{AfterArrive}', BeforeDeparture_OnStationTrackCol='{BeforeDeparture_OnStationTrackCol}', AfterArrive_OnStationTrackCol='{AfterArrive_OnStationTrackCol}', DayCount={DayCount}, IsRideOnMoving={IsRideOnMoving}, ColorId={ColorId})";
 }
 
 [Table("timetable_row")]
-public record TimetableRowData
+public class TimetableRowData : IEquatable<TimetableRowData>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -242,20 +473,133 @@ public record TimetableRowData
 
 	[Column("work_type")]
 	public int? WorkType { get; set; }
+
+	public bool Equals(TimetableRowData? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			TrainId == obj.TrainId
+			&&
+			StationId == obj.StationId
+			&&
+			DriveTime_MM == obj.DriveTime_MM
+			&&
+			DriveTime_SS == obj.DriveTime_SS
+			&&
+			IsOperationOnlyStop == obj.IsOperationOnlyStop
+			&&
+			IsPass == obj.IsPass
+			&&
+			HasBracket == obj.HasBracket
+			&&
+			IsLastStop == obj.IsLastStop
+			&&
+			Arrive_HH == obj.Arrive_HH
+			&&
+			Arrive_MM == obj.Arrive_MM
+			&&
+			Arrive_SS == obj.Arrive_SS
+			&&
+			Arrive_Str == obj.Arrive_Str
+			&&
+			Departure_HH == obj.Departure_HH
+			&&
+			Departure_MM == obj.Departure_MM
+			&&
+			Departure_SS == obj.Departure_SS
+			&&
+			Departure_Str == obj.Departure_Str
+			&&
+			StationTrackId == obj.StationTrackId
+			&&
+			RunInLimit == obj.RunInLimit
+			&&
+			RunOutLimit == obj.RunOutLimit
+			&&
+			Remarks == obj.Remarks
+			&&
+			MarkerColorId == obj.MarkerColorId
+			&&
+			MarkerText == obj.MarkerText
+			&&
+			WorkType == obj.WorkType
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as TimetableRowData);
+
+	public override int GetHashCode()
+	{
+		HashCode hashCode = new();
+		hashCode.Add(Id);
+		hashCode.Add(TrainId);
+		hashCode.Add(StationId);
+		hashCode.Add(DriveTime_MM);
+		hashCode.Add(DriveTime_SS);
+		hashCode.Add(IsOperationOnlyStop);
+		hashCode.Add(IsPass);
+		hashCode.Add(HasBracket);
+		hashCode.Add(IsLastStop);
+		hashCode.Add(Arrive_HH);
+		hashCode.Add(Arrive_MM);
+		hashCode.Add(Arrive_SS);
+		hashCode.Add(Arrive_Str);
+		hashCode.Add(Departure_HH);
+		hashCode.Add(Departure_MM);
+		hashCode.Add(Departure_SS);
+		hashCode.Add(Departure_Str);
+		hashCode.Add(StationTrackId);
+		hashCode.Add(RunInLimit);
+		hashCode.Add(RunOutLimit);
+		hashCode.Add(Remarks);
+		hashCode.Add(MarkerColorId);
+		hashCode.Add(MarkerText);
+		hashCode.Add(WorkType);
+		return hashCode.ToHashCode();
+	}
+
+	public override string ToString()
+		=> $"TimetableRowData[{TrainId} / {Id}](StationId={StationId}, DriveTime={DriveTime_MM}:{DriveTime_SS}, IsOperationOnlyStop={IsOperationOnlyStop}, IsPass={IsPass}, HasBracket={HasBracket}, IsLastStop={IsLastStop}, Arrive={Arrive_HH}:{Arrive_MM}:{Arrive_SS}({Arrive_Str}), Departure={Departure_HH}:{Departure_MM}:{Departure_SS}({Departure_Str}), StationTrackId={StationTrackId}, RunInLimit={RunInLimit}, RunOutLimit={RunOutLimit}, Remarks='{Remarks}', MarkerColorId={MarkerColorId}, MarkerText='{MarkerText}', WorkType={WorkType})";
 }
 
 [Table("language")]
-public record Language
+public class Language : IEquatable<Language>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
 
 	[Column("language_code"), NotNull, Unique]
 	public string LanguageCode { get; set; } = string.Empty;
+
+	public bool Equals(Language? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			LanguageCode == obj.LanguageCode
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as Language);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(Id, LanguageCode);
+
+	public override string ToString()
+		=> $"Language(Id={Id}, LanguageCode='{LanguageCode}')";
 }
 
 [Table("work_group_name_other_lang")]
-public record WorkGroupNameOtherLang
+public class WorkGroupNameOtherLang : IEquatable<WorkGroupNameOtherLang>
 {
 	[Column("work_group_id"), NotNull]
 	[Indexed(Name = "sqlite_autoindex_workgroupnameotherlang_1", Order = 1, Unique = true)]
@@ -267,10 +611,33 @@ public record WorkGroupNameOtherLang
 
 	[Column("name"), NotNull]
 	public string Name { get; set; } = string.Empty;
+
+	public bool Equals(WorkGroupNameOtherLang? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			WorkGroupId == obj.WorkGroupId
+			&&
+			LanguageId == obj.LanguageId
+			&&
+			Name == obj.Name
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as WorkGroupNameOtherLang);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(WorkGroupId, LanguageId, Name);
+
+	public override string ToString()
+		=> $"WorkGroupNameOtherLang[{WorkGroupId} / {LanguageId}](Name='{Name}')";
 }
 
 [Table("work_name_other_lang")]
-public record WorkNameOtherLang
+public class WorkNameOtherLang : IEquatable<WorkNameOtherLang>
 {
 	[Column("work_id"), NotNull]
 	[Indexed(Name = "sqlite_autoindex_worknameotherlang_1", Order = 1, Unique = true)]
@@ -282,10 +649,33 @@ public record WorkNameOtherLang
 
 	[Column("name"), NotNull]
 	public string Name { get; set; } = string.Empty;
+
+	public bool Equals(WorkNameOtherLang? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			WorkId == obj.WorkId
+			&&
+			LanguageId == obj.LanguageId
+			&&
+			Name == obj.Name
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as WorkNameOtherLang);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(WorkId, LanguageId, Name);
+
+	public override string ToString()
+		=> $"WorkNameOtherLang[{WorkId} / {LanguageId}](Name='{Name}')";
 }
 
 [Table("station_name_other_lang")]
-public record StationNameOtherLang
+public class StationNameOtherLang : IEquatable<StationNameOtherLang>
 {
 	[Column("station_id"), NotNull]
 	[Indexed(Name = "sqlite_autoindex_stationnameotherlang_1", Order = 1, Unique = true)]
@@ -300,10 +690,35 @@ public record StationNameOtherLang
 
 	[Column("full_name")]
 	public string? FullName { get; set; }
+
+	public bool Equals(StationNameOtherLang? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			StationId == obj.StationId
+			&&
+			LanguageId == obj.LanguageId
+			&&
+			Name == obj.Name
+			&&
+			FullName == obj.FullName
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as StationNameOtherLang);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(StationId, LanguageId, Name, FullName);
+
+	public override string ToString()
+		=> $"StationNameOtherLang[{StationId} / {LanguageId}](Name='{Name}', FullName='{FullName}')";
 }
 
 [Table("station_track_name_other_lang")]
-public record StationTrackNameOtherLang
+public class StationTrackNameOtherLang : IEquatable<StationTrackNameOtherLang>
 {
 	[Column("station_track_id"), NotNull]
 	[Indexed(Name = "sqlite_autoindex_stationtracknameotherlang_1", Order = 1, Unique = true)]
@@ -315,10 +730,33 @@ public record StationTrackNameOtherLang
 
 	[Column("name"), NotNull]
 	public string Name { get; set; } = string.Empty;
+
+	public bool Equals(StationTrackNameOtherLang? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			StationTrackId == obj.StationTrackId
+			&&
+			LanguageId == obj.LanguageId
+			&&
+			Name == obj.Name
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as StationTrackNameOtherLang);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(StationTrackId, LanguageId, Name);
+
+	public override string ToString()
+		=> $"StationTrackNameOtherLang[{StationTrackId} / {LanguageId}](Name='{Name}')";
 }
 
 [Table("color")]
-public record Color
+public class Color : IEquatable<Color>
 {
 	[PrimaryKey, AutoIncrement, Column("id"), NotNull, Unique]
 	public int Id { get; set; }
@@ -328,4 +766,27 @@ public record Color
 
 	[Column("rgb"), NotNull]
 	public int RGB { get; set; }
+
+	public bool Equals(Color? obj)
+	{
+		if (obj is null)
+			return false;
+
+		return (
+			Id == obj.Id
+			&&
+			Name == obj.Name
+			&&
+			RGB == obj.RGB
+		);
+	}
+
+	public override bool Equals(object? obj)
+		=> Equals(obj as Color);
+
+	public override int GetHashCode()
+		=> HashCode.Combine(Id, Name, RGB);
+
+	public override string ToString()
+		=> $"Color[{Id}](Name='{Name}', RGB={RGB:X6})";
 }

--- a/TRViS.IO/Utils.cs
+++ b/TRViS.IO/Utils.cs
@@ -1,0 +1,16 @@
+namespace TRViS.IO;
+
+internal static class Utils
+{
+	public static bool IsArrayEquals<T>(T[]? arr1, T[]? arr2, IEqualityComparer<T>? comparer = null)
+	{
+		if (arr1 == arr2)
+			return true;
+		else if (arr1 is null || arr2 is null)
+			return false;
+		else if (arr1.Length != arr2.Length)
+			return false;
+
+		return arr1.AsSpan().SequenceEqual(arr2.AsSpan(), comparer);
+	}
+}

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -2,6 +2,7 @@
 using System.Runtime.Versioning;
 #endif
 
+using System.Runtime.CompilerServices;
 using TRViS.RootPages;
 using TRViS.ViewModels;
 
@@ -64,6 +65,23 @@ public partial class AppShell : Shell
 			FlyoutIcon = null;
 			FlyoutBehavior = FlyoutBehavior.Disabled;
 			FlyoutIsPresented = false;
+		}
+	}
+
+	protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+	{
+		base.OnPropertyChanged(propertyName);
+
+		switch (propertyName)
+		{
+			case nameof(Width):
+				logger.Trace("Width: {0}", Width);
+				InstanceManager.AppViewModel.WindowWidth = Width;
+				break;
+			case nameof(Height):
+				logger.Trace("Height: {0}", Height);
+				InstanceManager.AppViewModel.WindowHeight = Height;
+				break;
 		}
 	}
 

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -96,7 +96,7 @@ public static class DTACElementStyles
 		v.Margin = new(4);
 		v.LineBreakMode = LineBreakMode.CharacterWrap;
 
-		v.LineHeight = DeviceInfo.Platform == DevicePlatform.Android ? 0.9 : 1;
+		v.LineHeight = DeviceInfo.Platform == DevicePlatform.Android ? 0.9 : 1.1;
 
 		return v;
 	}
@@ -119,6 +119,20 @@ public static class DTACElementStyles
 		v.FontSize = 18;
 		v.HorizontalOptions = LayoutOptions.Start;
 		v.Text = AffectDateLabelTextPrefix;
+
+		return v;
+	}
+
+	public static T HakoTabWorkInfoLabelStyle<T>() where T : Label, new()
+	{
+		T v = LabelStyle<T>();
+
+		v.Margin = new(12, 4);
+		v.LineHeight = 1.2;
+		v.FontAttributes = FontAttributes.Bold;
+		v.Text = null;
+		v.HorizontalOptions = LayoutOptions.End;
+		v.HorizontalTextAlignment = TextAlignment.End;
 
 		return v;
 	}

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -45,6 +45,8 @@ public static class DTACElementStyles
 		new(0x00, 0x33, 0x00)
 	);
 
+	public static readonly AppThemeColorBindingExtension ForegroundBlackWhite = genColor(0x00, 0xFF);
+
 	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideFrameColor = genColor(0xFF, 0xAA);
 	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideTextColor = genColor(0xFF, 0xDD);
 	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideBaseColor = genColor(0xFF, 0xDD);

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -114,9 +114,9 @@ public static class DTACElementStyles
 	{
 		T v = LabelStyle<T>();
 
-		v.Margin = new(18, 4);
-		v.LineHeight = 1.2;
-		v.FontSize = 18;
+		v.Margin = new(18, 0);
+		v.LineHeight = 1.4;
+		v.FontSize = 16;
 		v.HorizontalOptions = LayoutOptions.Start;
 		v.Text = AffectDateLabelTextPrefix;
 
@@ -125,11 +125,10 @@ public static class DTACElementStyles
 
 	public static T HakoTabWorkInfoLabelStyle<T>() where T : Label, new()
 	{
-		T v = LabelStyle<T>();
+		T v = AffectDateLabelStyle<T>();
 
-		v.Margin = new(12, 4);
-		v.LineHeight = 1.2;
 		v.FontAttributes = FontAttributes.Bold;
+		v.FontSize = DefaultTextSize;
 		v.Text = null;
 		v.HorizontalOptions = LayoutOptions.End;
 		v.HorizontalTextAlignment = TextAlignment.End;

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -62,6 +62,8 @@ public static class DTACElementStyles
 	public const string MaterialIconFontFamily = "MaterialIconsRegular";
 	public const string TimetableNumFontFamily = "Helvetica";
 
+	public const string AffectDateLabelTextPrefix = "行路施行日\n";
+
 	public static readonly Shadow DefaultShadow = new()
 	{
 		Brush = Colors.Black,
@@ -104,6 +106,19 @@ public static class DTACElementStyles
 		T v = LabelStyle<T>();
 
 		HeaderTextColor.Apply(v, Label.TextColorProperty);
+
+		return v;
+	}
+
+	public static T AffectDateLabelStyle<T>() where T : Label, new()
+	{
+		T v = LabelStyle<T>();
+
+		v.Margin = new(18, 4);
+		v.LineHeight = 1.2;
+		v.FontSize = 18;
+		v.HorizontalOptions = LayoutOptions.Start;
+		v.Text = AffectDateLabelTextPrefix;
 
 		return v;
 	}

--- a/TRViS/DTAC/Hako.xaml
+++ b/TRViS/DTAC/Hako.xaml
@@ -3,6 +3,21 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:local="clr-namespace:TRViS.DTAC"
+	xmlns:HakoParts="clr-namespace:TRViS.DTAC.HakoParts"
 	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}"
 	x:Class="TRViS.DTAC.Hako">
+	<Grid.RowDefinitions>
+		<RowDefinition Height="{x:Static local:VerticalStylePage.DATE_AND_START_BUTTON_ROW_HEIGHT}" />
+		<RowDefinition Height="80" />
+		<RowDefinition Height="*" />
+	</Grid.RowDefinitions>
+
+	<ScrollView
+		x:Name="SimpleViewScrollView"
+		Grid.Row="2"
+	>
+		<HakoParts:SimpleView
+			x:Name="SimpleView"
+		/>
+	</ScrollView>
 </Grid>

--- a/TRViS/DTAC/Hako.xaml
+++ b/TRViS/DTAC/Hako.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView
+<Grid
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:local="clr-namespace:TRViS.DTAC"
 	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}"
 	x:Class="TRViS.DTAC.Hako">
-</ContentView>
+</Grid>

--- a/TRViS/DTAC/Hako.xaml.cs
+++ b/TRViS/DTAC/Hako.xaml.cs
@@ -25,11 +25,8 @@ public partial class Hako : Grid
 	}
 	static Label GenWorkInfoLabel()
 	{
-		Label v = DTACElementStyles.AffectDateLabelStyle<Label>();
+		Label v = DTACElementStyles.HakoTabWorkInfoLabelStyle<Label>();
 
-		v.HorizontalOptions = LayoutOptions.End;
-		v.HorizontalTextAlignment = TextAlignment.End;
-		v.Text = null;
 		SetRow(v, 0);
 
 		return v;

--- a/TRViS/DTAC/Hako.xaml.cs
+++ b/TRViS/DTAC/Hako.xaml.cs
@@ -1,6 +1,6 @@
 namespace TRViS.DTAC;
 
-public partial class Hako : ContentView
+public partial class Hako : Grid
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	public Hako()

--- a/TRViS/DTAC/Hako.xaml.cs
+++ b/TRViS/DTAC/Hako.xaml.cs
@@ -1,14 +1,90 @@
+using DependencyPropertyGenerator;
+
+using TRViS.DTAC.HakoParts;
+
 namespace TRViS.DTAC;
 
+[DependencyProperty<string>("AffectDate")]
+[DependencyProperty<string>("WorkName")]
+[DependencyProperty<string>("WorkSpaceName")]
 public partial class Hako : Grid
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+	readonly HeaderView headerView = new();
+
+	readonly Label AffectDateLabel;
+	readonly Label WorkInfoLabel;
+	static Label GenAffectDateLabel()
+	{
+		Label v = DTACElementStyles.AffectDateLabelStyle<Label>();
+
+		SetRow(v, 0);
+
+		return v;
+	}
+	static Label GenWorkInfoLabel()
+	{
+		Label v = DTACElementStyles.AffectDateLabelStyle<Label>();
+
+		v.HorizontalOptions = LayoutOptions.End;
+		v.HorizontalTextAlignment = TextAlignment.End;
+		v.Text = null;
+		SetRow(v, 0);
+
+		return v;
+	}
+
 	public Hako()
 	{
 		logger.Trace("Creating...");
 
 		InitializeComponent();
 
+		Grid.SetRow(headerView, 1);
+		headerView.EdgeWidth = SimpleView.STA_NAME_TIME_COLUMN_WIDTH;
+		headerView.LeftEdgeText = Utils.InsertBetweenChars("乗務開始".AsSpan(), '\n');
+		headerView.RightEdgeText = Utils.InsertBetweenChars("乗務終了".AsSpan(), '\n');
+		Children.Add(headerView);
+
+		AffectDateLabel = GenAffectDateLabel();
+		Children.Add(AffectDateLabel);
+
+		WorkInfoLabel = GenWorkInfoLabel();
+		Children.Add(WorkInfoLabel);
+
+		SimpleView.SetBinding(
+			WidthRequestProperty,
+			new Binding()
+			{
+				Source = SimpleViewScrollView,
+				Path = nameof(headerView.Width),
+				Mode = BindingMode.OneWay,
+			}
+		);
+
 		logger.Trace("Created");
+	}
+
+	partial void OnAffectDateChanged(string? newValue)
+	{
+		logger.Info("AffectDate: {0}", newValue);
+		AffectDateLabel.Text = DTACElementStyles.AffectDateLabelTextPrefix + newValue;
+	}
+
+	partial void OnWorkNameChanged(string? newValue)
+	{
+		logger.Info("WorkName: {0}", newValue);
+		UpdateWorkInfoLabel(newValue, WorkSpaceName);
+	}
+	partial void OnWorkSpaceNameChanged(string? newValue)
+	{
+		logger.Info("WorkSpaceName: {0}", newValue);
+		UpdateWorkInfoLabel(WorkName, newValue);
+	}
+
+	void UpdateWorkInfoLabel(string? workName, string? workSpaceName)
+	{
+		WorkInfoLabel.Text = $"{workName}\n{workSpaceName}";
 	}
 }

--- a/TRViS/DTAC/HakoParts/HeaderView.cs
+++ b/TRViS/DTAC/HakoParts/HeaderView.cs
@@ -1,0 +1,70 @@
+namespace TRViS.DTAC.HakoParts;
+
+public class HeaderView : Grid
+{
+  private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+  readonly ColumnDefinition EdgeColumnDefinition = new(0);
+
+  readonly BoxView backgroundBoxView = new();
+
+  readonly Label leftEdgeLabel = DTACElementStyles.HeaderLabelStyle<Label>();
+  readonly Label rightEdgeLabel = DTACElementStyles.HeaderLabelStyle<Label>();
+
+  public HeaderView()
+  {
+    logger.Debug("Creating...");
+
+    ColumnDefinitions.Add(EdgeColumnDefinition);
+    ColumnDefinitions.Add(new(new(1, GridUnitType.Star)));
+    ColumnDefinitions.Add(EdgeColumnDefinition);
+
+    DTACElementStyles.HeaderBackgroundColor.Apply(backgroundBoxView, BoxView.ColorProperty);
+    Grid.SetColumnSpan(backgroundBoxView, 3);
+    backgroundBoxView.Shadow = new()
+    {
+      Brush = Colors.Black,
+      Offset = new(0, 1),
+      Radius = 1,
+      Opacity = 0.4f,
+    };
+    Children.Add(backgroundBoxView);
+
+    Grid.SetColumn(leftEdgeLabel, 0);
+    Children.Add(leftEdgeLabel);
+    Grid.SetColumn(rightEdgeLabel, 2);
+    Children.Add(rightEdgeLabel);
+
+    logger.Debug("Created");
+  }
+
+  public double EdgeWidth
+  {
+    get => EdgeColumnDefinition.Width.Value;
+    set
+    {
+      logger.Debug("value: {0} -> {0}", EdgeColumnDefinition.Width.Value, value);
+      EdgeColumnDefinition.Width = new(value, GridUnitType.Absolute);
+    }
+  }
+
+  public string? LeftEdgeText
+  {
+    get => leftEdgeLabel.Text;
+    set
+    {
+      logger.Debug("value: {0} -> {0}", leftEdgeLabel.Text, value);
+      leftEdgeLabel.Text = value;
+    }
+  }
+
+  public string? RightEdgeText
+  {
+    get => rightEdgeLabel.Text;
+    set
+    {
+      logger.Debug("value: {0} -> {0}", rightEdgeLabel.Text, value);
+      rightEdgeLabel.Text = value;
+    }
+  }
+}

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -173,6 +173,12 @@ public partial class SimpleRow
 		}
 	}
 
+	public bool IsSelected
+	{
+		get => SelectTrainButton.IsChecked;
+		set => SelectTrainButton.IsChecked = value;
+	}
+
 	public bool IsEnabled
 	{
 		get => SelectTrainButton.IsEnabled;

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -9,16 +9,94 @@ public partial class SimpleRow
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
+	static readonly Thickness StaNameTrainNumButtonMargin = new(0, 4);
+	static readonly Thickness TrainNumButtonPadding = new(32, 4);
+	static readonly double TimeLabelFontSize_HHMM = DTACElementStyles.LargeTextSize * 0.8;
+	static readonly double TimeLabelFontSize_SS = TimeLabelFontSize_HHMM * 0.7;
+	static readonly double TrainNumberLabelTextSize = DTACElementStyles.LargeTextSize * 0.8;
+
 	public event ValueChangedEventHandler<bool>? IsSelectedChanged;
 
-	readonly Label FromStationNameLabel = DTACElementStyles.LargeLabelStyle<Label>();
-	readonly Label FromTimeLabel = DTACElementStyles.LabelStyle<Label>();
-	readonly Label ToStationNameLabel = DTACElementStyles.LargeLabelStyle<Label>();
-	readonly Label ToTimeLabel = DTACElementStyles.LabelStyle<Label>();
+	readonly Label FromStationNameLabel;
+	readonly Label FromTimeLabel;
+	readonly Label ToStationNameLabel;
+	readonly Label ToTimeLabel;
+	static Label GenStationNameLabel(int rowIndex, int colIndex)
+	{
+		Label v = DTACElementStyles.LargeLabelStyle<Label>();
+		v.VerticalOptions = LayoutOptions.End;
+		v.HorizontalOptions = LayoutOptions.Center;
+		v.Margin = StaNameTrainNumButtonMargin;
 
-	readonly Frame SelectTrainButtonFrame = new();
+		Grid.SetRow(v, rowIndex);
+		Grid.SetColumn(v, colIndex);
+
+		return v;
+	}
+	static Label GenTimeLabel(int rowIndex, int colIndex)
+	{
+		Label v = DTACElementStyles.LabelStyle<Label>();
+		v.VerticalOptions = LayoutOptions.Center;
+		v.HorizontalOptions = LayoutOptions.Center;
+
+		Grid.SetRow(v, rowIndex);
+		Grid.SetColumn(v, colIndex);
+
+		return v;
+	}
+
+	readonly Frame SelectTrainButtonFrame;
+	static readonly Color SelectTrainButtonFrameBorderColor = new(0.6f);
+	static readonly Shadow SelectTrainButtonFrameShadow = new()
+	{
+		Brush = Colors.Black,
+		Offset = new(0, 0),
+		Radius = 4,
+		Opacity = 0.4f,
+	};
+	static Frame GenSelectTrainButtonFrame(Label TrainNumberLabel)
+	{
+		Frame v = new()
+		{
+			Margin = StaNameTrainNumButtonMargin,
+			Padding = TrainNumButtonPadding,
+			VerticalOptions = LayoutOptions.End,
+			HorizontalOptions = LayoutOptions.Center,
+			MinimumWidthRequest = 120,
+			HasShadow = true,
+			Shadow = SelectTrainButtonFrameShadow,
+			BorderColor = SelectTrainButtonFrameBorderColor,
+		};
+		DTACElementStyles.DefaultBGColor.Apply(v, Frame.BackgroundColorProperty);
+		v.Content = TrainNumberLabel;
+
+		return v;
+	}
+
 	readonly ToggleButton SelectTrainButton = new();
-	readonly Label TrainNumberLabel = DTACElementStyles.LargeLabelStyle<Label>();
+	static ToggleButton GenSelectTrainButton(Frame SelectTrainButtonFrame, EventHandler<ValueChangedEventArgs<bool>> IsSelectedChanged, int rowIndex)
+	{
+		ToggleButton v = new()
+		{
+			Content = SelectTrainButtonFrame
+		};
+
+		Grid.SetColumn(v, 1);
+		Grid.SetRow(v, rowIndex);
+
+		v.IsCheckedChanged += IsSelectedChanged;
+
+		return v;
+	}
+	readonly Label TrainNumberLabel;
+	static Label GenTrainNumberLabel()
+	{
+		Label v = DTACElementStyles.LargeLabelStyle<Label>();
+
+		v.FontSize = TrainNumberLabelTextSize;
+
+		return v;
+	}
 
 	readonly Line RouteLine = new()
 	{
@@ -26,6 +104,22 @@ public partial class SimpleRow
 		VerticalOptions = LayoutOptions.Center,
 		HorizontalOptions = LayoutOptions.Fill,
 	};
+	static Line GenRouteLine(int rowIndex)
+	{
+		Line v = new()
+		{
+			StrokeThickness = 2,
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Fill,
+		};
+
+		DTACElementStyles.ForegroundBlackWhite.Apply(v, Line.BackgroundColorProperty);
+
+		Grid.SetColumn(v, 1);
+		Grid.SetRow(v, rowIndex);
+
+		return v;
+	}
 
 	readonly Grid ParentGrid;
 
@@ -35,36 +129,27 @@ public partial class SimpleRow
 
 		ParentGrid = parentGrid;
 
-		SelectTrainButton.IsCheckedChanged += (sender, e) =>
-		{
-			IsSelectedChanged?.Invoke(this, e.OldValue, e.NewValue);
-		};
-		SelectTrainButton.Content = SelectTrainButtonFrame;
-		DTACElementStyles.DefaultBGColor.Apply(SelectTrainButtonFrame, Frame.BackgroundColorProperty);
-		SelectTrainButtonFrame.Content = TrainNumberLabel;
-
-		DTACElementStyles.ForegroundBlackWhite.Apply(RouteLine, Line.BackgroundColorProperty);
-
 		int rowIndex_StaName_SelectBtn = dataIndex * 2;
 		int rowIndex_time = rowIndex_StaName_SelectBtn + 1;
-		Grid.SetRow(FromStationNameLabel, rowIndex_StaName_SelectBtn);
-		Grid.SetRow(SelectTrainButton, rowIndex_StaName_SelectBtn);
-		Grid.SetRow(ToStationNameLabel, rowIndex_StaName_SelectBtn);
 
-		Grid.SetRow(FromTimeLabel, rowIndex_time);
-		Grid.SetRow(RouteLine, rowIndex_time);
-		Grid.SetRow(ToTimeLabel, rowIndex_time);
+		TrainNumberLabel = GenTrainNumberLabel();
+		SelectTrainButtonFrame = GenSelectTrainButtonFrame(TrainNumberLabel);
+		SelectTrainButton = GenSelectTrainButton(SelectTrainButtonFrame, (sender, e) =>
+		{
+			IsSelectedChanged?.Invoke(this, e.OldValue, e.NewValue);
+			SetTrainNumberButtonState();
+		}, rowIndex_StaName_SelectBtn);
 
-		Grid.SetColumn(FromStationNameLabel, 0);
-		Grid.SetColumn(SelectTrainButton, 1);
-		Grid.SetColumn(ToStationNameLabel, 2);
+		RouteLine = GenRouteLine(rowIndex_time);
 
-		Grid.SetColumn(FromTimeLabel, 0);
-		Grid.SetColumn(RouteLine, 1);
-		Grid.SetColumn(ToTimeLabel, 2);
+		FromStationNameLabel = GenStationNameLabel(rowIndex_StaName_SelectBtn, 0);
+		ToStationNameLabel = GenStationNameLabel(rowIndex_StaName_SelectBtn, 2);
 
-		parentGrid.Add(FromStationNameLabel);
+		FromTimeLabel = GenTimeLabel(rowIndex_time, 0);
+		ToTimeLabel = GenTimeLabel(rowIndex_time, 2);
+
 		parentGrid.Add(SelectTrainButton);
+		parentGrid.Add(FromStationNameLabel);
 		parentGrid.Add(ToStationNameLabel);
 
 		parentGrid.Add(FromTimeLabel);
@@ -72,6 +157,30 @@ public partial class SimpleRow
 		parentGrid.Add(ToTimeLabel);
 
 		logger.Debug("Created");
+	}
+
+	void SetTrainNumberButtonState()
+	{
+		if (SelectTrainButton.IsEnabled && SelectTrainButton.IsChecked)
+		{
+			DTACElementStyles.DefaultGreen.Apply(SelectTrainButtonFrame, Frame.BorderColorProperty);
+			SelectTrainButtonFrame.HasShadow = false;
+		}
+		else
+		{
+			SelectTrainButtonFrame.BorderColor = SelectTrainButtonFrameBorderColor;
+			SelectTrainButtonFrame.HasShadow = true;
+		}
+	}
+
+	public bool IsEnabled
+	{
+		get => SelectTrainButton.IsEnabled;
+		set
+		{
+			SelectTrainButton.IsEnabled = value;
+			SetTrainNumberButtonState();
+		}
 	}
 
 	public string FromStationName
@@ -87,7 +196,7 @@ public partial class SimpleRow
 	public string TrainNumber
 	{
 		get => TrainNumberLabel.Text;
-		set => TrainNumberLabel.Text = value;
+		set => TrainNumberLabel.Text = Utils.ToWide(value);
 	}
 
 	private TimeData? fromTime;
@@ -125,7 +234,7 @@ public partial class SimpleRow
 	{
 		FormattedString fs = new();
 
-		double baseTextSize = DTACElementStyles.LargeTextSize * 0.8;
+		double baseTextSize = TimeLabelFontSize_HHMM;
 		fs.Spans.Add(new(){
 			Text = $"{value.Hour:00}:{value.Minute:00}",
 			FontAttributes = FontAttributes.Bold,
@@ -133,7 +242,7 @@ public partial class SimpleRow
 		});
 		fs.Spans.Add(new(){
 			Text = value.Second?.ToString("00"),
-			FontSize = baseTextSize * 0.75,
+			FontSize = TimeLabelFontSize_SS,
 		});
 
 		return fs;

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -1,0 +1,141 @@
+using Microsoft.Maui.Controls.Shapes;
+
+using TRViS.Controls;
+using TRViS.IO.Models;
+
+namespace TRViS.DTAC.HakoParts;
+
+public partial class SimpleRow
+{
+	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+	public event ValueChangedEventHandler<bool>? IsSelectedChanged;
+
+	readonly Label FromStationNameLabel = DTACElementStyles.LargeLabelStyle<Label>();
+	readonly Label FromTimeLabel = DTACElementStyles.LabelStyle<Label>();
+	readonly Label ToStationNameLabel = DTACElementStyles.LargeLabelStyle<Label>();
+	readonly Label ToTimeLabel = DTACElementStyles.LabelStyle<Label>();
+
+	readonly Frame SelectTrainButtonFrame = new();
+	readonly ToggleButton SelectTrainButton = new();
+	readonly Label TrainNumberLabel = DTACElementStyles.LargeLabelStyle<Label>();
+
+	readonly Line RouteLine = new()
+	{
+		StrokeThickness = 1,
+		VerticalOptions = LayoutOptions.Center,
+		HorizontalOptions = LayoutOptions.Fill,
+	};
+
+	readonly Grid ParentGrid;
+
+	public SimpleRow(Grid parentGrid, int dataIndex)
+	{
+		logger.Debug("Creating");
+
+		ParentGrid = parentGrid;
+
+		SelectTrainButton.IsCheckedChanged += (sender, e) =>
+		{
+			IsSelectedChanged?.Invoke(this, e.OldValue, e.NewValue);
+		};
+		SelectTrainButton.Content = SelectTrainButtonFrame;
+		DTACElementStyles.DefaultBGColor.Apply(SelectTrainButtonFrame, Frame.BackgroundColorProperty);
+		SelectTrainButtonFrame.Content = TrainNumberLabel;
+
+		DTACElementStyles.ForegroundBlackWhite.Apply(RouteLine, Line.BackgroundColorProperty);
+
+		int rowIndex_StaName_SelectBtn = dataIndex * 2;
+		int rowIndex_time = rowIndex_StaName_SelectBtn + 1;
+		Grid.SetRow(FromStationNameLabel, rowIndex_StaName_SelectBtn);
+		Grid.SetRow(SelectTrainButton, rowIndex_StaName_SelectBtn);
+		Grid.SetRow(ToStationNameLabel, rowIndex_StaName_SelectBtn);
+
+		Grid.SetRow(FromTimeLabel, rowIndex_time);
+		Grid.SetRow(RouteLine, rowIndex_time);
+		Grid.SetRow(ToTimeLabel, rowIndex_time);
+
+		Grid.SetColumn(FromStationNameLabel, 0);
+		Grid.SetColumn(SelectTrainButton, 1);
+		Grid.SetColumn(ToStationNameLabel, 2);
+
+		Grid.SetColumn(FromTimeLabel, 0);
+		Grid.SetColumn(RouteLine, 1);
+		Grid.SetColumn(ToTimeLabel, 2);
+
+		parentGrid.Add(FromStationNameLabel);
+		parentGrid.Add(SelectTrainButton);
+		parentGrid.Add(ToStationNameLabel);
+
+		parentGrid.Add(FromTimeLabel);
+		parentGrid.Add(RouteLine);
+		parentGrid.Add(ToTimeLabel);
+
+		logger.Debug("Created");
+	}
+
+	public string FromStationName
+	{
+		get => FromStationNameLabel.Text;
+		set => FromStationNameLabel.Text = value;
+	}
+	public string ToStationName
+	{
+		get => ToStationNameLabel.Text;
+		set => ToStationNameLabel.Text = value;
+	}
+	public string TrainNumber
+	{
+		get => TrainNumberLabel.Text;
+		set => TrainNumberLabel.Text = value;
+	}
+
+	private TimeData? fromTime;
+	public TimeData? FromTime
+	{
+		get => fromTime;
+		set
+		{
+			if (value == fromTime)
+				return;
+			fromTime = value;
+			if (value is null)
+				FromTimeLabel.Text = null;
+			else
+				FromTimeLabel.FormattedText = GetTimeLabelText(value);
+		}
+	}
+	private TimeData? toTime;
+	public TimeData? ToTime
+	{
+		get => toTime;
+		set
+		{
+			if (value == toTime)
+				return;
+			toTime = value;
+			if (value is null)
+				ToTimeLabel.Text = null;
+			else
+				ToTimeLabel.FormattedText = GetTimeLabelText(value);
+		}
+	}
+
+	static FormattedString GetTimeLabelText(TimeData value)
+	{
+		FormattedString fs = new();
+
+		double baseTextSize = DTACElementStyles.LargeTextSize * 0.8;
+		fs.Spans.Add(new(){
+			Text = $"{value.Hour:00}:{value.Minute:00}",
+			FontAttributes = FontAttributes.Bold,
+			FontSize = baseTextSize,
+		});
+		fs.Spans.Add(new(){
+			Text = value.Second?.ToString("00"),
+			FontSize = baseTextSize * 0.75,
+		});
+
+		return fs;
+	}
+}

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -24,7 +24,7 @@ public class SimpleView : Grid
 		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
 		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
 
-		new SimpleRow(this, 0)
+		SimpleRow row1 = new(this, 0)
 		{
 			FromStationName = "試験1",
 			FromTime = new(12, 34, null, null),
@@ -32,7 +32,7 @@ public class SimpleView : Grid
 			ToTime = new(12, 34, 56, null),
 			TrainNumber = "試験3",
 		};
-		new SimpleRow(this, 1)
+		SimpleRow row2 = new(this, 1)
 		{
 			FromStationName = "さ新都心",
 			FromTime = new(12, 34, 56, null),
@@ -40,7 +40,7 @@ public class SimpleView : Grid
 			ToTime = new(12, 34, 56, null),
 			TrainNumber = "現回９９２３横浜",
 		};
-		new SimpleRow(this, 2)
+		SimpleRow row3 = new(this, 2)
 		{
 			FromStationName = "さ新都心",
 			FromTime = new(12, 34, 56, null),
@@ -49,6 +49,37 @@ public class SimpleView : Grid
 			TrainNumber = "入換担当\n　　現回９９２３横浜",
 		};
 
+		row1.IsSelectedChanged += OnIsSelectedChanged;
+		row2.IsSelectedChanged += OnIsSelectedChanged;
+		row3.IsSelectedChanged += OnIsSelectedChanged;
+
 		logger.Debug("Created");
+	}
+
+	void OnIsSelectedChanged(object? sender, bool oldValue, bool newValue)
+	{
+		if (sender is not SimpleRow row)
+		{
+			logger.Debug("sender is not SimpleRow");
+			return;
+		}
+
+		if (newValue == true)
+		{
+			if (SelectedRow is not null && SelectedRow != row)
+			{
+				logger.Debug("SelectedRow is not null and SelectedRow != row -> last selection ({0}) set to false", SelectedRow.TrainNumber);
+				SelectedRow.IsSelected = false;
+			}
+
+			logger.Debug("renew selection to {0}", row.TrainNumber);
+			SelectedRow = row;
+		}
+		else if (SelectedRow == row)
+		{
+			logger.Debug("SelectedRow == row ({0}) -> reset selection", SelectedRow.TrainNumber);
+			SelectedRow.IsSelected = false;
+			SelectedRow = null;
+		}
 	}
 }

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -54,6 +54,8 @@ public class SimpleView : Grid
 			logger.Debug("SelectedRow == row ({0}) -> reset selection", SelectedRow.TrainNumber);
 			SelectedRow.IsSelected = false;
 			SelectedRow = null;
+			InstanceManager.AppViewModel.SelectedDBTrainData = null;
+			InstanceManager.AppViewModel.SelectedTrainData = null;
 		}
 	}
 

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -22,13 +22,6 @@ public class SimpleView : Grid
 		ColumnDefinitions.Add(new(new(1, GridUnitType.Star)));
 		ColumnDefinitions.Add(new(new(STA_NAME_TIME_COLUMN_WIDTH, GridUnitType.Absolute)));
 
-		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
-		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
-		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
-		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
-		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
-		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
-
 		InstanceManager.AppViewModel.PropertyChanged += OnAppViewModelPropertyChanged;
 
 		OnSelectedWorkChanged(InstanceManager.AppViewModel.SelectedWork);

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -9,7 +9,7 @@ public class SimpleView : Grid
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-	const double STA_NAME_TIME_COLUMN_WIDTH = 120;
+	public const double STA_NAME_TIME_COLUMN_WIDTH = 120;
 	const double TRAIN_NUMBER_ROW_HEIGHT = 80;
 	const double TIME_ROW_HEIGHT = 20;
 	SimpleRow? SelectedRow = null;

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -68,6 +68,7 @@ public class SimpleView : Grid
 	{
 		logger.Debug("newWork: {0}", newWork?.Name ?? "null");
 		Clear();
+		SelectedRow = null;
 		if (newWork is null)
 		{
 			logger.Debug("newWork is null");
@@ -83,6 +84,7 @@ public class SimpleView : Grid
 
 		IReadOnlyList<TrainData> trainDataList = loader.GetTrainDataList(newWork.Id);
 		SetRowDefinitions(trainDataList.Count);
+		TrainData? selectedDBTrainData = InstanceManager.AppViewModel.SelectedDBTrainData;
 		for (int i = 0; i < trainDataList.Count; i++)
 		{
 			TrainData dbTrainData = trainDataList[i];
@@ -95,6 +97,12 @@ public class SimpleView : Grid
 
 			SimpleRow row = new(this, i, trainData, dbTrainData);
 			row.IsSelectedChanged += OnIsSelectedChanged;
+			if (dbTrainData == selectedDBTrainData)
+			{
+				logger.Debug("trainData == selectedTrainData ({0})", trainData.TrainNumber);
+				row.IsSelected = true;
+				SelectedRow = row;
+			}
 		}
 	}
 

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -5,7 +5,7 @@ public class SimpleView : Grid
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
 	const double STA_NAME_TIME_COLUMN_WIDTH = 120;
-	const double TRAIN_NUMBER_ROW_HEIGHT = 40;
+	const double TRAIN_NUMBER_ROW_HEIGHT = 80;
 	const double TIME_ROW_HEIGHT = 20;
 	SimpleRow? SelectedRow = null;
 

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -1,0 +1,44 @@
+namespace TRViS.DTAC.HakoParts;
+
+public class SimpleView : Grid
+{
+	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+	const double STA_NAME_TIME_COLUMN_WIDTH = 120;
+	const double TRAIN_NUMBER_ROW_HEIGHT = 40;
+	const double TIME_ROW_HEIGHT = 20;
+	SimpleRow? SelectedRow = null;
+
+	public SimpleView()
+	{
+		logger.Debug("Creating...");
+		
+		ColumnDefinitions.Add(new(new(STA_NAME_TIME_COLUMN_WIDTH, GridUnitType.Absolute)));
+		ColumnDefinitions.Add(new(new(1, GridUnitType.Star)));
+		ColumnDefinitions.Add(new(new(STA_NAME_TIME_COLUMN_WIDTH, GridUnitType.Absolute)));
+
+		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
+		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
+		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
+		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
+
+		new SimpleRow(this, 0)
+		{
+			FromStationName = "試験1",
+			FromTime = new(12, 34, null, null),
+			ToStationName = "試験2",
+			ToTime = new(12, 34, 56, null),
+			TrainNumber = "試験3",
+		};
+		new SimpleRow(this, 1)
+		{
+			FromStationName = "さ新都心",
+			FromTime = new(12, 34, 56, null),
+			ToStationName = "長い駅名",
+			ToTime = new(12, 34, 56, null),
+			TrainNumber = "現回９９２３横浜",
+		};
+
+		logger.Debug("Created");
+	}
+}

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -1,3 +1,8 @@
+using System.ComponentModel;
+
+using TRViS.IO;
+using TRViS.IO.Models.DB;
+
 namespace TRViS.DTAC.HakoParts;
 
 public class SimpleView : Grid
@@ -12,7 +17,7 @@ public class SimpleView : Grid
 	public SimpleView()
 	{
 		logger.Debug("Creating...");
-		
+
 		ColumnDefinitions.Add(new(new(STA_NAME_TIME_COLUMN_WIDTH, GridUnitType.Absolute)));
 		ColumnDefinitions.Add(new(new(1, GridUnitType.Star)));
 		ColumnDefinitions.Add(new(new(STA_NAME_TIME_COLUMN_WIDTH, GridUnitType.Absolute)));
@@ -24,34 +29,9 @@ public class SimpleView : Grid
 		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
 		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
 
-		SimpleRow row1 = new(this, 0)
-		{
-			FromStationName = "試験1",
-			FromTime = new(12, 34, null, null),
-			ToStationName = "試験2",
-			ToTime = new(12, 34, 56, null),
-			TrainNumber = "試験3",
-		};
-		SimpleRow row2 = new(this, 1)
-		{
-			FromStationName = "さ新都心",
-			FromTime = new(12, 34, 56, null),
-			ToStationName = "長い駅名",
-			ToTime = new(12, 34, 56, null),
-			TrainNumber = "現回９９２３横浜",
-		};
-		SimpleRow row3 = new(this, 2)
-		{
-			FromStationName = "さ新都心",
-			FromTime = new(12, 34, 56, null),
-			ToStationName = "長い駅名",
-			ToTime = new(12, 34, 56, null),
-			TrainNumber = "入換担当\n　　現回９９２３横浜",
-		};
+		InstanceManager.AppViewModel.PropertyChanged += OnAppViewModelPropertyChanged;
 
-		row1.IsSelectedChanged += OnIsSelectedChanged;
-		row2.IsSelectedChanged += OnIsSelectedChanged;
-		row3.IsSelectedChanged += OnIsSelectedChanged;
+		OnSelectedWorkChanged(InstanceManager.AppViewModel.SelectedWork);
 
 		logger.Debug("Created");
 	}
@@ -74,12 +54,75 @@ public class SimpleView : Grid
 
 			logger.Debug("renew selection to {0}", row.TrainNumber);
 			SelectedRow = row;
+			InstanceManager.AppViewModel.SelectedTrainData = row.TrainData;
 		}
 		else if (SelectedRow == row)
 		{
 			logger.Debug("SelectedRow == row ({0}) -> reset selection", SelectedRow.TrainNumber);
 			SelectedRow.IsSelected = false;
 			SelectedRow = null;
+		}
+	}
+
+	void OnAppViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName == nameof(InstanceManager.AppViewModel.SelectedWork))
+		{
+			OnSelectedWorkChanged(InstanceManager.AppViewModel.SelectedWork);
+		}
+	}
+	void OnSelectedWorkChanged(Work? newWork)
+	{
+		logger.Debug("newWork: {0}", newWork?.Name ?? "null");
+		Clear();
+		if (newWork is null)
+		{
+			logger.Debug("newWork is null");
+			return;
+		}
+
+		ILoader? loader = InstanceManager.AppViewModel.Loader;
+		if (loader is null)
+		{
+			logger.Debug("loader is null");
+			return;
+		}
+
+		IReadOnlyList<TrainData> trainDataList = loader.GetTrainDataList(newWork.Id);
+		SetRowDefinitions(trainDataList.Count);
+		for (int i = 0; i < trainDataList.Count; i++)
+		{
+			TrainData dbTrainData = trainDataList[i];
+			IO.Models.TrainData? trainData = loader.GetTrainData(dbTrainData.Id);
+			if (trainData is null)
+			{
+				logger.Debug("trainData is null");
+				continue;
+			}
+
+			SimpleRow row = new(this, i, trainData, dbTrainData);
+			row.IsSelectedChanged += OnIsSelectedChanged;
+		}
+	}
+
+	void SetRowDefinitions(int workCount)
+	{
+		int currentWorkCount = RowDefinitions.Count / 2;
+		if (currentWorkCount == workCount)
+		{
+			logger.Debug("currentWorkCount == workCount ({0})", workCount);
+			return;
+		}
+
+		for (int i = currentWorkCount; i < workCount; i++)
+		{
+			RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
+			RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
+		}
+		for (int i = currentWorkCount - 1; workCount <= i; i--)
+		{
+			RowDefinitions.RemoveAt(i * 2);
+			RowDefinitions.RemoveAt(i * 2);
 		}
 	}
 }

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -10,7 +10,7 @@ public class SimpleView : Grid
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
 	public const double STA_NAME_TIME_COLUMN_WIDTH = 120;
-	const double TRAIN_NUMBER_ROW_HEIGHT = 80;
+	const double TRAIN_NUMBER_ROW_HEIGHT = 72;
 	const double TIME_ROW_HEIGHT = 20;
 	SimpleRow? SelectedRow = null;
 

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -21,6 +21,8 @@ public class SimpleView : Grid
 		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
 		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
 		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
+		RowDefinitions.Add(new(new(TRAIN_NUMBER_ROW_HEIGHT, GridUnitType.Absolute)));
+		RowDefinitions.Add(new(new(TIME_ROW_HEIGHT, GridUnitType.Absolute)));
 
 		new SimpleRow(this, 0)
 		{
@@ -37,6 +39,14 @@ public class SimpleView : Grid
 			ToStationName = "長い駅名",
 			ToTime = new(12, 34, 56, null),
 			TrainNumber = "現回９９２３横浜",
+		};
+		new SimpleRow(this, 2)
+		{
+			FromStationName = "さ新都心",
+			FromTime = new(12, 34, 56, null),
+			ToStationName = "長い駅名",
+			ToTime = new(12, 34, 56, null),
+			TrainNumber = "入換担当\n　　現回９９２３横浜",
 		};
 
 		logger.Debug("Created");

--- a/TRViS/DTAC/PageHeader.cs
+++ b/TRViS/DTAC/PageHeader.cs
@@ -19,9 +19,8 @@ public partial class PageHeader : Grid
 	};
 
 	#region Affect Date Label
-	const string AffectDateLabelTextPrefix = "行路施行日\n";
 
-	readonly Label AffectDateLabel = DTACElementStyles.LabelStyle<Label>();
+	readonly Label AffectDateLabel = DTACElementStyles.AffectDateLabelStyle<Label>();
 
 	string _AffectDateLabelText = "";
 	public string AffectDateLabelText
@@ -37,7 +36,7 @@ public partial class PageHeader : Grid
 
 			_AffectDateLabelText = value;
 
-			AffectDateLabel.Text = AffectDateLabelTextPrefix + value;
+			AffectDateLabel.Text = DTACElementStyles.AffectDateLabelTextPrefix + value;
 			logger.Info("AffectDateLabelText: {0}", value);
 		}
 	}
@@ -113,11 +112,6 @@ public partial class PageHeader : Grid
 		logger.Trace("Creating...");
 
 		ColumnDefinitions = DefaultColumnDefinitions;
-
-		AffectDateLabel.Margin = new(18, 4);
-		AffectDateLabel.FontSize = 18;
-		AffectDateLabel.HorizontalOptions = LayoutOptions.Start;
-		AffectDateLabel.Text = AffectDateLabelTextPrefix;
 
 		StartEndRunButton.VerticalOptions = LayoutOptions.Center;
 		StartEndRunButton.HorizontalOptions = LayoutOptions.End;

--- a/TRViS/DTAC/Remarks.xaml
+++ b/TRViS/DTAC/Remarks.xaml
@@ -34,6 +34,7 @@
 		TextColor="White"/>
 
 	<local:OpenCloseButton
+		x:Name="OpenCloseButton"
 		Grid.Row="0"
 		TextWhenOpen="&#xe5cf;"
 		TextWhenClosed="&#xe5ce;"

--- a/TRViS/DTAC/Remarks.xaml.cs
+++ b/TRViS/DTAC/Remarks.xaml.cs
@@ -3,7 +3,7 @@ using TRViS.IO.Models;
 
 namespace TRViS.DTAC;
 
-[DependencyProperty<bool>("IsOpen", DefaultBindingMode = DefaultBindingMode.TwoWay, IsReadOnly = true)]
+[DependencyProperty<bool>("IsOpen", DefaultBindingMode = DefaultBindingMode.TwoWay)]
 [DependencyProperty<IHasRemarksProperty>("RemarksData", DefaultBindingMode = DefaultBindingMode.TwoWay)]
 [DependencyProperty<GridLength>("ContentAreaHeight", IsReadOnly = true)]
 [DependencyProperty<double>("BottomSafeAreaHeight")]
@@ -32,6 +32,7 @@ public partial class Remarks : Grid
 	partial void OnIsOpenChanged(bool newValue)
 	{
 		logger.Info("IsOpen: {0}, BottomMargin: {1}", newValue, BottomMargin);
+		OpenCloseButton.IsOpen = newValue;
 		this.TranslateTo(0, newValue ? BottomMargin : 0, easing: Easing.SinInOut);
 	}
 

--- a/TRViS/DTAC/TabButton.xaml.cs
+++ b/TRViS/DTAC/TabButton.xaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using DependencyPropertyGenerator;
 using TRViS.ViewModels;
 
@@ -12,6 +13,8 @@ public partial class TabButton : ContentView
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	public static readonly Color BASE_COLOR_DISABLED = new(0xDD, 0xDD, 0xDD);
 
+	public static readonly double NORMAL_MODE_WIDTH = 152;
+
 	public TabButton()
 	{
 		logger.Trace("Creating...");
@@ -21,7 +24,28 @@ public partial class TabButton : ContentView
 		UpdateIsSelectedProperty();
 		DTACElementStyles.TimetableTextColor.Apply(ButtonLabel, Label.TextColorProperty);
 
+		InstanceManager.AppViewModel.PropertyChanged += AppViewModel_PropertyChanged;
+		OnWindowWidthChanged(InstanceManager.AppViewModel.WindowWidth);
+
 		logger.Trace("Created");
+	}
+
+	private void AppViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		switch (e.PropertyName)
+		{
+			case nameof(AppViewModel.WindowWidth):
+				OnWindowWidthChanged(InstanceManager.AppViewModel.WindowWidth);
+				break;
+		}
+	}
+	void OnWindowWidthChanged(double newValue)
+	{
+		logger.Trace("newValue: {0}", newValue);
+
+		int tabButtonCount = 3;
+		double calcedMaxWidth = (newValue - 8) / tabButtonCount;
+		WidthRequest = Math.Min(calcedMaxWidth, NORMAL_MODE_WIDTH);
 	}
 
 	partial void OnCurrentModeChanged()

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -10,7 +10,7 @@ namespace TRViS.DTAC;
 public partial class VerticalStylePage : ContentView
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-	public const double DATE_AND_START_BUTTON_ROW_HEIGHT = 64;
+	public const double DATE_AND_START_BUTTON_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT = DTACElementStyles.BeforeDeparture_AfterArrive_Height * 2;

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -131,11 +131,6 @@ public partial class VerticalStylePage : ContentView
 
 		int dayCount = newValue?.DayCount ?? 0;
 		this.IsNextDayLabel.IsVisible = dayCount > 0;
-		AffectDate = (
-			newValue?.AffectDate
-			?? DateOnly.FromDateTime(DateTime.Now).AddDays(-dayCount)
-		).ToString("yyyy年M月d日");
-		logger.Debug("date: {0}, dayCount: {1}, AffectDate: {2}", newValue?.AffectDate, dayCount, AffectDate);
 	}
 
 	partial void OnAffectDateChanged(string? newValue)

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -8,7 +8,7 @@ namespace TRViS.DTAC;
 public partial class VerticalStylePage : ContentView
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-	const double DATE_AND_START_BUTTON_ROW_HEIGHT = 60;
+	public const double DATE_AND_START_BUTTON_ROW_HEIGHT = 64;
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT = DTACElementStyles.BeforeDeparture_AfterArrive_Height * 2;

--- a/TRViS/DTAC/ViewHost.xaml
+++ b/TRViS/DTAC/ViewHost.xaml
@@ -66,10 +66,13 @@
 				TargetMode="WorkAffix"/>
 		</HorizontalStackLayout>
 
-		<local:Hako
-			x:Name="HakoView"
+		<local:WithRemarksView
+			x:Name="HakoRemarksView"
 			IsVisible="False"
-			Grid.Row="2"/>
+			Grid.Row="2">
+			<local:Hako
+				x:Name="HakoView"/>
+		</local:WithRemarksView>
 
 		<local:WorkAffix
 			x:Name="WorkAffixView"

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using TRViS.IO.Models;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
@@ -77,6 +78,10 @@ public partial class ViewHost : ContentPage
 
 		DTACElementStyles.DefaultBGColor.Apply(this, BackgroundColorProperty);
 
+		OnSelectedWorkGroupChanged(vm.SelectedWorkGroup);
+		OnSelectedWorkChanged(vm.SelectedWork);
+		OnSelectedTrainChanged(vm.SelectedTrainData);
+
 		logger.Trace("Created");
 	}
 
@@ -133,6 +138,10 @@ public partial class ViewHost : ContentPage
 
 		switch (e.PropertyName)
 		{
+			case nameof(AppViewModel.SelectedWorkGroup):
+				OnSelectedWorkGroupChanged(vm.SelectedWorkGroup);
+				break;
+
 			case nameof(AppViewModel.SelectedWork):
 				OnSelectedWorkChanged(vm.SelectedWork);
 				break;
@@ -143,11 +152,20 @@ public partial class ViewHost : ContentPage
 		}
 	}
 
+	void OnSelectedWorkGroupChanged(IO.Models.DB.WorkGroup? newValue)
+	{
+		string title = newValue?.Name ?? string.Empty;
+		logger.Info("SelectedWorkGroup is changed to {0}", title);
+		HakoView.WorkSpaceName = title;
+	}
+
 	void OnSelectedWorkChanged(IO.Models.DB.Work? newValue)
 	{
 		string title = newValue?.Name ?? string.Empty;
 		logger.Info("SelectedWork is changed to {0}", title);
 		TitleLabel.Text = title;
+
+		HakoView.WorkName = title;
 	}
 
 	void OnSelectedTrainChanged(TrainData? newValue)
@@ -166,6 +184,7 @@ public partial class ViewHost : ContentPage
 		);
 
 		VerticalStylePageView.AffectDate = affectDate;
+		HakoView.AffectDate = affectDate;
 	}
 
 	private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -67,6 +67,11 @@ public partial class ViewHost : ContentPage
 			Path = nameof(AppViewModel.SelectedTrainData)
 		});
 
+		HakoRemarksView.SetBinding(WithRemarksView.RemarksDataProperty, new Binding()
+		{
+			Source = vm,
+			Path = nameof(AppViewModel.SelectedWork)
+		});
 		VerticalStylePageRemarksView.SetBinding(WithRemarksView.RemarksDataProperty, new Binding()
 		{
 			Source = vm,
@@ -207,7 +212,7 @@ public partial class ViewHost : ContentPage
 			ViewModel.IsVerticalViewMode,
 			ViewModel.IsWorkAffixMode
 		);
-		HakoView.IsVisible = ViewModel.IsHakoMode;
+		HakoRemarksView.IsVisible = ViewModel.IsHakoMode;
 		VerticalStylePageRemarksView.IsVisible = ViewModel.IsVerticalViewMode;
 		WorkAffixView.IsVisible = ViewModel.IsWorkAffixMode;
 	}

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -128,12 +128,22 @@ public partial class ViewHost : ContentPage
 
 	private void Vm_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		if (e.PropertyName == nameof(AppViewModel.SelectedWork))
+		if (sender is not AppViewModel vm)
+			return;
+
+		switch (e.PropertyName)
 		{
-			string title = (sender as AppViewModel)?.SelectedWork?.Name ?? "";
-			logger.Info("SelectedWork is changed to {0}", title);
-			TitleLabel.Text = title;
+			case nameof(AppViewModel.SelectedWork):
+				OnSelectedWorkChanged(vm.SelectedWork);
+				break;
 		}
+	}
+
+	void OnSelectedWorkChanged(IO.Models.DB.Work? newValue)
+	{
+		string title = newValue?.Name ?? string.Empty;
+		logger.Info("SelectedWork is changed to {0}", title);
+		TitleLabel.Text = title;
 	}
 
 	private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -136,6 +136,10 @@ public partial class ViewHost : ContentPage
 			case nameof(AppViewModel.SelectedWork):
 				OnSelectedWorkChanged(vm.SelectedWork);
 				break;
+
+			case nameof(AppViewModel.SelectedTrainData):
+				OnSelectedTrainChanged(vm.SelectedTrainData);
+				break;
 		}
 	}
 
@@ -144,6 +148,24 @@ public partial class ViewHost : ContentPage
 		string title = newValue?.Name ?? string.Empty;
 		logger.Info("SelectedWork is changed to {0}", title);
 		TitleLabel.Text = title;
+	}
+
+	void OnSelectedTrainChanged(TrainData? newValue)
+	{
+		int dayCount = newValue?.DayCount ?? 0;
+		string affectDate = (
+			newValue?.AffectDate
+			?? DateOnly.FromDateTime(DateTime.Now).AddDays(-dayCount)
+		).ToString("yyyy年M月d日");
+
+		logger.Debug(
+			"date: {0}, dayCount: {1}, AffectDate: {2}",
+			newValue?.AffectDate,
+			dayCount,
+			affectDate
+		);
+
+		VerticalStylePageView.AffectDate = affectDate;
 	}
 
 	private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -215,5 +215,14 @@ public partial class ViewHost : ContentPage
 		HakoRemarksView.IsVisible = ViewModel.IsHakoMode;
 		VerticalStylePageRemarksView.IsVisible = ViewModel.IsVerticalViewMode;
 		WorkAffixView.IsVisible = ViewModel.IsWorkAffixMode;
+
+		if (!ViewModel.IsHakoMode && HakoRemarksView.IsOpen)
+		{
+			HakoRemarksView.IsOpen = false;
+		}
+		if (!ViewModel.IsVerticalViewMode && VerticalStylePageRemarksView.IsOpen)
+		{
+			VerticalStylePageRemarksView.IsOpen = false;
+		}
 	}
 }

--- a/TRViS/DTAC/WithRemarksView.cs
+++ b/TRViS/DTAC/WithRemarksView.cs
@@ -19,6 +19,12 @@ public partial class WithRemarksView : Grid
 	};
 #endif
 
+	public bool IsOpen
+	{
+		get => RemarksView.IsOpen;
+		set => RemarksView.IsOpen = value;
+	}
+
 	public WithRemarksView()
 	{
 		logger.Trace("Creating...");

--- a/TRViS/Utils/CharUtils.cs
+++ b/TRViS/Utils/CharUtils.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace TRViS;
 
 public static partial class Utils
@@ -30,4 +32,38 @@ public static partial class Utils
 
 	static public string ToWide(string s)
 		=> new string(s.Select(ToWide).ToArray());
+
+	static public string InsertBetweenChars(ReadOnlySpan<char> chars, string toInsert)
+	{
+		StringBuilder builder = new(chars.Length + toInsert.Length * (chars.Length - 1));
+
+		foreach (char v in chars)
+		{
+			if (builder.Length != 0)
+			{
+				builder.Append(toInsert);
+			}
+
+			builder.Append(v);
+		}
+
+		return builder.ToString();
+	}
+
+	static public string InsertBetweenChars(ReadOnlySpan<char> chars, char toInsert)
+	{
+		StringBuilder builder = new(chars.Length + (chars.Length - 1));
+
+		foreach (char v in chars)
+		{
+			if (builder.Length != 0)
+			{
+				builder.Append(toInsert);
+			}
+
+			builder.Append(v);
+		}
+
+		return builder.ToString();
+	}
 }

--- a/TRViS/Utils/SampleDataLoader.cs
+++ b/TRViS/Utils/SampleDataLoader.cs
@@ -18,7 +18,7 @@ public class SampleDataLoader : TRViS.IO.ILoader
 
 	static readonly List<Work> WorkList = new()
 	{
-		new(){ Id = WORK_1_1, Name = "Work1-1" },
+		new(){ Id = WORK_1_1, Name = "Work1-1", Remarks = "Sample Work Remarks\nLine 2\nLine 3" },
 	};
 
 	static readonly List<IO.Models.DB.TrainData> TrainDataList = new()

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -31,6 +31,12 @@ public partial class AppViewModel : ObservableObject
 	[ObservableProperty]
 	TrainData? _SelectedTrainData;
 
+	[ObservableProperty]
+	double _WindowHeight;
+
+	[ObservableProperty]
+	double _WindowWidth;
+
 	public event EventHandler<ValueChangedEventArgs<AppTheme>>? CurrentAppThemeChanged;
 	AppTheme _SystemAppTheme;
 	AppTheme _CurrentAppTheme;

--- a/TRViS/ViewModels/DTACViewHostViewModel.cs
+++ b/TRViS/ViewModels/DTACViewHostViewModel.cs
@@ -14,12 +14,12 @@ public partial class DTACViewHostViewModel : ObservableObject
 	public AppViewModel AppViewModel { get; }
 
 	[ObservableProperty]
-	Mode _TabMode = Mode.VerticalView;
+	Mode _TabMode = Mode.Hako;
 
 	[ObservableProperty]
-	bool _IsVerticalViewMode = true;
+	bool _IsVerticalViewMode = false;
 	[ObservableProperty]
-	bool _IsHakoMode = false;
+	bool _IsHakoMode = true;
 	[ObservableProperty]
 	bool _IsWorkAffixMode = false;
 


### PR DESCRIPTION
ハコタブを簡易的ながら実装した。
本物はちゃんと「ハコ」を表示するものの、そこまで実装するのは少し面倒なので、今回は相鉄11000の行路選択画面のような形で実装を行った。

↓SO11k 行路選択画面
![image](https://github.com/TetsuOtter/TRViS/assets/31824852/e607be1b-aa86-4fde-bc8e-01974250f850)

![Screenshot 2023-11-10 at 1 22 32](https://github.com/TetsuOtter/TRViS/assets/31824852/cde44954-9439-421a-8323-8fc79adf79c2)
