### PR TITLE
AppTheme変更ボタンを実装

### DIFF
--- a/TRViS/DTAC/LocationServiceButton.cs
+++ b/TRViS/DTAC/LocationServiceButton.cs
@@ -9,7 +9,7 @@ public class LocationServiceButton : ToggleButton
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	const float CornerRadius = 5;
 	const float SelectedRectMargin = 2;
-	const float SelectedRectThickness = 2;
+	const float SelectedRectThickness = 1;
 	const float NotSelectedRectMargin = 1;
 
 	readonly Label Label_Location = DTACElementStyles.LargeLabelStyle<Label>();

--- a/TRViS/DTAC/Remarks.xaml.cs
+++ b/TRViS/DTAC/Remarks.xaml.cs
@@ -26,6 +26,8 @@ public partial class Remarks : Grid
 		ContentAreaHeight = new(DEFAULT_CONTENT_AREA_HEIGHT);
 
 		DTACElementStyles.DefaultBGColor.Apply(RemarksTextScrollView, BackgroundColorProperty);
+		DTACElementStyles.DefaultTextColor.Apply(RemarksLabel, Label.TextColorProperty);
+
 		logger.Trace("Created");
 	}
 

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -80,6 +80,7 @@
 				Grid.Column="0"/>
 
 			<ctrls:HtmlAutoDetectLabel
+				x:Name="MaxSpeedLabel"
 				Style="{x:Static dtac:DTACElementStyles.LabelStyleResource}"
 				Text="{Binding MaxSpeed, Converter={StaticResource ToWideConverter}}"
 				HorizontalTextAlignment="End"
@@ -90,6 +91,7 @@
 				Grid.Column="1"/>
 
 			<ctrls:HtmlAutoDetectLabel
+				x:Name="SpeedTypeLabel"
 				Style="{x:Static dtac:DTACElementStyles.LabelStyleResource}"
 				Text="{Binding SpeedType, Converter={StaticResource ToWideConverter}}"
 				HorizontalTextAlignment="End"
@@ -100,6 +102,7 @@
 				Grid.Column="2"/>
 
 			<ctrls:HtmlAutoDetectLabel
+				x:Name="NominalTractiveCapacityLabel"
 				Style="{x:Static dtac:DTACElementStyles.LabelStyleResource}"
 				Text="{Binding NominalTractiveCapacity, Converter={StaticResource ToWideConverter}}"
 				HorizontalTextAlignment="End"
@@ -176,6 +179,7 @@
 				Grid.Column="1"/>
 
 			<ctrls:HtmlAutoDetectLabel
+				x:Name="BeginRemarksLabel"
 				Style="{x:Static dtac:DTACElementStyles.LabelStyleResource}"
 				Grid.Column="2"
 				Grid.ColumnSpan="6"

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -14,7 +14,7 @@ public partial class VerticalStylePage : ContentView
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_BEFORE_DEPARTURE_ROW_HEIGHT = DTACElementStyles.BeforeDeparture_AfterArrive_Height * 2;
-	const double CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT = 54;
+	const double CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT = 60;
 	const double TIMETABLE_HEADER_ROW_HEIGHT = 60;
 
 	RowDefinition TrainInfo_BeforeDepature_RowDefinition { get; } = new(0);

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -135,6 +135,12 @@ public partial class VerticalStylePage : ContentView
 			PageHeaderArea.CanUseLocationService = canUseLocationService;
 		};
 
+		DTACElementStyles.DefaultTextColor.Apply(BeginRemarksLabel, Label.TextColorProperty);
+		DTACElementStyles.DefaultTextColor.Apply(MaxSpeedLabel, Label.TextColorProperty);
+		DTACElementStyles.DefaultTextColor.Apply(SpeedTypeLabel, Label.TextColorProperty);
+		DTACElementStyles.DefaultTextColor.Apply(NominalTractiveCapacityLabel, Label.TextColorProperty);
+		DTACElementStyles.DefaultTextColor.Apply(BeginRemarksLabel, Label.TextColorProperty);
+
 		logger.Trace("Created");
 	}
 

--- a/TRViS/DTAC/ViewHost.xaml
+++ b/TRViS/DTAC/ViewHost.xaml
@@ -41,6 +41,23 @@
 			BackgroundColor="Transparent"
 			Clicked="MenuButton_Clicked" />
 
