### PR TITLE
位置情報データが登録されていない場合にLocationServiceボタンを有効にしないようにした

### DIFF
--- a/TRViS.LocationService/ILocationService.cs
+++ b/TRViS.LocationService/ILocationService.cs
@@ -40,6 +40,9 @@ public class LocationStateChangedEventArgs : EventArgs, IEquatable<LocationState
 
 public interface ILocationService
 {
+	bool CanUseService { get; }
+	event EventHandler<bool>? CanUseServiceChanged;
+
 	event EventHandler<LocationStateChangedEventArgs>? LocationStateChanged;
 
 	StaLocationInfo[]? StaLocationInfo { get; set; }

--- a/TRViS/DTAC/PageHeader.cs
+++ b/TRViS/DTAC/PageHeader.cs
@@ -5,6 +5,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<bool>("IsOpen")]
 [DependencyProperty<bool>("IsRunning")]
 [DependencyProperty<bool>("IsLocationServiceEnabled")]
+[DependencyProperty<bool>("CanUseLocationService")]
 public partial class PageHeader : Grid
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -56,7 +57,7 @@ public partial class PageHeader : Grid
 		logger.Info("IsRunning: {0}", newValue);
 		StartEndRunButton.IsChecked = newValue;
 
-		LocationServiceButton.IsEnabled = newValue;
+		LocationServiceButton.IsEnabled = CanUseLocationService && newValue;
 	}
 
 	private void StartEndRunButton_IsCheckedChanged(object? sender, ValueChangedEventArgs<bool> e)
@@ -65,7 +66,7 @@ public partial class PageHeader : Grid
 
 		this.IsRunning = e.NewValue;
 
-		LocationServiceButton.IsEnabled = e.NewValue;
+		LocationServiceButton.IsEnabled = CanUseLocationService && e.NewValue;
 	}
 	#endregion
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -130,6 +130,11 @@ public partial class VerticalStylePage : ContentView
 		PageHeaderArea.IsLocationServiceEnabledChanged += OnIsLocationServiceEnabledChanged;
 		TimetableView.IsLocationServiceEnabledChanged += OnIsLocationServiceEnabledChanged;
 
+		TimetableView.CanUseLocationServiceChanged += (_, canUseLocationService) => {
+			logger.Info("CanUseLocationServiceChanged: {0}", canUseLocationService);
+			PageHeaderArea.CanUseLocationService = canUseLocationService;
+		};
+
 		logger.Trace("Created");
 	}
 

--- a/TRViS/DTAC/VerticalTimetableView.LocationService.cs
+++ b/TRViS/DTAC/VerticalTimetableView.LocationService.cs
@@ -10,6 +10,11 @@ namespace TRViS.DTAC;
 public partial class VerticalTimetableView : Grid
 {
 	LocationService LocationService { get; } = new();
+	public event EventHandler<bool>? CanUseLocationServiceChanged
+	{
+		add => LocationService.CanUseServiceChanged += value;
+		remove => LocationService.CanUseServiceChanged -= value;
+	}
 
 	public event EventHandler<ValueChangedEventArgs<bool>>? IsLocationServiceEnabledChanged;
 	partial void OnIsLocationServiceEnabledChanged(bool newValue)

--- a/TRViS/Services/LocationService.cs
+++ b/TRViS/Services/LocationService.cs
@@ -25,6 +25,12 @@ public partial class LocationService : ObservableObject, IDisposable
 	bool _IsEnabled;
 	public event EventHandler<ValueChangedEventArgs<bool>>? IsEnabledChanged;
 
+	public event EventHandler<bool>? CanUseServiceChanged
+	{
+		add => LonLatLocationService.CanUseServiceChanged += value;
+		remove => LonLatLocationService.CanUseServiceChanged -= value;
+	}
+
 	readonly LonLatLocationService LonLatLocationService;
 
 	public event EventHandler<LocationStateChangedEventArgs> LocationStateChanged


### PR DESCRIPTION
位置情報が設定されていないデータで位置情報サービスを有効にするとクラッシュする場合があるため、位置情報サービスを利用できない場合は位置情報ボタンを有効にできないようにした。

本質的な解決方法ではないものの、発生箇所の特定に時間がかかりそうであるため、とりあえずこれで対応する。

![Screenshot 2024-02-21 at 0 03 33](https://github.com/TetsuOtter/TRViS/assets/31824852/5e7b9f60-38d3-4a31-9bf6-66914c330fa2)
