### PR TITLE
「次列車へ」ボタンでクラッシュする不具合を修正

### DIFF
--- a/TRViS/RootPages/SelectTrainPage.xaml.cs
+++ b/TRViS/RootPages/SelectTrainPage.xaml.cs
@@ -116,6 +116,7 @@ public partial class SelectTrainPage : ContentPage
 				viewModel.Loader = lastLoader;
 			}
 
+			Crashes.TrackError(ex);
 			logger.Error(ex, "File Selection Failed");
 			await Utils.DisplayAlert(this, "Cannot Open File", ex.ToString(), "OK");
 		}


### PR DESCRIPTION
hotfix扱い。

原因はわからないものの、存在しない列車IDを指定してクラッシュしてしまう例があった。この修正により、クラッシュはしなくなる。
エラー解消を監視するため、TrackErrorだけは残しておく。