+		<HorizontalStackLayout
+			Grid.Row="1"
+			Margin="8,4"
+			Padding="0"
+			HorizontalOptions="End"
+			VerticalOptions="Center"
+			Spacing="8">
+			<Button
+				x:Name="ChangeThemeButton"
+				Margin="0"
+				Padding="0"
+				FontFamily="MaterialIconsRegular"
+				FontSize="28"
+				BackgroundColor="Transparent"
+				Clicked="OnChangeThemeButtonClicked" />
+		</HorizontalStackLayout>
+
 		<Label
 			x:Name="TitleLabel"
 			Grid.Row="1"

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -8,6 +8,8 @@ public partial class ViewHost : ContentPage
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 	static public readonly double TITLE_VIEW_HEIGHT = 50;
+	public const string CHANGE_THEME_BUTTON_TEXT_TO_LIGHT = "\xe518";
+	public const string CHANGE_THEME_BUTTON_TEXT_TO_DARK = "\xe51c";
 
 	DTACViewHostViewModel ViewModel { get; }
 
@@ -28,7 +30,10 @@ public partial class ViewHost : ContentPage
 		InitializeComponent();
 
 		TitleLabel.Text = vm.SelectedWork?.Name;
-		TitleLabel.TextColor = MenuButton.TextColor = eevm.ShellTitleTextColor;
+		TitleLabel.TextColor
+			= MenuButton.TextColor
+			= ChangeThemeButton.TextColor
+			= eevm.ShellTitleTextColor;
 
 		TitleBGBoxView.SetBinding(BoxView.ColorProperty, new Binding()
 		{
@@ -93,6 +98,9 @@ public partial class ViewHost : ContentPage
 		OnSelectedWorkChanged(vm.SelectedWork);
 		OnSelectedTrainChanged(vm.SelectedTrainData);
 
+		ChangeChangeThemeButtonText(vm.CurrentAppTheme);
+		vm.CurrentAppThemeChanged += (s, e) => ChangeChangeThemeButtonText(e.NewValue);
+
 		logger.Trace("Created");
 	}
 
@@ -138,7 +146,10 @@ public partial class ViewHost : ContentPage
 		{
 			case nameof(EasterEggPageViewModel.ShellTitleTextColor):
 				logger.Trace("ShellTitleTextColor is changed to {0}", vm.ShellTitleTextColor);
-				TitleLabel.TextColor = MenuButton.TextColor = vm.ShellTitleTextColor;
+				TitleLabel.TextColor
+					= MenuButton.TextColor
+					= ChangeThemeButton.TextColor
+					= vm.ShellTitleTextColor;
 				break;
 		}
 	}
@@ -161,6 +172,38 @@ public partial class ViewHost : ContentPage
 			case nameof(AppViewModel.SelectedTrainData):
 				OnSelectedTrainChanged(vm.SelectedTrainData);
 				break;
+		}
+	}
+
+	private void ChangeChangeThemeButtonText(AppTheme newTheme)
+	{
+		logger.Trace("newTheme: {0}", newTheme);
+		ChangeThemeButton.Text = newTheme == AppTheme.Dark
+			? CHANGE_THEME_BUTTON_TEXT_TO_LIGHT
+			: CHANGE_THEME_BUTTON_TEXT_TO_DARK;
+	}
+	private void OnChangeThemeButtonClicked(object? sender, EventArgs e)
+	{
+		AppViewModel vm = InstanceManager.AppViewModel;
+		AppTheme newTheme = vm.CurrentAppTheme == AppTheme.Dark
+			? AppTheme.Light
+			: AppTheme.Dark;
+
+		if (Application.Current is not null)
+		{
+			logger.Info(
+				"CurrentAppTheme is changed to {0} (User: {1}, Platform: {2}, Requested: {3})",
+				newTheme,
+				Application.Current.UserAppTheme,
+				Application.Current.PlatformAppTheme,
+				Application.Current.RequestedTheme
+			);
+			vm.CurrentAppTheme = newTheme;
+			Application.Current.UserAppTheme = newTheme;
+		}
+		else
+		{
+			logger.Warn("Application.Current is null -> do nothing");
 		}
 	}
 

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -35,13 +35,19 @@ public class SettingFileStructure
 	public double LocationServiceInterval_Seconds { get; set; } = 1;
 	public static readonly double MinimumLocationServiceIntervalValue = 0.1;
 
