### PR TITLE
マーカー選択Popupに閉じるボタンを追加

### DIFF
--- a/TRViS/DTAC/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml
@@ -9,55 +9,69 @@
 	x:DataType="vm:DTACMarkerViewModel"
 	VerticalOptions="Center"
 	HorizontalOptions="End"
-	Size="240,240">
-	<HorizontalStackLayout
-		Padding="8"
-		HorizontalOptions="Center">
-		<Frame
-			Margin="4"
-			Padding="16"
-			WidthRequest="80">
-			<ListView
-				SelectionMode="Single"
-				SeparatorVisibility="Default"
-				ios:ListView.SeparatorStyle="FullWidth"
-				ItemsSource="{Binding ColorList, Mode=OneTime}"
-				SelectedItem="{Binding SelectedMarkerInfo, Mode=TwoWay}">
-				<ListView.ItemTemplate>
-					<DataTemplate>
-						<ViewCell
-							x:DataType="vm:MarkerInfo">
-							<ContentView>
-								<Frame
-									HeightRequest="32"
-									WidthRequest="32"
-									VerticalOptions="Center"
-									HorizontalOptions="Center"
-									BackgroundColor="{Binding Color}">
-									<Label
-										Text="{Binding Name}"
-										TextColor="Black"
-										Background="#AFFF"
-										HorizontalOptions="Center"
-										VerticalOptions="Center"/>
-								</Frame>
-							</ContentView>
-						</ViewCell>
-					</DataTemplate>
-				</ListView.ItemTemplate>
-			</ListView>
-		</Frame>
+	Size="240,360">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="*"/>
+		</Grid.RowDefinitions>
 
-		<Frame
-			Margin="4"
-			Padding="16"
-			WidthRequest="128">
-			<ListView
-				SelectionMode="Single"
-				SeparatorVisibility="Default"
-				ios:ListView.SeparatorStyle="FullWidth"
-				ItemsSource="{Binding TextList, Mode=OneTime}"
-				SelectedItem="{Binding SelectedText, Mode=TwoWay}"/>
-		</Frame>
-	</HorizontalStackLayout>
+		<Button
+			Grid.Row="0"
+			Margin="0,8,8,0"
+			Text="Close"
+			HorizontalOptions="End"
+			Clicked="OnCloseButtonClicked"/>
+		<HorizontalStackLayout
+			Grid.Row="1"
+			Padding="8"
+			HorizontalOptions="Center">
+			<Frame
+				Margin="4"
+				Padding="16"
+				WidthRequest="80">
+				<ListView
+					SelectionMode="Single"
+					SeparatorVisibility="Default"
+					ios:ListView.SeparatorStyle="FullWidth"
+					ItemsSource="{Binding ColorList, Mode=OneTime}"
+					SelectedItem="{Binding SelectedMarkerInfo, Mode=TwoWay}">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+							<ViewCell
+								x:DataType="vm:MarkerInfo">
+								<ContentView>
+									<Frame
+										HeightRequest="32"
+										WidthRequest="32"
+										VerticalOptions="Center"
+										HorizontalOptions="Center"
+										BackgroundColor="{Binding Color}">
+										<Label
+											Text="{Binding Name}"
+											TextColor="Black"
+											Background="#AFFF"
+											HorizontalOptions="Center"
+											VerticalOptions="Center"/>
+									</Frame>
+								</ContentView>
+							</ViewCell>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+			</Frame>
+
+			<Frame
+				Margin="4"
+				Padding="16"
+				WidthRequest="128">
+				<ListView
+					SelectionMode="Single"
+					SeparatorVisibility="Default"
+					ios:ListView.SeparatorStyle="FullWidth"
+					ItemsSource="{Binding TextList, Mode=OneTime}"
+					SelectedItem="{Binding SelectedText, Mode=TwoWay}"/>
+			</Frame>
+		</HorizontalStackLayout>
+	</Grid>
 </xct:Popup>

--- a/TRViS/DTAC/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml.cs
@@ -18,4 +18,13 @@ public partial class SelectMarkerPopup : Popup
 
 		logger.Trace("Created");
 	}
+
+	async void OnCloseButtonClicked(object sender, EventArgs e)
+	{
+		logger.Trace("Closing...");
+
+		await CloseAsync();
+
+		logger.Trace("Closed");
+	}
 }


### PR DESCRIPTION
iOSデバイスでは、ポップアップが全画面で表示されてしまい、閉じる方法が無い。

そこで、閉じるボタンを追加してマーカーを閉じれるようにした。

<img width="270" alt="Screenshot 2023-11-24 at 10 52 11" src="https://github.com/TetsuOtter/TRViS/assets/31824852/1a51f010-0380-4db2-9cc8-0362f1c04088">

![Screenshot 2023-11-24 at 10 52 29](https://github.com/TetsuOtter/TRViS/assets/31824852/7dcde628-c5b3-406b-98e7-6f51fcea0d7a)
