### PR TITLE
AffectDateのフォーマット実装ミスを修正

### DIFF
--- a/TRViS.IO.Tests/Utils/StringToDateOnly.tests.cs
+++ b/TRViS.IO.Tests/Utils/StringToDateOnly.tests.cs
@@ -1,0 +1,27 @@
+namespace TRViS.IO.Tests;
+
+public class StringToDateOnlyTests
+{
+	[Test]
+	public void EmptyStringTest()
+	{
+		Assert.That(Utils.TryStringToDateOnly("", out DateOnly date), Is.False);
+		Assert.That(date, Is.EqualTo(default(DateOnly)));
+	}
+
+	[Test]
+	public void NullStringTest()
+	{
+		Assert.That(Utils.TryStringToDateOnly(null, out DateOnly date), Is.False);
+		Assert.That(date, Is.EqualTo(default(DateOnly)));
+	}
+
+	[TestCase("20230318")]
+	[TestCase("2023-03-18")]
+	[TestCase("2023-3-18")]
+	public void ValidStringTest(string input)
+	{
+		Assert.That(Utils.TryStringToDateOnly(input, out DateOnly date), Is.True);
+		Assert.That(date, Is.EqualTo(new DateOnly(2023, 3, 18)));
+	}
+}

--- a/TRViS.IO/Loaders/LoaderJson.cs
+++ b/TRViS.IO/Loaders/LoaderJson.cs
@@ -96,7 +96,7 @@ public class LoaderJson : ILoader
 
 		return new Models.TrainData(
 			WorkName: r.Work.Name,
-			AffectDate: DateOnly.TryParse(r.Work.AffectDate, out DateOnly date) ? date : null,
+			AffectDate: Utils.StringToDateOnlyOrNull(r.Work.AffectDate),
 			TrainNumber: r.Train.TrainNumber,
 			MaxSpeed: t.MaxSpeed,
 			SpeedType: t.SpeedType,

--- a/TRViS.IO/Loaders/LoaderSQL.cs
+++ b/TRViS.IO/Loaders/LoaderSQL.cs
@@ -53,7 +53,7 @@ public class LoaderSQL : ILoader, IDisposable
 				on t.WorkId equals w.Id
 				select new TrainData(
 					WorkName: w.Name,
-					AffectDate: DateOnly.TryParse(w.AffectDate, out DateOnly date) ? date : null,
+					AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
 					TrainNumber: t.TrainNumber,
 					MaxSpeed: t.MaxSpeed,
 					SpeedType: t.SpeedType,

--- a/TRViS.IO/Utils/StringToDateOnly.cs
+++ b/TRViS.IO/Utils/StringToDateOnly.cs
@@ -1,0 +1,27 @@
+namespace TRViS.IO;
+
+public static partial class Utils
+{
+	public static bool TryStringToDateOnly(string? value, out DateOnly date)
+	{
+		if (string.IsNullOrEmpty(value))
+		{
+			date = default;
+			return false;
+		}
+
+		if (value.Length == 8 && value.All(char.IsDigit))
+		{
+			int year = int.Parse(value[..4]);
+			int month = int.Parse(value[4..6]);
+			int day = int.Parse(value[6..]);
+			date = new DateOnly(year, month, day);
+			return true;
+		}
+
+		return DateOnly.TryParse(value, out date);
+	}
+
+	public static DateOnly? StringToDateOnlyOrNull(string? value)
+		=> TryStringToDateOnly(value, out DateOnly date) ? date : null;
+}


### PR DESCRIPTION
`20240531` のような8文字での指定もできるようにしたつもりだったが、できていなかった

これにより、サンプルファイルにて施行日が正常に `2023年3月18日` と表示されるようになった

https://github.com/TetsuOtter/TRViS/blob/3f8fae1a71643c102d8db36fb7df62077cef7b98/TRViS.IO.Tests/Resources/db.sample.json#L9