+	/// <summary>
+	/// アプリのテーマ初期値 (null/Unspecifiedの場合は、システムの設定に従う)
+	/// </summary>
+	public AppTheme? InitialTheme { get; set; } = AppTheme.Unspecified;
+
 	public override string ToString()
 	{
 		return
 			$"TitleColor: {TitleColor},"
 			+ $"MarkerColors: {MarkerColors},"
 			+ $"MarkerTexts: {MarkerTexts},"
-			+ $"LocationServiceInterval: {LocationServiceInterval_Seconds}[s]"
+			+ $"LocationServiceInterval: {LocationServiceInterval_Seconds}[s],"
+			+ $"InitialTheme: {InitialTheme},"
 		;
 	}
 
@@ -55,6 +61,7 @@ public class SettingFileStructure
 			&& MarkerColors.Equals(v.MarkerColors)
 			&& MarkerTexts.Equals(v.MarkerTexts)
 			&& LocationServiceInterval_Seconds.Equals(v.LocationServiceInterval_Seconds)
+			&& InitialTheme.Equals(v.InitialTheme)
 		;
 	}
 
@@ -62,7 +69,7 @@ public class SettingFileStructure
 		=> Equals(obj as SettingFileStructure);
 
 	public override int GetHashCode()
-		=> HashCode.Combine(TitleColor, MarkerColors, MarkerTexts, LocationServiceInterval_Seconds);
+		=> HashCode.Combine(TitleColor, MarkerColors, MarkerTexts, LocationServiceInterval_Seconds, InitialTheme);
 
 	#region Loaders
 

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -127,6 +127,19 @@ public partial class EasterEggPageViewModel : ObservableObject
 		MarkerViewModel?.UpdateList(settingFile);
 
 		SetTitleTextColor();
+
+		if (settingFile.InitialTheme is AppTheme theme and not AppTheme.Unspecified)
+		{
+			InstanceManager.AppViewModel.CurrentAppTheme = theme;
+			if (Application.Current is not null)
+			{
+				MainThread.BeginInvokeOnMainThread(() =>
+				{
+					Application.Current.UserAppTheme = theme;
+				});
+			}
+		}
+
 		logger.Trace("InitAsync Completed");
 	}
 


### PR DESCRIPTION
D-TAC風ページにAppTheme変更ボタンを設置した。

また、JSON経由での初期値セット機能も実装した。
とはいえ、わざわざ設定するケースはあまり想定していない。

## 実装した機能の説明

TRViSでは、独自機能としてダークモード対応を実装している。
しかし、現状システムの設定を参照するのみであるため、ダークモード端末で実物同様のライトモードを使用したい場合は、端末側のテーマ設定を変更する必要があった。
そこで、D-TAC風ページから直接テーマ設定を変更できるようにすることで、簡単にテーマ変更を行えるようになる。

また、端末側にテーマ変更機能が存在しないOS (iOS12など) の場合は、この機能を使用しないとテーマ変更を行うことができない。

## 仕様の説明

基本は端末の設定に従い、D-TAC風ページ右上のボタン押下にて、「ダーク→ライト」および「ライト→ダーク」操作を実行することができる。

また、MyAppCustomizables.jsonに新しいプロパティ `InitialTheme` を追加したため、これに以下の値を設定することで初期状態をセットすることができる。
- 0: Unspecified
- 1: Light
- 2: Dark

(例: `"InitialTheme":2`)

なお、これら以外の値がセットされた場合の挙動は未定義である。たぶんエラーを吐く。

## 将来的にやりたいこと

EasterEggPageからも設定できるようにしたいものの、UIがかなり面倒なため、よほど要望がない限り実装しない予定。

## スクリーンショット

iPad mini2 (iOS 12.5.7) にてダークモードを試した図。

iPhone 15 でも文字色がうまく変わらない場合がある不具合があり、調査が必要

![IMG_0029](https://github.com/TetsuOtter/TRViS/assets/31824852/4ec2023b-c7bb-489b-8c2c-a402dff50ca0)
