### PR TITLE
Crash when Invalid Format DB

### DIFF
--- a/TRViS/RootPages/SelectTrainPage.xaml.cs
+++ b/TRViS/RootPages/SelectTrainPage.xaml.cs
@@ -68,6 +68,7 @@ public partial class SelectTrainPage : ContentPage
 	{
 		logger.Info("Select File Button Clicked");
 
+		ILoader? lastLoader = viewModel.Loader;
 		try
 		{
 			var result = await FilePicker.Default.PickAsync();
@@ -75,7 +76,6 @@ public partial class SelectTrainPage : ContentPage
 			if (result is not null)
 			{
 				logger.Info("File Selected: {0}", result.FullPath);
-				ILoader? lastLoader = viewModel.Loader;
 
 				if (result.FullPath.EndsWith(".json"))
 				{
@@ -100,7 +100,6 @@ public partial class SelectTrainPage : ContentPage
 					logger.Debug("Loader changed -> dispose lastLoader");
 					// どちらもnullの可能性がある
 					lastLoader?.Dispose();
-					return;
 				}
 			}
 			else
@@ -110,6 +109,13 @@ public partial class SelectTrainPage : ContentPage
 		}
 		catch (Exception ex)
 		{
+			if (!ReferenceEquals(lastLoader, viewModel.Loader))
+			{
+				logger.Debug("Loader changed -> restore lastLoader");
+				viewModel.Loader?.Dispose();
+				viewModel.Loader = lastLoader;
+			}
+
 			logger.Error(ex, "File Selection Failed");
 			await Utils.DisplayAlert(this, "Cannot Open File", ex.ToString(), "OK");
 		}

--- a/TRViS/RootPages/SelectTrainPage.xaml.cs
+++ b/TRViS/RootPages/SelectTrainPage.xaml.cs
@@ -83,11 +83,16 @@ public partial class SelectTrainPage : ContentPage
 					viewModel.Loader = await LoaderJson.InitFromFileAsync(result.FullPath);
 					logger.Trace("LoaderJson Initialized");
 				}
-				else
+				else if (result.FullPath.EndsWith(".sqlite") || result.FullPath.EndsWith(".db") || result.FullPath.EndsWith(".sqlite3"))
 				{
 					logger.Debug("Loading SQLite File");
 					viewModel.Loader = new LoaderSQL(result.FullPath);
 					logger.Trace("LoaderSQL Initialized");
+				}
+				else
+				{
+					logger.Warn("Unknown File Type");
+					await Utils.DisplayAlert(this, "Unknown File Type", "The selected file is not a supported file type.", "OK");
 				}
 
 				if (!ReferenceEquals(lastLoader, viewModel.Loader))

--- a/TRViS/RootPages/SelectTrainPage.xaml.cs
+++ b/TRViS/RootPages/SelectTrainPage.xaml.cs
@@ -75,7 +75,7 @@ public partial class SelectTrainPage : ContentPage
 			if (result is not null)
 			{
 				logger.Info("File Selected: {0}", result.FullPath);
-				viewModel.Loader?.Dispose();
+				ILoader? lastLoader = viewModel.Loader;
 
 				if (result.FullPath.EndsWith(".json"))
 				{
@@ -88,6 +88,14 @@ public partial class SelectTrainPage : ContentPage
 					logger.Debug("Loading SQLite File");
 					viewModel.Loader = new LoaderSQL(result.FullPath);
 					logger.Trace("LoaderSQL Initialized");
+				}
+
+				if (!ReferenceEquals(lastLoader, viewModel.Loader))
+				{
+					logger.Debug("Loader changed -> dispose lastLoader");
+					// どちらもnullの可能性がある
+					lastLoader?.Dispose();
+					return;
 				}
 			}
 			else


### PR DESCRIPTION
変なフォーマット等、DBの読み込みに失敗するとクラッシュする不具合を修正した。

ロードが完了する前にDisposeしてて、しかもDispose後に `null` セットされていないせいで、Dispose後のオブジェクトにアクセスしてクラッシュしていた。

このため、ロード完了後にDisposeするようにした。  
ついでに、SQLiteにも拡張子チェックを追加した