### PR TITLE
Disable Font AutoScale

### DIFF
--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -180,6 +180,7 @@ public static class DTACElementStyles
 	{
 		T v = AffectDateLabelStyle<T>();
 
+		v.Margin = new(0, 0, v.Margin.Left, 0);
 		v.FontAttributes = FontAttributes.Bold;
 		v.FontSize = DefaultTextSize;
 		v.Text = null;

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -109,6 +109,7 @@ public static class DTACElementStyles
 			_labelStyleResource.Setters.Add(Label.MarginProperty, new Thickness(4, 0));
 			_labelStyleResource.Setters.Add(Label.LineBreakModeProperty, LineBreakMode.CharacterWrap);
 			_labelStyleResource.Setters.Add(Label.LineHeightProperty, DeviceInfo.Platform == DevicePlatform.Android ? 0.75 : 1.1);
+			_labelStyleResource.Setters.Add(Label.FontAutoScalingEnabledProperty, false);
 
 			return _labelStyleResource;
 		}
@@ -127,6 +128,8 @@ public static class DTACElementStyles
 		v.LineBreakMode = LineBreakMode.CharacterWrap;
 
 		v.LineHeight = DeviceInfo.Platform == DevicePlatform.Android ? 0.75 : 1.1;
+
+		v.FontAutoScalingEnabled = false;
 
 		return v;
 	}

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -226,10 +226,12 @@ public partial class SimpleRow
 			Text = $"{value.Hour:00}:{value.Minute:00}",
 			FontAttributes = FontAttributes.Bold,
 			FontSize = baseTextSize,
+			FontAutoScalingEnabled = false,
 		});
 		fs.Spans.Add(new(){
 			Text = value.Second?.ToString("00"),
 			FontSize = TimeLabelFontSize_SS,
+			FontAutoScalingEnabled = false,
 		});
 
 		return fs;

--- a/TRViS/DTAC/OpenCloseButton.cs
+++ b/TRViS/DTAC/OpenCloseButton.cs
@@ -47,6 +47,7 @@ public partial class OpenCloseButton : Button
 		BorderWidth = 0;
 		FontFamily = "MaterialIconsRegular";
 		FontSize = 40;
+		FontAutoScalingEnabled = false;
 		DTACElementStyles.OpenCloseButtonBGColor.Apply(this, BackgroundColorProperty);
 		DTACElementStyles.OpenCloseButtonTextColor.Apply(this, TextColorProperty);
 

--- a/TRViS/DTAC/Remarks.xaml
+++ b/TRViS/DTAC/Remarks.xaml
@@ -52,6 +52,7 @@
 		<ctrls:HtmlAutoDetectLabel
 			x:Name="RemarksLabel"
 			Style="{x:Static dtac:DTACElementStyles.LabelStyleResource}"
+			FontAutoScalingEnabled="True"
 			HorizontalOptions="Start"
 			VerticalOptions="Start"/>
 	</ScrollView>

--- a/TRViS/DTAC/Remarks.xaml
+++ b/TRViS/DTAC/Remarks.xaml
@@ -27,6 +27,7 @@
 		Grid.Row="0"
 		FontSize="28"
 		FontFamily="Hiragino Sans W6"
+		FontAutoScalingEnabled="False"
 		Margin="16,0"
 		Text="注 意 事 項"
 		HorizontalOptions="Start"

--- a/TRViS/DTAC/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml
@@ -3,6 +3,7 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:xct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+	xmlns:local="clr-namespace:TRViS.DTAC"
 	xmlns:vm="clr-namespace:TRViS.ViewModels"
 	xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
 	x:Class="TRViS.DTAC.SelectMarkerPopup"
@@ -29,6 +30,7 @@
 			<Frame
 				Margin="4"
 				Padding="16"
+				BackgroundColor="{x:Static local:DTACElementStyles.TabAreaBGColor}"
 				WidthRequest="80">
 				<ListView
 					SelectionMode="Single"
@@ -64,6 +66,7 @@
 			<Frame
 				Margin="4"
 				Padding="16"
+				BackgroundColor="{x:Static local:DTACElementStyles.TabAreaBGColor}"
 				WidthRequest="128">
 				<ListView
 					SelectionMode="Single"

--- a/TRViS/DTAC/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/SelectMarkerPopup.xaml.cs
@@ -16,6 +16,8 @@ public partial class SelectMarkerPopup : Popup
 
 		InitializeComponent();
 
+		DTACElementStyles.DefaultBGColor.Apply(this, ColorProperty);
+
 		logger.Trace("Created");
 	}
 

--- a/TRViS/DTAC/StartEndRunButton.xaml
+++ b/TRViS/DTAC/StartEndRunButton.xaml
@@ -22,6 +22,7 @@
 				TextColor="{x:Static local:DTACElementStyles.StartEndRunButtonTextColor}"
 				FontFamily="MaterialIconsRegular"
 				FontSize="32"
+				FontAutoScalingEnabled="False"
 				VerticalOptions="Center"
 				Margin="2"
 				Padding="0">
@@ -42,6 +43,7 @@
 				TextColor="{x:Static local:DTACElementStyles.StartEndRunButtonTextColor}"
 				FontFamily="Hiragino Sans"
 				FontSize="24"
+				FontAutoScalingEnabled="False"
 				FontAttributes="Bold"
 				VerticalOptions="Center"
 				Margin="4"

--- a/TRViS/DTAC/TabButton.xaml
+++ b/TRViS/DTAC/TabButton.xaml
@@ -32,6 +32,7 @@
 				x:Name="ButtonLabel"
 				FontFamily="Hiragino Sans"
 				FontSize="18"
+				FontAutoScalingEnabled="False"
 				FontAttributes="Bold"
 				VerticalOptions="Center"
 				HorizontalOptions="Center"/>

--- a/TRViS/DTAC/VerticalTimetableRow.Init.cs
+++ b/TRViS/DTAC/VerticalTimetableRow.Init.cs
@@ -333,6 +333,7 @@ public partial class VerticalTimetableRow
 			IsEnabled = true,
 			FontFamily = "Hiragino Sans",
 			FontSize = 18,
+			FontAutoScalingEnabled = false,
 			FontAttributes = FontAttributes.Bold,
 			BorderColor = Colors.Transparent,
 			CornerRadius = 4,


### PR DESCRIPTION
D-TAC風表示にて、フォントのAutoScaleを無効化することで、レイアウトが崩れないようにした
(RemarksやMarker Popupはレイアウトへの影響が無いため、AutoScaleは無効化していない。

![Screenshot 2024-05-20 at 2 49 28](https://github.com/TetsuOtter/TRViS/assets/31824852/a5893dc7-2ddb-4027-be1e-142d26087e2d)
iPad Gen8にて、フォントサイズ設定を通常範囲の最大にした図

![Screenshot 2024-05-20 at 2 51 11](https://github.com/TetsuOtter/TRViS/assets/31824852/4f1f931c-a459-477b-bea1-e6a2a36da051)
iPad Gen8にて、Larger Accessibility Sizesを有効にした状態の最大に設定した図
ヘッダ部分は完全に読めなくなっているが、そこまで対応は難しいので諦め