### PR TITLE
位置情報マーカー周りの修正 ほか

### DIFF
--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -160,7 +160,7 @@ public static class DTACElementStyles
 	{
 		T v = LabelStyle<T>();
 
-		v.Margin = new(18, 0);
+		v.Margin = new(18, 0, 0, 0);
 		v.LineHeight = 1.4;
 		v.FontSize = 16;
 		v.HorizontalOptions = LayoutOptions.Start;

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -160,6 +160,7 @@ public partial class VerticalStylePage : ContentView
 		BindingContext = newValue;
 		TimetableView.SelectedTrainData = newValue;
 		PageHeaderArea.IsRunning = false;
+		InstanceManager.DTACMarkerViewModel.IsToggled = false;
 
 		TrainInfo_BeforeDepartureArea.TrainInfoText = newValue?.TrainInfo ?? "";
 		TrainInfo_BeforeDepartureArea.BeforeDepartureText = newValue?.BeforeDeparture ?? "";

--- a/TRViS/DTAC/VerticalTimetableView.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableView.Init.cs
@@ -46,6 +46,8 @@ public partial class VerticalTimetableView
 
 		ColumnDefinitions = DTACElementStyles.TimetableColumnWidthCollection;
 
+		Grid.SetColumnSpan(CurrentLocationLine, 8);
+
 		LocationService.LocationStateChanged += LocationService_LocationStateChanged;
 		LocationService.ExceptionThrown += (s, e) =>
 		{
@@ -111,7 +113,13 @@ public partial class VerticalTimetableView
 			IsBusy = true;
 
 			Children.Clear();
+
 			logger.Trace("MainThread: Clearing old RowViews Complete");
+
+			Add(CurrentLocationBoxView);
+			Add(CurrentLocationLine);
+
+			logger.Trace("MainThread: Insert CurrentLocationMarker Complete");
 		});
 		logger.Trace("ClearOldRowViews Task Complete");
 
@@ -155,10 +163,6 @@ public partial class VerticalTimetableView
 
 			AfterRemarks.AddToParent();
 			AfterArrive.AddToParent();
-
-			Add(CurrentLocationBoxView);
-			Grid.SetColumnSpan(CurrentLocationBoxView, 8);
-			Add(CurrentLocationLine);
 
 			IsBusy = false;
 

--- a/TRViS/DTAC/VerticalTimetableView.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableView.Init.cs
@@ -19,6 +19,7 @@ public partial class VerticalTimetableView
 		HorizontalOptions = LayoutOptions.Start,
 		Color = CURRENT_LOCATION_MARKER_COLOR,
 		InputTransparent = true,
+		ZIndex = 1,
 	};
 	BoxView CurrentLocationLine { get; } = new()
 	{
@@ -28,6 +29,7 @@ public partial class VerticalTimetableView
 		VerticalOptions = LayoutOptions.End,
 		Color = CURRENT_LOCATION_MARKER_COLOR,
 		InputTransparent = true,
+		ZIndex = 1,
 	};
 
 	readonly BeforeAfterRemarks AfterRemarks;


### PR DESCRIPTION
InfoRowの直後の行では、位置情報マーカーが色マーカーの後ろに回ってしまう場合があるらしいことを報告頂いた。
発生条件が不明で、手元でも再現しなかったものの、念のためZIndexを `1` に設定した。

ほか、
- 時刻表画面で「行路施行日」の「日」だけ表示できない場合がある不具合にも対応した
- 列車を変更した際はマーカーを一旦閉じるようにした
- 現在位置マーカーはRowView挿入前に挿入するようにした (RowView挿入完了前に運転開始される可能性があるため)

