### PR TITLE
ライトモード時はアイコン背景を常に表示 ほか

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -19,12 +19,12 @@ env:
   CSPROJ_PATH: ./TRViS/TRViS.csproj
   THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
   THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net8.0-ios
+  TARGET_FRAMEWORK: net9.0-ios
   TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net8.0-maccatalyst
+  TARGET_FRAMEWORK_MAC: net9.0-maccatalyst
   TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net8.0-android
-  TARGET_FRAMEWORK_WIN: net8.0-windows10.0.19041.0
+  TARGET_FRAMEWORK_ANDROID: net9.0-android
+  TARGET_FRAMEWORK_WIN: net9.0-windows10.0.19041.0
   TARGET_RUNTIME_WINX64: win10-x64
   TARGET_RUNTIME_WINX86: win10-x86
   OUTPUT_DIR: ./out
@@ -36,9 +36,9 @@ env:
   ASSET_NAME_WIN_X86: TRViS-win-x86
   ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
   ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: '8.0.401'
+  SDK_VERSION: '9.0.100'
   APP_CENTER_SECRETS_FILE_NAME: ./TRViS/AppCenterSecrets.cs
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net8.0-ios/ios-arm64
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net9.0-ios/ios-arm64
   IOS_DSYM_FILENAME: TRViS.app.dSYM
 
 jobs:

--- a/TRViS.IO/Loaders/LoaderJson.cs
+++ b/TRViS.IO/Loaders/LoaderJson.cs
@@ -158,7 +158,7 @@ public class LoaderJson : ILoader
 							// TODO: JSONでのNextTrainIdのサポート
 							NextTrainId = trainIndex != trainList.Length - 1 ? trainIdList[trainIdIndex] : null
 						},
-						trainData.TimetableRows.Select((v, i) => new TimetableRow(
+						trainData.TimetableRows.Select(static (v, i) => new TimetableRow(
 							Id: v.Id ?? i.ToString(),
 							Location: new(v.Location_m, v.Longitude_deg, v.Latitude_deg, v.OnStationDetectRadius_m),
 							DriveTimeMM: v.DriveTime_MM,
@@ -257,7 +257,7 @@ public class LoaderJson : ILoader
 		=> WorkData.Values.Where(v => v.WorkGroupId == workGroupId).ToArray();
 
 	public IReadOnlyList<Models.DB.TrainData> GetTrainDataList(string workId)
-		=> TrainData.Values.Where((v) => WorkIdByTrainId[v.Item1.Id] == workId).Select(v => v.Item1).ToArray();
+		=> TrainData.Values.Where((v) => WorkIdByTrainId[v.Item1.Id] == workId).Select(static v => v.Item1).ToArray();
 
 	public IReadOnlyList<TrainDataGroup> GetTrainDataGroupList()
 	{

--- a/TRViS.IO/Loaders/LoaderSQL.cs
+++ b/TRViS.IO/Loaders/LoaderSQL.cs
@@ -32,7 +32,7 @@ public class LoaderSQL : ILoader, IDisposable
 				TrainNumber = t.TrainNumber
 			};
 
-		foreach (var group in res.GroupBy(v => v.GroupId))
+		foreach (var group in res.GroupBy(static v => v.GroupId))
 		{
 			List<TrainDataFileInfo> fileInfo = new();
 			foreach (var work in group)

--- a/TRViS.LocationService.Tests/TRViS.LocationService.Tests.csproj
+++ b/TRViS.LocationService.Tests/TRViS.LocationService.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/TRViS.LocationService/LonLatLocationService.cs
+++ b/TRViS.LocationService/LonLatLocationService.cs
@@ -37,7 +37,7 @@ public class LonLatLocationService : ILocationService
 				return;
 
 			_staLocationInfo = value;
-			CanUseService = _staLocationInfo?.Any(v => v.HasLonLatLocation) ?? false;
+			CanUseService = _staLocationInfo?.Any(static v => v.HasLonLatLocation) ?? false;
 			ResetLocationInfo();
 		}
 	}

--- a/TRViS.NetworkSyncService/TRViS.NetworkSyncService.csproj
+++ b/TRViS.NetworkSyncService/TRViS.NetworkSyncService.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="System.Text.Json" Version="9.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/TRViS/App.xaml.cs
+++ b/TRViS/App.xaml.cs
@@ -14,14 +14,12 @@ public partial class App : Application
 
 		InitializeComponent();
 
-		MainPage = new AppShell();
-
 		logger.Trace("App Created");
 	}
 
 	protected override Window CreateWindow(IActivationState? activationState)
 	{
-		Window window = base.CreateWindow(activationState);
+		Window window = new(new AppShell());
 
 		logger.Info("Window Created");
 
@@ -59,9 +57,9 @@ public partial class App : Application
 			return;
 		}
 
-		if (app.MainPage is null)
+		if (app.Windows.Count == 0)
 		{
-			logger.Warn("App.Current.MainPage is null");
+			logger.Warn("app.Windows is Empty");
 			AppLinkUri = uri;
 			return;
 		}

--- a/TRViS/App.xaml.cs
+++ b/TRViS/App.xaml.cs
@@ -12,7 +12,17 @@ public partial class App : Application
 	{
 		logger.Trace("App Creating (URL: {0})", AppLinkUri?.ToString() ?? "(null))");
 
+	try
+	{
 		InitializeComponent();
+	}
+	catch (Exception ex)
+	{
+		logger.Error(ex, "App Initialize Failed");
+		NLog.LogManager.Flush();
+		NLog.LogManager.Shutdown();
+		System.Environment.Exit(1);
+	}
 
 		logger.Trace("App Created");
 	}

--- a/TRViS/AppShell.xaml
+++ b/TRViS/AppShell.xaml
@@ -18,15 +18,15 @@
 	<Shell.FlyoutFooter>
 		<VerticalStackLayout
 			Margin="4">
-			<Frame
+			<Border
 				BackgroundColor="{AppThemeBinding Default=White, Dark=Black}"
-				BorderColor="{AppThemeBinding Default=#333, Dark=#CCC}"
+				Stroke="{AppThemeBinding Default=#333, Dark=#CCC}"
 				HorizontalOptions="Center"
 				Margin="8"
 				Padding="8">
 				<Label
 					Text="{x:Static local:AppShell.AppVersionString}"/>
-			</Frame>
+			</Border>
 		</VerticalStackLayout>
 	</Shell.FlyoutFooter>
 

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -90,12 +90,12 @@ public partial class AppShell : Shell
 		}
 	}
 
-	protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+	protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 	{
 		InstanceManager.AppViewModel.WindowWidth = widthConstraint;
 		InstanceManager.AppViewModel.WindowHeight = heightConstraint;
-		logger.Trace("OnMeasure: {0}x{1}", widthConstraint, heightConstraint);
-		return base.OnMeasure(widthConstraint, heightConstraint);
+		logger.Trace("MeasureOverride: {0}x{1}", widthConstraint, heightConstraint);
+		return base.MeasureOverride(widthConstraint, heightConstraint);
 	}
 
 	public event ValueChangedEventHandler<Thickness>? SafeAreaMarginChanged;

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -45,10 +45,12 @@ public partial class AppShell : Shell
 		AppCenterSettingViewModel.IsEnabledChanged += ApplyFlyoutBhavior;
 		ApplyFlyoutBhavior(this, false, AppCenterSettingViewModel.IsEnabled);
 
-		SetBinding(Shell.BackgroundColorProperty, new Binding() { Source = easterEggPageViewModel, Path = nameof(EasterEggPageViewModel.ShellBackgroundColor) });
-		SetBinding(Shell.TitleColorProperty, new Binding() { Source = easterEggPageViewModel, Path = nameof(EasterEggPageViewModel.ShellTitleTextColor) });
+		this.BindingContext = easterEggPageViewModel;
+		this.SetBinding(BackgroundColorProperty, static (EasterEggPageViewModel vm) => vm.ShellBackgroundColor);
+		this.SetBinding(TitleColorProperty, static (EasterEggPageViewModel vm) => vm.ShellTitleTextColor);
 
-		FlyoutIconImage.SetBinding(FontImageSource.ColorProperty, new Binding() { Source = easterEggPageViewModel, Path = nameof(EasterEggPageViewModel.ShellTitleTextColor) });
+		FlyoutIconImage.BindingContext = easterEggPageViewModel;
+		FlyoutIconImage.SetBinding(FontImageSource.ColorProperty, static (EasterEggPageViewModel vm) => vm.ShellTitleTextColor);
 
 		InstanceManager.AppViewModel.WindowWidth = DeviceDisplay.Current.MainDisplayInfo.Width;
 		InstanceManager.AppViewModel.WindowHeight = DeviceDisplay.Current.MainDisplayInfo.Height;

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -100,7 +100,7 @@ public static partial class DTACElementStyles
 		new(new(64))
 		);
 
-	public static readonly AppThemeGenericsValueTypeBindingExtension<double> AppIconOpacity = new(0.05, 0.05);
+	public static readonly AppThemeGenericsValueTypeBindingExtension<double> AppIconOpacity = new(0.05, 0.025);
 	public static readonly AppThemeColorBindingExtension AppIconBgColor = new(
 		new(0xCC, 0xFF, 0xCC),
 		new(0xA3, 0xCC, 0xA3)

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -100,7 +100,7 @@ public static partial class DTACElementStyles
 		new(new(64))
 		);
 
-	public static readonly AppThemeGenericsValueTypeBindingExtension<double> AppIconOpacity = new(0.1, 0.05);
+	public static readonly AppThemeGenericsValueTypeBindingExtension<double> AppIconOpacity = new(0.05, 0.05);
 	public static readonly AppThemeColorBindingExtension AppIconBgColor = new(
 		new(0xCC, 0xFF, 0xCC),
 		new(0xA3, 0xCC, 0xA3)

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -415,7 +415,7 @@ public static partial class DTACElementStyles
 			trackName = HtmlTagRegex().Replace(trackName, "");
 			trackName = XmlEscapedStrRegex().Replace(trackName, "");
 		}
-		int maxLineLength = trackName.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Select(v => v.Length).Max();
+		int maxLineLength = trackName.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Select(static v => v.Length).Max();
 		if (maxLineLength <= 2)
 			return currentFontSize;
 		else

--- a/TRViS/DTAC/DTACElementStyles.cs
+++ b/TRViS/DTAC/DTACElementStyles.cs
@@ -53,8 +53,8 @@ public static partial class DTACElementStyles
 	public static readonly AppThemeColorBindingExtension ForegroundBlackWhite = genColor(0x00, 0xFF);
 	public static readonly AppThemeGenericsBindingExtension<Brush> ForegroundBlackWhiteBrush = ForegroundBlackWhite.ToBrushTheme();
 
-	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideFrameColor = genColor(0xFF, 0xAA);
-	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideDisabledFrameColor = genColor(0xDD, 0x99);
+	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideBorderColor = genColor(0xFF, 0xAA);
+	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideDisabledBorderColor = genColor(0xDD, 0x99);
 	public static readonly AppThemeColorBindingExtension LocationServiceSelectedSideTextColor = genColor(0xFF, 0xDD);
 	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideTextColor = genColor(0x00, 0x00);
 	public static readonly AppThemeColorBindingExtension LocationServiceNotSelectedSideBaseColor = genColor(0xFF, 0xDD);

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -152,8 +152,8 @@ public partial class SimpleRow
 
 		if (TrainData.Rows is not null)
 		{
-			FirstRow = TrainData.Rows.FirstOrDefault(v => !v.IsInfoRow);
-			LastRow = TrainData.Rows.LastOrDefault(v => !v.IsInfoRow);
+			FirstRow = TrainData.Rows.FirstOrDefault(static v => !v.IsInfoRow);
+			LastRow = TrainData.Rows.LastOrDefault(static v => !v.IsInfoRow);
 		}
 
 		int rowIndex_StaName_SelectBtn = dataIndex * 2;

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -51,40 +51,50 @@ public partial class SimpleRow
 		return v;
 	}
 
-	readonly Frame SelectTrainButtonFrame;
-	static readonly Color SelectTrainButtonFrameBorderColor = new(0.6f);
-	static readonly Shadow SelectTrainButtonFrameShadow = new()
+	readonly Border SelectTrainButtonBorder;
+	static readonly Color SelectTrainButtonBorderStrokeColor = new(0.6f);
+	static readonly Shadow SelectTrainButtonShadow = new()
 	{
 		Brush = Colors.Black,
 		Offset = new(0, 0),
 		Radius = 4,
 		Opacity = 0.4f,
 	};
-	static Frame GenSelectTrainButtonFrame(Label TrainNumberLabel)
+	static readonly Shadow SelectTrainButtonEmptyShadow = new()
 	{
-		Frame v = new()
+		Brush = Colors.Transparent,
+		Offset = new(0, 0),
+		Radius = 4,
+		Opacity = 0,
+	};
+	static Border GenSelectTrainButtonBorder(Label TrainNumberLabel)
+	{
+		Border v = new()
 		{
 			Margin = StaNameTrainNumButtonMargin,
 			Padding = TrainNumButtonPadding,
 			VerticalOptions = LayoutOptions.End,
 			HorizontalOptions = LayoutOptions.Center,
 			MinimumWidthRequest = 120,
-			HasShadow = true,
-			Shadow = SelectTrainButtonFrameShadow,
-			BorderColor = SelectTrainButtonFrameBorderColor,
+			Shadow = SelectTrainButtonEmptyShadow,
+			Stroke = SelectTrainButtonBorderStrokeColor,
+			StrokeShape = new RoundRectangle()
+			{
+				CornerRadius = 8,
+			},
 		};
-		DTACElementStyles.DefaultBGColor.Apply(v, Frame.BackgroundColorProperty);
+		DTACElementStyles.DefaultBGColor.Apply(v, Border.BackgroundColorProperty);
 		v.Content = TrainNumberLabel;
 
 		return v;
 	}
 
 	readonly ToggleButton SelectTrainButton;
-	static ToggleButton GenSelectTrainButton(Frame SelectTrainButtonFrame, EventHandler<ValueChangedEventArgs<bool>> IsSelectedChanged, int rowIndex)
+	static ToggleButton GenSelectTrainButton(Border SelectTrainButtonBorder, EventHandler<ValueChangedEventArgs<bool>> IsSelectedChanged, int rowIndex)
 	{
 		ToggleButton v = new()
 		{
-			Content = SelectTrainButtonFrame,
+			Content = SelectTrainButtonBorder,
 			IsRadio = true,
 		};
 
@@ -150,8 +160,8 @@ public partial class SimpleRow
 		int rowIndex_time = rowIndex_StaName_SelectBtn + 1;
 
 		TrainNumberLabel = GenTrainNumberLabel(TrainData);
-		SelectTrainButtonFrame = GenSelectTrainButtonFrame(TrainNumberLabel);
-		SelectTrainButton = GenSelectTrainButton(SelectTrainButtonFrame, (sender, e) =>
+		SelectTrainButtonBorder = GenSelectTrainButtonBorder(TrainNumberLabel);
+		SelectTrainButton = GenSelectTrainButton(SelectTrainButtonBorder, (sender, e) =>
 		{
 			IsSelectedChanged?.Invoke(this, e.OldValue, e.NewValue);
 			SetTrainNumberButtonState();
@@ -183,13 +193,13 @@ public partial class SimpleRow
 	{
 		if (SelectTrainButton.IsEnabled && SelectTrainButton.IsChecked)
 		{
-			DTACElementStyles.DefaultGreen.Apply(SelectTrainButtonFrame, Frame.BorderColorProperty);
-			SelectTrainButtonFrame.HasShadow = false;
+			DTACElementStyles.DefaultGreen.Apply(SelectTrainButtonBorder, Border.StrokeProperty);
+			SelectTrainButtonBorder.Shadow = SelectTrainButtonEmptyShadow;
 		}
 		else
 		{
-			SelectTrainButtonFrame.BorderColor = SelectTrainButtonFrameBorderColor;
-			SelectTrainButtonFrame.HasShadow = true;
+			SelectTrainButtonBorder.Stroke = SelectTrainButtonBorderStrokeColor;
+			SelectTrainButtonBorder.Shadow = SelectTrainButtonShadow;
 		}
 	}
 

--- a/TRViS/DTAC/OpenCloseButton.cs
+++ b/TRViS/DTAC/OpenCloseButton.cs
@@ -15,34 +15,7 @@ public partial class OpenCloseButton : Button
 	{
 		logger.Trace("Creating...");
 
-		this.SetBinding(TextProperty, new Binding()
-		{
-			Source = this,
-			Path = nameof(TextWhenClosed)
-		});
-
-		DataTrigger dataTrigger = new(typeof(OpenCloseButton))
-		{
-			Binding = new Binding()
-			{
-				Source = this,
-				Path = nameof(IsOpen)
-			},
-			Value = true,
-		};
-
-		dataTrigger.Setters.Add(new()
-		{
-			Property = TextProperty,
-			Value = new Binding()
-			{
-				Source = this,
-				Path = nameof(TextWhenOpen)
-			}
-		});
-
-		Triggers.Add(dataTrigger);
-
+		Text = IsOpen ? TextWhenOpen : TextWhenClosed;
 		CornerRadius = 4;
 		Padding = 0;
 		BorderWidth = 0;
@@ -71,12 +44,28 @@ public partial class OpenCloseButton : Button
 		try
 		{
 			IsOpenChanged?.Invoke(this, new(oldValue, newValue));
+			Text = newValue ? TextWhenOpen : TextWhenClosed;
 		}
 		catch (Exception ex)
 		{
 			logger.Fatal(ex, "Unknown Exception");
 			Crashes.TrackError(ex);
 			Utils.ExitWithAlert(ex);
+		}
+	}
+
+	partial void OnTextWhenOpenChanged(string? newValue)
+	{
+		if (IsOpen)
+		{
+			Text = newValue;
+		}
+	}
+	partial void OnTextWhenClosedChanged(string? newValue)
+	{
+		if (!IsOpen)
+		{
+			Text = newValue;
 		}
 	}
 }

--- a/TRViS/DTAC/PageParts/Hako.xaml
+++ b/TRViS/DTAC/PageParts/Hako.xaml
@@ -4,6 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:local="clr-namespace:TRViS.DTAC"
 	xmlns:root="clr-namespace:TRViS"
+	xmlns:vm="clr-namespace:TRViS.ViewModels"
 	xmlns:HakoParts="clr-namespace:TRViS.DTAC.HakoParts"
 	BackgroundColor="{x:Static local:DTACElementStyles.DefaultBGColor}"
 	x:Class="TRViS.DTAC.Hako">
@@ -15,6 +16,7 @@
 
 	<Image
 		Style="{x:Static local:DTACElementStyles.AppIconStyleResource}"
+		x:DataType="vm:AppViewModel"
 		IsVisible="{Binding IsBgAppIconVisible, Source={x:Static root:InstanceManager.AppViewModel}}"
 		Opacity="{x:Static local:DTACElementStyles.AppIconOpacity}"
 		Grid.Row="2"/>

--- a/TRViS/DTAC/PageParts/Hako.xaml.cs
+++ b/TRViS/DTAC/PageParts/Hako.xaml.cs
@@ -52,12 +52,7 @@ public partial class Hako : Grid
 
 		SimpleView.SetBinding(
 			WidthRequestProperty,
-			new Binding()
-			{
-				Source = SimpleViewScrollView,
-				Path = nameof(headerView.Width),
-				Mode = BindingMode.OneWay,
-			}
+			BindingBase.Create(static (ScrollView x) => x.Width, BindingMode.OneWay, source: headerView)
 		);
 
 		logger.Trace("Created");

--- a/TRViS/DTAC/PageParts/TabButton.xaml.cs
+++ b/TRViS/DTAC/PageParts/TabButton.xaml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using DependencyPropertyGenerator;
 using Microsoft.AppCenter.Crashes;
 using TRViS.ViewModels;
@@ -28,6 +29,8 @@ public partial class TabButton : ContentView
 		InstanceManager.AppViewModel.PropertyChanged += AppViewModel_PropertyChanged;
 		OnWindowWidthChanged(InstanceManager.AppViewModel.WindowWidth);
 
+		OnIsEnabledChanged(IsEnabled);
+
 		logger.Trace("Created");
 	}
 
@@ -37,6 +40,16 @@ public partial class TabButton : ContentView
 		{
 			case nameof(AppViewModel.WindowWidth):
 				OnWindowWidthChanged(InstanceManager.AppViewModel.WindowWidth);
+				break;
+		}
+	}
+	protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+	{
+		base.OnPropertyChanged(propertyName);
+		switch (propertyName)
+		{
+			case nameof(IsEnabled):
+				OnIsEnabledChanged(IsEnabled);
 				break;
 		}
 	}
@@ -103,6 +116,24 @@ public partial class TabButton : ContentView
 			DTACElementStyles.TabButtonBGColor.Apply(BaseBox, BoxView.ColorProperty);
 			BaseBox.Shadow.Opacity = 0;
 			logger.Info("Tab `{0}` unselected", Text);
+		}
+	}
+
+	private void OnIsEnabledChanged(bool newValue)
+	{
+		if (newValue)
+		{
+			DTACElementStyles.TabButtonBGColor.Apply(BaseBox, BoxView.ColorProperty);
+			ButtonLabel.Opacity = 1;
+		}
+		else
+		{
+			BaseBox.BackgroundColor = BASE_COLOR_DISABLED;
+			ButtonLabel.Opacity = 0.5;
+			if (IsSelected)
+			{
+				InstanceManager.DTACViewHostViewModel.TabMode = DTACViewHostViewModel.Mode.Hako;
+			}
 		}
 	}
 

--- a/TRViS/DTAC/PageParts/TabButton.xaml.cs
+++ b/TRViS/DTAC/PageParts/TabButton.xaml.cs
@@ -123,12 +123,10 @@ public partial class TabButton : ContentView
 	{
 		if (newValue)
 		{
-			DTACElementStyles.TabButtonBGColor.Apply(BaseBox, BoxView.ColorProperty);
 			ButtonLabel.Opacity = 1;
 		}
 		else
 		{
-			BaseBox.BackgroundColor = BASE_COLOR_DISABLED;
 			ButtonLabel.Opacity = 0.5;
 			if (IsSelected)
 			{

--- a/TRViS/DTAC/TimetableParts/LocationServiceButton.cs
+++ b/TRViS/DTAC/TimetableParts/LocationServiceButton.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Microsoft.AppCenter.Crashes;
+using Microsoft.Maui.Controls.Shapes;
 using TRViS.Controls;
 
 namespace TRViS.DTAC;
@@ -16,23 +17,28 @@ public class LocationServiceButton : ToggleButton
 	readonly Label Label_ON = DTACElementStyles.LabelStyle<Label>();
 	readonly Label Label_OFF = DTACElementStyles.LabelStyle<Label>();
 
-	readonly Frame SelectedSideBase = new()
+	readonly Border SelectedSideBase = new()
 	{
 		Margin = new(SelectedRectMargin),
 		Padding = new(0),
-		CornerRadius = CornerRadius - SelectedRectMargin,
-		BorderColor = Colors.Transparent,
-		HasShadow = false,
+		Stroke = Colors.Transparent,
+		StrokeShape = new RoundRectangle()
+		{
+			CornerRadius = new(CornerRadius - SelectedRectMargin),
+		},
 		Content = new BoxView()
 		{
 			Margin = new(SelectedRectThickness),
 			CornerRadius = CornerRadius - SelectedRectMargin - SelectedRectThickness,
 		}
 	};
-	readonly Frame NotSelectedSideBase = new()
+	readonly Border NotSelectedSideBase = new()
 	{
 		Margin = new(NotSelectedRectMargin),
-		CornerRadius = CornerRadius - NotSelectedRectMargin,
+		StrokeShape = new RoundRectangle()
+		{
+			CornerRadius = new(CornerRadius - NotSelectedRectMargin),
+		},
 		Shadow = DTACElementStyles.DefaultShadow,
 	};
 
@@ -51,21 +57,23 @@ public class LocationServiceButton : ToggleButton
 			}
 		};
 
-		Frame baseFrame = new()
+		Border baseBorder = new()
 		{
 			Margin = new(0),
 			Padding = new(0),
-			CornerRadius = CornerRadius,
-			BorderColor = Colors.Transparent,
-			HasShadow = true,
+			Stroke = Colors.Transparent,
+			StrokeShape = new RoundRectangle()
+			{
+				CornerRadius = new(CornerRadius),
+			},
 			Shadow = DTACElementStyles.DefaultShadow,
 		};
 
 		InitElements();
 
-		DTACElementStyles.DarkGreen.Apply(baseFrame, BackgroundColorProperty);
+		DTACElementStyles.DarkGreen.Apply(baseBorder, BackgroundColorProperty);
 		DTACElementStyles.DarkGreen.Apply(SelectedSideBase.Content, BoxView.ColorProperty);
-		DTACElementStyles.LocationServiceSelectedSideFrameColor.Apply(SelectedSideBase, BackgroundColorProperty);
+		DTACElementStyles.LocationServiceSelectedSideBorderColor.Apply(SelectedSideBase, BackgroundColorProperty);
 		DTACElementStyles.LocationServiceNotSelectedSideBaseColor.Apply(NotSelectedSideBase, BackgroundColorProperty);
 
 		HorizontalStackLayout on_group = new()
@@ -83,8 +91,8 @@ public class LocationServiceButton : ToggleButton
 			= Label_OFF.ScaleX
 			= 0.9;
 
-		Grid.SetColumnSpan(baseFrame, 2);
-		grid.Add(baseFrame);
+		Grid.SetColumnSpan(baseBorder, 2);
+		grid.Add(baseBorder);
 		grid.Add(SelectedSideBase);
 		grid.Add(NotSelectedSideBase);
 
@@ -191,12 +199,12 @@ public class LocationServiceButton : ToggleButton
 		logger.Trace("IsEnabled: {0}", newValue);
 		if (newValue)
 		{
-			DTACElementStyles.LocationServiceSelectedSideFrameColor.Apply(SelectedSideBase, BackgroundColorProperty);
+			DTACElementStyles.LocationServiceSelectedSideBorderColor.Apply(SelectedSideBase, BackgroundColorProperty);
 			DTACElementStyles.LocationServiceNotSelectedSideBaseColor.Apply(NotSelectedSideBase, BackgroundColorProperty);
 		}
 		else
 		{
-			DTACElementStyles.LocationServiceSelectedSideDisabledFrameColor.Apply(SelectedSideBase, BackgroundColorProperty);
+			DTACElementStyles.LocationServiceSelectedSideDisabledBorderColor.Apply(SelectedSideBase, BackgroundColorProperty);
 			DTACElementStyles.LocationServiceNotSelectedSideDisabledBaseColor.Apply(NotSelectedSideBase, BackgroundColorProperty);
 		}
 	}

--- a/TRViS/DTAC/TimetableParts/MarkerButton.xaml
+++ b/TRViS/DTAC/TimetableParts/MarkerButton.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Frame
+<Border
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:vm="clr-namespace:TRViS.ViewModels"
@@ -7,22 +7,23 @@
 	x:Class="TRViS.DTAC.MarkerButton"
 	x:DataType="vm:DTACMarkerViewModel"
 	x:Name="this"
-	CornerRadius="4"
 	Padding="0"
 	WidthRequest="56"
 	HeightRequest="44"
 	HorizontalOptions="Center"
 	VerticalOptions="Center"
-	BorderColor="{x:Null}"
-	HasShadow="False"
+	Stroke="Transparent"
 	BackgroundColor="{x:Static local:DTACElementStyles.OpenCloseButtonBGColor}">
-	<Frame.Resources>
+	<Border.StrokeShape>
+		<RoundRectangle CornerRadius="4"/>
+	</Border.StrokeShape>
+	<Border.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="../Style_VerticalView.xaml" />
 			</ResourceDictionary.MergedDictionaries>
 		</ResourceDictionary>
-	</Frame.Resources>
+	</Border.Resources>
 
 	<Grid
 		Margin="{OnPlatform iOS='4,6', MacCatalyst='4,6', Default='4,0'}">
@@ -63,17 +64,17 @@
 		</Label>
 	</Grid>
 
-	<Frame.GestureRecognizers>
+	<Border.GestureRecognizers>
 		<TapGestureRecognizer
 			Tapped="TapGestureRecognizer_Tapped"/>
-	</Frame.GestureRecognizers>
+	</Border.GestureRecognizers>
 
-	<Frame.Triggers>
+	<Border.Triggers>
 		<DataTrigger
-			TargetType="Frame"
+			TargetType="Border"
 			Binding="{Binding IsToggled}"
 			Value="True">
 			<Setter Property="BackgroundColor" Value="{StaticResource DarkerGreen}"/>
 		</DataTrigger>
-	</Frame.Triggers>
-</Frame>
+	</Border.Triggers>
+</Border>

--- a/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
@@ -4,7 +4,7 @@ using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
-public partial class MarkerButton : Frame
+public partial class MarkerButton : Border
 {
 	DTACMarkerViewModel MarkerSettings { get; }
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();

--- a/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml
@@ -27,7 +27,7 @@
 			Grid.Row="1"
 			Padding="8"
 			HorizontalOptions="Center">
-			<Frame
+			<Border
 				Margin="4"
 				Padding="16"
 				BackgroundColor="{x:Static local:DTACElementStyles.TabAreaBGColor}"
@@ -43,7 +43,7 @@
 							<ViewCell
 								x:DataType="vm:MarkerInfo">
 								<ContentView>
-									<Frame
+									<Border
 										HeightRequest="32"
 										WidthRequest="32"
 										VerticalOptions="Center"
@@ -52,18 +52,18 @@
 										<Label
 											Text="{Binding Name}"
 											TextColor="Black"
-											Background="#AFFF"
+											Background="#AAFFFFFF"
 											HorizontalOptions="Center"
 											VerticalOptions="Center"/>
-									</Frame>
+									</Border>
 								</ContentView>
 							</ViewCell>
 						</DataTemplate>
 					</ListView.ItemTemplate>
 				</ListView>
-			</Frame>
+			</Border>
 
-			<Frame
+			<Border
 				Margin="4"
 				Padding="16"
 				BackgroundColor="{x:Static local:DTACElementStyles.TabAreaBGColor}"
@@ -74,7 +74,7 @@
 					ios:ListView.SeparatorStyle="FullWidth"
 					ItemsSource="{Binding TextList, Mode=OneTime}"
 					SelectedItem="{Binding SelectedText, Mode=TwoWay}"/>
-			</Frame>
+			</Border>
 		</HorizontalStackLayout>
 	</Grid>
 </xct:Popup>

--- a/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml
+++ b/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml
@@ -32,6 +32,7 @@
 				<Label.Triggers>
 					<DataTrigger
 						TargetType="Label"
+						x:DataType="local:StartEndRunButton"
 						Binding="{Binding IsChecked, Source={x:Reference this}}"
 						Value="True">
 						<Setter
@@ -54,6 +55,7 @@
 				<Label.Triggers>
 					<DataTrigger
 						TargetType="Label"
+						x:DataType="local:StartEndRunButton"
 						Binding="{Binding IsChecked, Source={x:Reference this}}"
 						Value="True">
 						<Setter

--- a/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml
+++ b/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml
@@ -6,13 +6,16 @@
 	xmlns:ctrls="clr-namespace:TRViS.Controls"
 	xmlns:local="clr-namespace:TRViS.DTAC"
 	x:Class="TRViS.DTAC.StartEndRunButton">
-	<Frame
-		x:Name="BaseFrame"
-		CornerRadius="6"
+	<Border
+		x:Name="BaseBorder"
 		Margin="0"
 		Padding="4"
+		Stroke="Transparent"
 		VerticalOptions="Center"
 		HorizontalOptions="Center">
+		<Border.StrokeShape>
+			<RoundRectangle CornerRadius="8"/>
+		</Border.StrokeShape>
 		<HorizontalStackLayout
 			ScaleY="0.95"
 			HorizontalOptions="Center"
@@ -60,7 +63,7 @@
 				</Label.Triggers>
 			</Label>
 		</HorizontalStackLayout>
-	</Frame>
+	</Border>
 
 	<ctrls:ToggleButton.Shadow>
 		<Shadow

--- a/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml.cs
@@ -45,7 +45,7 @@ public partial class StartEndRunButton : ToggleButton
 		brush.GradientStops.Add(gradientStop_Up);
 		brush.GradientStops.Add(gradientStop_Down);
 
-		BaseFrame.Background = brush;
+		BaseBorder.Background = brush;
 
 		logger.Trace("Created");
 	}

--- a/TRViS/DTAC/TimetableParts/TimeCell.xaml
+++ b/TRViS/DTAC/TimetableParts/TimeCell.xaml
@@ -25,6 +25,7 @@
 		Grid.Column="0"
 		HorizontalOptions="End"
 		Margin="0"
+		x:DataType="dtac:TimeCell"
 		TextColor="{Binding TextColor, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"
 		Text="{Binding HHMM, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"/>
 
@@ -32,6 +33,7 @@
 		Style="{x:Static dtac:DTACElementStyles.TimetableDefaultNumberLabelStyleResource}"
 		Grid.Column="1"
 		HorizontalOptions="Start"
+		x:DataType="dtac:TimeCell"
 		TextColor="{Binding TextColor, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"
 		Text="{Binding TimeData.Second, StringFormat='{0:D02}', Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"/>
 
@@ -42,11 +44,13 @@
 		VerticalOptions="Center"
 		Padding="2"
 		Grid.ColumnSpan="2"
+		x:DataType="dtac:TimeCell"
 		TextColor="{Binding TextColor, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"
 		Text="{Binding TimeData.Text, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"
 		FontAttributes="Bold"/>
 
 	<Image
+		x:DataType="dtac:TimeCell"
 		IsVisible="{Binding IsArrowVisible, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimeCell}}}"
 		Aspect="AspectFit"
 		HeightRequest="22"

--- a/TRViS/DTAC/TimetableParts/TimetableHeader.xaml
+++ b/TRViS/DTAC/TimetableParts/TimetableHeader.xaml
@@ -29,13 +29,15 @@
 		Style="{x:Static dtac:DTACElementStyles.VerticalSeparatorLineStyleResource}"
 		Grid.Column="1"/>
 
-	<Frame
+	<Border
 		Grid.Column="2"
 		Margin="16,4"
 		Padding="0"
-		HasShadow="False"
-		BorderColor="{x:Null}"
+		Stroke="Transparent"
 		BackgroundColor="{StaticResource DarkerGreen}">
+		<Border.StrokeShape>
+			<RoundRectangle CornerRadius="8"/>
+		</Border.StrokeShape>
 		<Label
 			Style="{x:Static dtac:DTACElementStyles.HeaderLabelStyleResource}"
 			Margin="0"
@@ -46,7 +48,7 @@
 			FontAttributes="Bold"
 			TextColor="White"
 			Text="着"/>
-	</Frame>
+	</Border>
 	<Line
 		Style="{x:Static dtac:DTACElementStyles.VerticalSeparatorLineStyleResource}"
 		Grid.Column="2"/>

--- a/TRViS/DTAC/TimetableParts/TimetableHeader.xaml
+++ b/TRViS/DTAC/TimetableParts/TimetableHeader.xaml
@@ -44,6 +44,7 @@
 			Padding="0"
 			HorizontalOptions="Center"
 			VerticalOptions="Center"
+			x:DataType="dtac:TimetableHeader"
 			FontSize="{Binding FontSize_Large, Source={RelativeSource Mode=FindAncestor, AncestorType={x:Type dtac:TimetableHeader}}}"
 			FontAttributes="Bold"
 			TextColor="White"

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -3,6 +3,7 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:root="clr-namespace:TRViS"
+	xmlns:vm="clr-namespace:TRViS.ViewModels"
 	xmlns:dtac="clr-namespace:TRViS.DTAC"
 	xmlns:models="clr-namespace:TRViS.IO.Models;assembly=TRViS.IO"
 	xmlns:ctrls="clr-namespace:TRViS.Controls"
@@ -205,6 +206,7 @@
 
 		<Image
 			Style="{x:Static dtac:DTACElementStyles.AppIconStyleResource}"
+			x:DataType="vm:AppViewModel"
 			IsVisible="{Binding IsBgAppIconVisible, Source={x:Static root:InstanceManager.AppViewModel}}"
 			Opacity="{x:Static dtac:DTACElementStyles.AppIconOpacity}"
 			Grid.Row="6"/>

--- a/TRViS/DTAC/VerticalStylePage.xaml
+++ b/TRViS/DTAC/VerticalStylePage.xaml
@@ -143,15 +143,16 @@
 				Style="{x:Static dtac:DTACElementStyles.VerticalSeparatorLineStyleResource}"
 				Grid.Column="0"/>
 
-			<Frame
+			<Border
 				IsVisible="{Binding CarCount, Converter={x:Static conv:IsOneOrMoreIntConverter.Default}}"
 				Grid.Column="1"
 				BackgroundColor="{x:Static dtac:DTACElementStyles.CarCountBGColor}"
-				BorderColor="Transparent"
-				CornerRadius="4"
+				Stroke="Transparent"
 				Padding="0"
-				Margin="16,6"
-				HasShadow="True">
+				Margin="16,6">
+				<Border.StrokeShape>
+					<RoundRectangle CornerRadius="4"/>
+				</Border.StrokeShape>
 				<Grid
 					Margin="0"
 					Padding="4">
@@ -167,14 +168,14 @@
 						HorizontalOptions="End"
 						Text="両"/>
 				</Grid>
-				<Frame.Shadow>
+				<Border.Shadow>
 					<Shadow
 						Brush="Black"
 						Offset="2,2"
 						Radius="2"
 						Opacity="0.2" />
-				</Frame.Shadow>
-			</Frame>
+				</Border.Shadow>
+			</Border>
 			<Line
 				Style="{x:Static dtac:DTACElementStyles.VerticalSeparatorLineStyleResource}"
 				Grid.Column="1"/>
@@ -212,19 +213,27 @@
 			x:Name="TimetableAreaScrollView"
 			Grid.Row="6"/>
 
-		<Frame
-			x:Name="TimetableViewActivityIndicatorFrame"
-			Opacity="{x:Static dtac:VerticalStylePage.TimetableViewActivityIndicatorFrameMaxOpacity}"
+		<Border
+			x:Name="TimetableViewActivityIndicatorBorder"
+			Opacity="{x:Static dtac:VerticalStylePage.TimetableViewActivityIndicatorBorderMaxOpacity}"
 			VerticalOptions="Start"
 			IsVisible="False"
-			HasShadow="True"
 			HeightRequest="50"
 			WidthRequest="50"
 			Margin="8"
-			CornerRadius="25"
 			Grid.Row="6">
+			<Border.Shadow>
+				<Shadow
+					Brush="Black"
+					Offset="2,2"
+					Radius="2"
+					Opacity="0.2" />
+			</Border.Shadow>
+			<Border.StrokeShape>
+				<RoundRectangle CornerRadius="25"/>
+			</Border.StrokeShape>
 			<ActivityIndicator
 				IsRunning="True"/>
-		</Frame>
+		</Border>
 	</Grid>
 </ContentView>

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -138,11 +138,15 @@ public partial class VerticalStylePage : ContentView
 		{
 			logger.Info("Device is not Phone nor Unknown -> set TimetableView to TimetableAreaScrollView");
 			TimetableAreaScrollView.Content = TimetableView;
-			TimetableView.SetBinding(VerticalTimetableView.ScrollViewHeightProperty, new Binding()
+			TimetableAreaScrollView.PropertyChanged += (_, e) =>
 			{
-				Source = TimetableAreaScrollView,
-				Path = nameof(TimetableAreaScrollView.Height)
-			});
+				// Bindingに失敗するため、代わり。
+				if (e.PropertyName == nameof(TimetableView.Height))
+				{
+					logger.Debug("TimetableView.Height: {0}", TimetableView.HeightRequest);
+					TimetableView.ScrollViewHeight = TimetableAreaScrollView.Height;
+				}
+			};
 		}
 
 		PageHeaderArea.IsLocationServiceEnabledChanged += OnIsLocationServiceEnabledChanged;

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -27,7 +27,7 @@ public partial class VerticalStylePage : ContentView
 		+ CAR_COUNT_AND_BEFORE_REMARKS_ROW_HEIGHT
 		+ TIMETABLE_HEADER_ROW_HEIGHT;
 
-	public static double TimetableViewActivityIndicatorFrameMaxOpacity { get; } = 0.6;
+	public static double TimetableViewActivityIndicatorBorderMaxOpacity { get; } = 0.6;
 
 	VerticalTimetableView TimetableView { get; } = new();
 	DTACViewHostViewModel DTACViewHostViewModel { get; }
@@ -92,13 +92,13 @@ public partial class VerticalStylePage : ContentView
 			{
 				if (v.IsBusy)
 				{
-					TimetableViewActivityIndicatorFrame.IsVisible = true;
-					TimetableViewActivityIndicatorFrame.FadeTo(TimetableViewActivityIndicatorFrameMaxOpacity);
+					TimetableViewActivityIndicatorBorder.IsVisible = true;
+					TimetableViewActivityIndicatorBorder.FadeTo(TimetableViewActivityIndicatorBorderMaxOpacity);
 				}
 				else
-					TimetableViewActivityIndicatorFrame.FadeTo(0).ContinueWith((_) => {
-						logger.Debug("TimetableViewActivityIndicatorFrame.FadeTo(0) completed");
-						TimetableViewActivityIndicatorFrame.IsVisible = false;
+					TimetableViewActivityIndicatorBorder.FadeTo(0).ContinueWith((_) => {
+						logger.Debug("TimetableViewActivityIndicatorBorder.FadeTo(0) completed");
+						TimetableViewActivityIndicatorBorder.IsVisible = false;
 					});
 
 				// iPhoneにて、画面を回転させないとScrollViewのDesiredSizeが正常に更新されないバグに対応するため

--- a/TRViS/DTAC/ViewHost.xaml
+++ b/TRViS/DTAC/ViewHost.xaml
@@ -50,7 +50,7 @@
 			Spacing="8">
 			<ImageButton
 				Aspect="AspectFill"
-				Margin="0,8"
+				Margin="12,8"
 				HeightRequest="30"
 				WidthRequest="30"
 				Padding="0"

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -51,11 +51,7 @@ public partial class ViewHost : ContentPage
 			TimeLabel.Text = text;
 		};
 
-		TitleBGBoxView.SetBinding(BoxView.ColorProperty, new Binding()
-		{
-			Source = eevm,
-			Path = nameof(EasterEggPageViewModel.ShellBackgroundColor)
-		});
+		TitleBGBoxView.SetBinding(BoxView.ColorProperty, BindingBase.Create(static (EasterEggPageViewModel vm) => vm.ShellBackgroundColor, source: eevm));
 
 		TitleBGGradientBox.Color = null;
 		TitleBGGradientBox.Background = new LinearGradientBrush(new GradientStopCollection()
@@ -83,22 +79,9 @@ public partial class ViewHost : ContentPage
 			ViewModel.IsViewHostVisible = Shell.Current.CurrentPage is ViewHost;
 		};
 
-		VerticalStylePageView.SetBinding(VerticalStylePage.SelectedTrainDataProperty, new Binding()
-		{
-			Source = vm,
-			Path = nameof(AppViewModel.SelectedTrainData)
-		});
-
-		HakoRemarksView.SetBinding(WithRemarksView.RemarksDataProperty, new Binding()
-		{
-			Source = vm,
-			Path = nameof(AppViewModel.SelectedWork)
-		});
-		VerticalStylePageRemarksView.SetBinding(WithRemarksView.RemarksDataProperty, new Binding()
-		{
-			Source = vm,
-			Path = nameof(AppViewModel.SelectedTrainData)
-		});
+		VerticalStylePageView.SetBinding(VerticalStylePage.SelectedTrainDataProperty, BindingBase.Create(static (AppViewModel vm) => vm.SelectedTrainData, source: vm));
+		HakoRemarksView.SetBinding(WithRemarksView.RemarksDataProperty, BindingBase.Create(static (AppViewModel vm) => vm.SelectedWork, source: vm));
+		VerticalStylePageRemarksView.SetBinding(WithRemarksView.RemarksDataProperty, BindingBase.Create(static (AppViewModel vm) => vm.SelectedTrainData, source: vm));
 
 		UpdateContent();
 

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -166,6 +166,13 @@ public partial class ViewHost : ContentPage
 	private void OnToggleBgAppIconButtonClicked(object? sender, EventArgs e)
 	{
 		bool newState = !InstanceManager.AppViewModel.IsBgAppIconVisible;
+		if (InstanceManager.AppViewModel.CurrentAppTheme == AppTheme.Light
+			&& newState == false)
+		{
+			logger.Warn("IsBgAppIconVisible is not changed to false because CurrentAppTheme is Light");
+			Utils.DisplayAlert("背景を非表示にできません", "現在のテーマがライトモードのため、背景アイコンは非表示にできません。", "OK");
+			return;
+		}
 		InstanceManager.AppViewModel.IsBgAppIconVisible = newState;
 		logger.Debug("IsBgAppIconVisible is changed to {0}", newState);
 		if (sender is VisualElement button)

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -149,11 +149,12 @@ public partial class ViewHost : ContentPage
 		logger.Debug("SafeAreaMargin is changed -> set TitleBGGradientBox.Margin to {0}", Utils.ThicknessToString(TitleBGGradientBox.Margin));
 	}
 
-	protected override void LayoutChildren(double x, double y, double width, double height)
+	protected override Size ArrangeOverride(Rect bounds)
 	{
-		base.LayoutChildren(x, y, width, height);
-		logger.Info("LayoutChildren({0}, {1}, {2}, {3})", x, y, width, height);
-		TimeLabel.IsVisible = (TIME_LABEL_VISIBLE_MIN_PARENT_WIDTH + TimeLabel.Margin.Right) < width;
+		Size ret = base.ArrangeOverride(bounds);
+		logger.Info("ArrangeOverride(X:{0}, Y:{1}, W:{2}, H:{3})", bounds.X, bounds.Y, bounds.Width, bounds.Height);
+		TimeLabel.IsVisible = (TIME_LABEL_VISIBLE_MIN_PARENT_WIDTH + TimeLabel.Margin.Right) < bounds.Width;
+		return ret;
 	}
 
 	private void MenuButton_Clicked(object? sender, EventArgs e)

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -132,12 +132,21 @@ public partial class ViewHost : ContentPage
 		logger.Debug("SafeAreaMargin is changed -> set TitleBGGradientBox.Margin to {0}", Utils.ThicknessToString(TitleBGGradientBox.Margin));
 	}
 
-	protected override Size ArrangeOverride(Rect bounds)
+	protected override void OnSizeAllocated(double width, double height)
 	{
-		Size ret = base.ArrangeOverride(bounds);
-		logger.Info("ArrangeOverride(X:{0}, Y:{1}, W:{2}, H:{3})", bounds.X, bounds.Y, bounds.Width, bounds.Height);
-		TimeLabel.IsVisible = (TIME_LABEL_VISIBLE_MIN_PARENT_WIDTH + TimeLabel.Margin.Right) < bounds.Width;
-		return ret;
+		try
+		{
+			logger.Trace("width: {0}, height: {1}", width, height);
+			TimeLabel.IsVisible = (TIME_LABEL_VISIBLE_MIN_PARENT_WIDTH + TimeLabel.Margin.Right) < width;
+
+			base.OnSizeAllocated(width, height);
+		}
+		catch (Exception ex)
+		{
+			logger.Fatal(ex, "Unknown Exception");
+			Crashes.TrackError(ex);
+			Utils.ExitWithAlert(ex);
+		}
 	}
 
 	private void MenuButton_Clicked(object? sender, EventArgs e)

--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -31,12 +31,12 @@ public static class MauiProgram
 			.UseMauiApp<App>()
 			.UseMauiCommunityToolkit()
 			#if IOS
-			.ConfigureMauiHandlers(handlers =>
+			.ConfigureMauiHandlers(static handlers =>
 			{
 				handlers.AddHandler<Shell, HideShellTabRenderer>();
 			})
 			#endif
-			.ConfigureFonts(fonts =>
+			.ConfigureFonts(static fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -94,7 +94,7 @@ public partial class SettingFileStructure
 			SettingFileStructure setting = new()
 			{
 				MarkerTexts = [.. DTACMarkerViewModel.TextListDefaultValue],
-				MarkerColors = DTACMarkerViewModel.ColorListDefaultValue.ToDictionary(v => v.Name, v => new ColorSetting(v.Color)),
+				MarkerColors = DTACMarkerViewModel.ColorListDefaultValue.ToDictionary(static v => v.Name, static v => new ColorSetting(v.Color)),
 			};
 			using FileStream jsonStream = File.Create(settingFileInfo.FullName);
 			await setting.SaveToJsonFileAsync(jsonStream);

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-
+using System.Text.Json.Serialization;
 using TRViS.ViewModels;
 
 namespace TRViS.MyAppCustomizables;
@@ -7,8 +7,11 @@ namespace TRViS.MyAppCustomizables;
 /// <summary>
 /// カスタマイズ設定ファイルの構造が定義されたクラスです。
 /// </summary>
-public class SettingFileStructure
+public partial class SettingFileStructure
 {
+	[JsonSourceGenerationOptions(WriteIndented = true)]
+	[JsonSerializable(typeof(SettingFileStructure))]
+	internal partial class SourceGenerationContext : JsonSerializerContext {}
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
 	/// <summary>
@@ -118,7 +121,7 @@ public class SettingFileStructure
 		try
 		{
 			logger.Info("Loading setting file...");
-			settingFileStructure = await JsonSerializer.DeserializeAsync<SettingFileStructure>(jsonStream);
+			settingFileStructure = await JsonSerializer.DeserializeAsync(jsonStream, SourceGenerationContext.Default.SettingFileStructure);
 			logger.Trace("Loaded setting file.");
 		}
 		catch (Exception ex)
@@ -149,7 +152,7 @@ public class SettingFileStructure
 		try
 		{
 			logger.Info("Loading setting file...");
-			settingFileStructure = JsonSerializer.Deserialize<SettingFileStructure>(jsonString);
+			settingFileStructure = JsonSerializer.Deserialize(jsonString, SourceGenerationContext.Default.SettingFileStructure);
 			logger.Trace("Loaded setting file.");
 		}
 		catch (Exception ex)
@@ -168,9 +171,9 @@ public class SettingFileStructure
 	}
 
 	public string ToJsonString()
-		=> JsonSerializer.Serialize(this);
+		=> JsonSerializer.Serialize(this, SourceGenerationContext.Default.SettingFileStructure);
 	public Task SaveToJsonFileAsync(Stream dst)
-		=> JsonSerializer.SerializeAsync(dst, this);
+		=> JsonSerializer.SerializeAsync(dst, this, SourceGenerationContext.Default.SettingFileStructure);
 	public async Task SaveToJsonFileAsync()
 	{
 		FileStream? jsonStream = null;

--- a/TRViS/Resources/Styles/Styles.xaml
+++ b/TRViS/Resources/Styles/Styles.xaml
@@ -188,21 +188,6 @@
 		</Setter>
 	</Style>
 
-	<Style TargetType="Frame">
-		<Setter
-			Property="HasShadow"
-			Value="False" />
-		<Setter
-			Property="BorderColor"
-			Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-		<Setter
-			Property="BackgroundColor"
-			Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}" />
-		<Setter
-			Property="CornerRadius"
-			Value="8" />
-	</Style>
-
 	<Style TargetType="ImageButton">
 		<Setter
 			Property="Opacity"

--- a/TRViS/RootPages/AppCenterSettingPage.xaml
+++ b/TRViS/RootPages/AppCenterSettingPage.xaml
@@ -46,7 +46,7 @@ TRViSでは、アプリの品質向上のため、アプリのクラッシュや
 			<Border.StrokeShape>
 				<RoundRectangle CornerRadius="4"/>
 			</Border.StrokeShape>
-			<Grid>
+			<Grid RowSpacing="4">
 				<Grid.RowDefinitions>
 					<RowDefinition Height="*"/>
 					<RowDefinition Height="*"/>

--- a/TRViS/RootPages/AppCenterSettingPage.xaml
+++ b/TRViS/RootPages/AppCenterSettingPage.xaml
@@ -29,23 +29,23 @@ TRViSでは、アプリの品質向上のため、アプリのクラッシュや
 			</Label>
 		</VerticalStackLayout>
 
-		<Frame
+		<Border
 			Grid.Row="1"
 			Margin="4"
-			Padding="4"
-			CornerRadius="0"
-			HasShadow="False">
+			Padding="4">
 			<ctrls:SimpleMarkdownView
 				FileName="PrivacyPolicy_md"/>
-		</Frame>
+		</Border>
 
-		<Frame
+		<Border
 			Grid.Row="2"
-			CornerRadius="4"
 			HorizontalOptions="Center"
-			HasShadow="True"
+			Padding="8"
 			Margin="8"
 		>
+			<Border.StrokeShape>
+				<RoundRectangle CornerRadius="4"/>
+			</Border.StrokeShape>
 			<Grid>
 				<Grid.RowDefinitions>
 					<RowDefinition Height="*"/>
@@ -91,7 +91,7 @@ TRViSでは、アプリの品質向上のため、アプリのクラッシュや
 					IsToggled="{Binding IsAnalyticsEnabled}"/>
 
 				<Button
-					Padding="16,32"
+					Padding="16"
 					Grid.Row="4"
 					Grid.Column="0"
 					Grid.ColumnSpan="2"
@@ -99,7 +99,7 @@ TRViSでは、アプリの品質向上のため、アプリのクラッシュや
 					Clicked="OnResetButtonClicked"
 					Text="保存値を復元"/>
 				<Button
-					Padding="16,32"
+					Padding="16"
 					Grid.Row="4"
 					Grid.Column="0"
 					Grid.ColumnSpan="2"
@@ -107,6 +107,6 @@ TRViSでは、アプリの品質向上のため、アプリのクラッシュや
 					Clicked="OnSaveButtonClicked"
 					Text="保存"/>
 			</Grid>
-		</Frame>
+		</Border>
 	</Grid>
 </ContentPage>

--- a/TRViS/RootPages/EasterEggPage.xaml
+++ b/TRViS/RootPages/EasterEggPage.xaml
@@ -17,7 +17,7 @@
 				<Setter Property="Margin" Value="4"/>
 			</Style>
 
-			<Style TargetType="Frame">
+			<Style TargetType="Border">
 				<Setter Property="Margin" Value="8"/>
 			</Style>
 
@@ -54,7 +54,7 @@
 					Clicked="OnSaveClicked"
 				/>
 			</HorizontalStackLayout>
-			<Frame>
+			<Border>
 				<Grid>
 					<Grid.RowDefinitions>
 						<RowDefinition Height="*"/>
@@ -98,8 +98,8 @@
 						VerticalOptions="Center"
 						Text="{Binding Color_Blue, StringFormat='{0:D3} (0x{0:X02})'}"/>
 				</Grid>
-			</Frame>
-			<Frame>
+			</Border>
+			<Border>
 				<VerticalStackLayout>
 					<Label
 						x:Name="LocationServiceIntervalSettingHeaderLabel"
@@ -112,8 +112,8 @@
 						SelectedItem="{Binding LocationServiceInterval_Seconds, Mode=TwoWay}"
 					/>
 				</VerticalStackLayout>
-			</Frame>
-			<Frame>
+			</Border>
+			<Border>
 				<VerticalStackLayout>
 					<Label
 						Text="Log File Path"
@@ -124,7 +124,7 @@
 						FontSize="Body"
 						/>
 				</VerticalStackLayout>
-			</Frame>
+			</Border>
 		</VerticalStackLayout>
 	</ScrollView>
 </ContentPage>

--- a/TRViS/RootPages/EasterEggPage.xaml
+++ b/TRViS/RootPages/EasterEggPage.xaml
@@ -19,6 +19,8 @@
 
 			<Style TargetType="Border">
 				<Setter Property="Margin" Value="8"/>
+				<Setter Property="Padding" Value="8"/>
+				<Setter Property="Stroke" Value="{AppThemeBinding Default=Black,Dark=White}"/>
 			</Style>
 
 			<Style TargetType="Button">

--- a/TRViS/RootPages/SelectOnlineResourcePopup.cs
+++ b/TRViS/RootPages/SelectOnlineResourcePopup.cs
@@ -74,7 +74,7 @@ public class SelectOnlineResourcePopup : Popup
 		UrlHistoryListView.ItemTemplate = new DataTemplate(() => {
 			TextCell cell = new();
 			RootStyles.TableTextColor.Apply(cell, TextCell.TextColorProperty);
-			cell.SetBinding(TextCell.TextProperty, ".");
+			cell.SetBinding(TextCell.TextProperty, static (string? v) => v);
 			return cell;
 		});
 

--- a/TRViS/RootPages/SelectTrainPage.xaml
+++ b/TRViS/RootPages/SelectTrainPage.xaml
@@ -11,9 +11,8 @@
 	Title="Select Train">
 	<ContentPage.Resources>
 		<ResourceDictionary>
-			<Style TargetType="Frame">
-				<Setter Property="HasShadow" Value="True"/>
-				<Setter Property="BorderColor" Value="{x:Static local:RootStyles.FrameBorderColor}"/>
+			<Style TargetType="Border">
+				<Setter Property="Stroke" Value="{x:Static local:RootStyles.BorderStrokeColor}"/>
 				<Setter Property="BackgroundColor" Value="{x:Static local:RootStyles.BackgroundColor}"/>
 				<Setter Property="Margin" Value="4"/>
 				<Setter Property="Padding" Value="8"/>
@@ -59,7 +58,7 @@
 		<FlexLayout
 			Grid.Row="2"
 			Wrap="Wrap">
-			<Frame>
+			<Border>
 				<Grid>
 					<Grid.RowDefinitions>
 						<RowDefinition Height="40"/>
@@ -84,9 +83,9 @@
 						</ListView.ItemTemplate>
 					</ListView>
 				</Grid>
-			</Frame>
+			</Border>
 
-			<Frame>
+			<Border>
 				<Grid>
 					<Grid.RowDefinitions>
 						<RowDefinition Height="40"/>
@@ -111,7 +110,7 @@
 						</ListView.ItemTemplate>
 					</ListView>
 				</Grid>
-			</Frame>
+			</Border>
 		</FlexLayout>
 
 	</Grid>

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml
@@ -13,7 +13,7 @@
 		Wrap="Wrap">
 		<Border
 			FlexLayout.Grow="1"
-			FlexLayout.Basis="400"
+			FlexLayout.Basis="200"
 			Margin="4">
 			<ListView
 				SelectionMode="Single"
@@ -34,8 +34,9 @@
 
 		<Border
 			Margin="4"
+			Padding="4"
 			FlexLayout.Grow="2"
-			FlexLayout.Basis="600">
+			FlexLayout.Basis="400">
 			<Grid>
 				<Grid.RowDefinitions>
 					<RowDefinition Height="40"/>

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml
@@ -11,7 +11,7 @@
 		AlignContent="Stretch"
 		AlignItems="Stretch"
 		Wrap="Wrap">
-		<Frame
+		<Border
 			FlexLayout.Grow="1"
 			FlexLayout.Basis="400"
 			Margin="4">
@@ -30,9 +30,9 @@
 					</DataTemplate>
 				</ListView.ItemTemplate>
 			</ListView>
-		</Frame>
+		</Border>
 
-		<Frame
+		<Border
 			Margin="4"
 			FlexLayout.Grow="2"
 			FlexLayout.Basis="600">
@@ -67,6 +67,6 @@
 					x:Name="LicenseTextArea"
 					Grid.Row="2"/>
 			</Grid>
-		</Frame>
+		</Border>
 	</FlexLayout>
 </ContentPage>

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using TRViS.Controls;
 using TRViS.Models;
 using TRViS.ViewModels;
@@ -79,6 +80,10 @@ public partial class ThirdPartyLicenses : ContentPage
 		logger.Info("License List Loaded");
 	}
 
+	[JsonSourceGenerationOptions]
+	[JsonSerializable(typeof(LicenseData[]))]
+	internal partial class LicenseDataArrayJsonSourceGenerationContext : JsonSerializerContext { }
+
 	static async Task<LicenseData[]> LoadLicenseList(string fileName)
 	{
 		logger.Info("Loading License List from {0}", fileName);
@@ -89,7 +94,7 @@ public partial class ThirdPartyLicenses : ContentPage
 		if (await FileSystem.AppPackageFileExistsAsync(path))
 		{
 			using Stream stream = await FileSystem.OpenAppPackageFileAsync(path);
-			result = await JsonSerializer.DeserializeAsync<LicenseData[]>(stream);
+			result = await JsonSerializer.DeserializeAsync<LicenseData[]>(stream, LicenseDataArrayJsonSourceGenerationContext.Default.LicenseDataArray);
 			logger.Debug("License List Loaded from App Package (Length: {0})", result?.Length ?? 0);
 		}
 

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
@@ -74,7 +74,7 @@ public partial class ThirdPartyLicenses : ContentPage
 			.Concat(await LoadLicenseList("license_list_custom.json"))
 			.ToList();
 
-		list.Sort((v1, v2) => string.Compare(v1.id, v2.id));
+		list.Sort(static (v1, v2) => string.Compare(v1.id, v2.id));
 
 		viewModel.LicenseDataArray = list;
 		logger.Info("License List Loaded");

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
@@ -22,6 +22,21 @@ public partial class ThirdPartyLicenses : ContentPage
 		BindingContext = viewModel;
 
 		viewModel.PropertyChanged += ViewModel_PropertyChanged;
+		LicenseTextArea.PropertyChanged += (_, e) => {
+			if (e.PropertyName == nameof(Width))
+			{
+				if (LicenseTextArea.Content is not VerticalStackLayout licenses)
+					return;
+
+				foreach (var v in licenses.Children)
+				{
+					if (v is not HtmlAutoDetectLabel label)
+						continue;
+
+					label.WidthRequest = LicenseTextArea.Width;
+				}
+			}
+		};
 
 		logger.Trace("Creating Task to Load License List");
 		Task.Run(LoadLicenseList);
@@ -44,7 +59,11 @@ public partial class ThirdPartyLicenses : ContentPage
 			{
 				licenses.Children.Add(new HtmlAutoDetectLabel()
 				{
-					Text = v.Value
+					Text = v.Value,
+					FontAutoScalingEnabled = true,
+					LineBreakMode = LineBreakMode.WordWrap,
+					Padding = new(4),
+					WidthRequest = LicenseTextArea.Width,
 				});
 				licenses.Children.Add(new BoxView()
 				{

--- a/TRViS/RootStyles.cs
+++ b/TRViS/RootStyles.cs
@@ -6,5 +6,5 @@ public static class RootStyles
 	public static readonly AppThemeColorBindingExtension TableDetailColor = new(new(0x55, 0x55, 0x55), new(0xAA, 0xAA, 0xAA));
 	public static readonly AppThemeColorBindingExtension BackgroundColor = new(new(0xDD, 0xDD, 0xDD), new(0x22, 0x22, 0x22));
 	public static readonly AppThemeColorBindingExtension BackgroundBlackWhite = new(new(1), new(0));
-	public static readonly AppThemeColorBindingExtension FrameBorderColor = new(new(0x22, 0x22, 0x22), new(0xDD, 0xDD, 0xDD));
+	public static readonly AppThemeColorBindingExtension BorderStrokeColor = new(new(0x22, 0x22, 0x22), new(0xDD, 0xDD, 0xDD));
 }

--- a/TRViS/Services/AppPreferenceService.cs
+++ b/TRViS/Services/AppPreferenceService.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace TRViS.Services;
 
@@ -53,10 +55,10 @@ public static class AppPreferenceService
 		return value;
 	}
 
-	public static T GetFromJson<T>(in AppPreferenceKeys key, T defaultValue, out bool hasKey)
+	public static T GetFromJson<T>(in AppPreferenceKeys key, T defaultValue, out bool hasKey, JsonTypeInfo<T> jsonTypeInfo)
 	{
 		string result = Get(in key, string.Empty, out hasKey);
-		return string.IsNullOrEmpty(result) ? defaultValue : JsonSerializer.Deserialize<T>(result) ?? defaultValue;
+		return string.IsNullOrEmpty(result) ? defaultValue : JsonSerializer.Deserialize(result, jsonTypeInfo) ?? defaultValue;
 	}
 
 	public static void Set(in AppPreferenceKeys key, bool value)
@@ -73,6 +75,6 @@ public static class AppPreferenceService
 		Preferences.Set(keyStr, value);
 	}
 
-	public static void SetToJson<T>(in AppPreferenceKeys key, T value)
-		=> Set(in key, JsonSerializer.Serialize(value));
+	public static void SetToJson<T>(in AppPreferenceKeys key, T value, JsonTypeInfo<T> jsonTypeInfo)
+		=> Set(in key, JsonSerializer.Serialize(value, jsonTypeInfo));
 }

--- a/TRViS/Services/LocationService.cs
+++ b/TRViS/Services/LocationService.cs
@@ -272,7 +272,7 @@ public partial class LocationService : IDisposable
 			return;
 		}
 
-		_CurrentService.StaLocationInfo = timetableRows?.Where(v => !v.IsInfoRow).Select(v => new StaLocationInfo(v.Location.Location_m, v.Location.Longitude_deg, v.Location.Latitude_deg, v.Location.OnStationDetectRadius_m)).ToArray();
+		_CurrentService.StaLocationInfo = timetableRows?.Where(static v => !v.IsInfoRow).Select(static v => new StaLocationInfo(v.Location.Location_m, v.Location.Longitude_deg, v.Location.Latitude_deg, v.Location.OnStationDetectRadius_m)).ToArray();
 	}
 
 	static EasterEggPageViewModel EasterEggPageViewModel { get; } = InstanceManager.EasterEggPageViewModel;

--- a/TRViS/Services/LoggerService.cs
+++ b/TRViS/Services/LoggerService.cs
@@ -70,7 +70,7 @@ public static class LoggerService
 				ARCHIVE_LOG_FILE_NAME_PATTERN,
 				SearchOption.TopDirectoryOnly
 			)
-				.OrderByDescending(fileInfo => fileInfo.LastWriteTime)
+				.OrderByDescending(static fileInfo => fileInfo.LastWriteTime)
 				.Skip(MAX_ARCHIVE_LOG_FILE_COUNT);
 
 			foreach (FileInfo oldLogFile in oldLogFiles)
@@ -196,7 +196,7 @@ public static class LoggerService
 				ARCHIVE_LOG_FILE_NAME_PATTERN,
 				SearchOption.TopDirectoryOnly
 			)
-				.OrderByDescending(fileInfo => fileInfo.LastWriteTime)
+				.OrderByDescending(static fileInfo => fileInfo.LastWriteTime)
 				.FirstOrDefault()
 				?.FullName;
 			if (string.IsNullOrEmpty(lastLogFilePath))

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net8.0-android;</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([System.String]::IsNullOrEmpty('$(WITHOUT_ANDROID)'))">net9.0-android;</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
 		<UseMauiNuGets>true</UseMauiNuGets>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>TRViS</RootNamespace>
@@ -20,7 +20,7 @@
 		<!-- Versions -->
 		<ApplicationDisplayVersion>0.1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -21,7 +21,7 @@
 		<ApplicationDisplayVersion>0.1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -25,6 +25,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 	</PropertyGroup>
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
 		<RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -52,7 +52,7 @@
 			Include="Resources\AppIcon\appiconfg.png"
 			LogicalName="appiconfg.png" />
 		<MauiAsset
-			Include="..\docs\md\**"
+			Include="Resources\Raw\**"
 			LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 		<MauiAsset
 			Include="..\docs\md\**"

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -62,7 +62,7 @@
 	<ItemGroup>
 		<PackageReference
 			Include="Microsoft.Maui.Controls"
-			Version="8.0.92" />
+			Version="9.0.10" />
 		<PackageReference
 			Include="CommunityToolkit.Mvvm"
 			Version="8.3.2" />
@@ -73,10 +73,10 @@
 			ExcludeAssets="runtime" />
 		<PackageReference
 			Include="System.Text.Json"
-			Version="8.0.5" />
+			Version="9.0.0" />
 		<PackageReference
 			Include="CommunityToolkit.Maui"
-			Version="9.1.0" />
+			Version="9.1.1" />
 		<PackageReference
 			Include="NLog"
 			Version="5.3.4" />

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -26,6 +26,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
 		<RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>

--- a/TRViS/Utils/ShowAlert.cs
+++ b/TRViS/Utils/ShowAlert.cs
@@ -41,5 +41,5 @@ public static partial class Utils
 	}
 
 	public static Task ExitWithAlert(Exception ex)
-		=> DisplayAlert("エラー", "不明なエラーが発生しました。アプリを終了します。\n" + ex.Message, "OK").ContinueWith(_ => Environment.Exit(1));
+		=> DisplayAlert("エラー", "不明なエラーが発生しました。アプリを終了します。\n" + ex.Message, "OK").ContinueWith(static _ => Environment.Exit(1));
 }

--- a/TRViS/Utils/ShowAlert.cs
+++ b/TRViS/Utils/ShowAlert.cs
@@ -4,7 +4,7 @@ public static partial class Utils
 {
 	public static Task DisplayAlert(string title, string message, string cancel)
 	{
-		Page? page = Application.Current?.MainPage;
+		Page? page = 0 < Application.Current?.Windows.Count ? Application.Current?.Windows[0].Page : null;
 
 		if (page is null)
 		{
@@ -23,7 +23,7 @@ public static partial class Utils
 
 	public static Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
 	{
-		Page? page = Application.Current?.MainPage;
+		Page? page = 0 < Application.Current?.Windows.Count ? Application.Current?.Windows[0].Page : null;
 
 		if (page is null)
 		{

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -128,7 +128,7 @@ public partial class AppViewModel
 			}
 
 			_ExternalResourceUrlHistory.Add(decodedUrl);
-			AppPreferenceService.SetToJson(AppPreferenceKeys.ExternalResourceUrlHistory, _ExternalResourceUrlHistory);
+			AppPreferenceService.SetToJson(AppPreferenceKeys.ExternalResourceUrlHistory, _ExternalResourceUrlHistory, StringListJsonSourceGenerationContext.Default.ListString);
 		}
 
 		if (appLinkInfo.RealtimeServiceUri is not null)

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -211,7 +211,7 @@ public partial class AppViewModel
 		token.ThrowIfCancellationRequested();
 
 		logger.Warn("remoteIp is private but not same network");
-		string myIpListStr = string.Join('\n', myIpList.Select((x, i) => $"この端末[{i}]:{x}"));
+		string myIpListStr = string.Join('\n', myIpList.Select(static (x, i) => $"この端末[{i}]:{x}"));
 		bool continueProcessing = await Utils.DisplayAlert(
 			"Maybe Different Network",
 			$"接続先と違うネットワークに属しているため、接続に失敗する可能性があります。\nこのまま接続しますか?\n接続先:{remoteIp}\n{myIpListStr}",
@@ -240,7 +240,7 @@ public partial class AppViewModel
 
 #if DEBUG
 		// パフォーマンスとプライバシーの理由で、ヘッダーの内容はDEBUGビルドのみ表示する
-		IEnumerable<string> headerStrEnumerable = response.Content.Headers.Select(x => $"{x.Key}: {string.Join(", ", x.Value)}");
+		IEnumerable<string> headerStrEnumerable = response.Content.Headers.Select(static x => $"{x.Key}: {string.Join(", ", x.Value)}");
 		logger.Trace("ResponseHeaders: {0}", string.Join(", ", headerStrEnumerable));
 #endif
 

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -29,8 +29,20 @@ public partial class AppViewModel : ObservableObject
 	[ObservableProperty]
 	TrainData? _SelectedTrainData;
 
-	[ObservableProperty]
 	bool _IsBgAppIconVisible = true;
+	public bool IsBgAppIconVisible
+	{
+		get => _IsBgAppIconVisible;
+		set
+		{
+			if (_IsBgAppIconVisible == value)
+				return;
+			// 不正利用・誤認防止のため、ライトモード時はアイコン背景を強制表示する。
+			if (CurrentAppTheme == AppTheme.Light && value == false)
+				return;
+			SetProperty(ref _IsBgAppIconVisible, value);
+		}
+	}
 
 	[ObservableProperty]
 	double _WindowHeight;
@@ -40,6 +52,7 @@ public partial class AppViewModel : ObservableObject
 
 	public event EventHandler<ValueChangedEventArgs<AppTheme>>? CurrentAppThemeChanged;
 	AppTheme _SystemAppTheme;
+	public AppTheme SystemAppTheme => _SystemAppTheme;
 	AppTheme _CurrentAppTheme;
 	public AppTheme CurrentAppTheme
 	{
@@ -55,6 +68,9 @@ public partial class AppViewModel : ObservableObject
 			AppTheme tmp = _CurrentAppTheme;
 			_CurrentAppTheme = value;
 			CurrentAppThemeChanged?.Invoke(this, new(tmp, value));
+			// 不正利用・誤認防止のため、ライトモード時はアイコン背景を強制表示する。
+			if (value == AppTheme.Light)
+				IsBgAppIconVisible = true;
 		}
 	}
 

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -1,5 +1,5 @@
 using System.Collections.ObjectModel;
-
+using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using TRViS.IO;
@@ -74,6 +74,12 @@ public partial class AppViewModel : ObservableObject
 		}
 	}
 
+	[JsonSourceGenerationOptions(WriteIndented = false)]
+	[JsonSerializable(typeof(List<string>))]
+	internal partial class StringListJsonSourceGenerationContext : JsonSerializerContext
+	{
+	}
+
 	public AppViewModel()
 	{
 		if (Application.Current is not null)
@@ -91,7 +97,7 @@ public partial class AppViewModel : ObservableObject
 			};
 		}
 
-		_ExternalResourceUrlHistory = AppPreferenceService.GetFromJson<List<string>>(AppPreferenceKeys.ExternalResourceUrlHistory, [], out _);
+		_ExternalResourceUrlHistory = AppPreferenceService.GetFromJson(AppPreferenceKeys.ExternalResourceUrlHistory, [], out _, StringListJsonSourceGenerationContext.Default.ListString);
 	}
 
 	partial void OnLoaderChanged(ILoader? value)

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -23,11 +23,25 @@ public partial class AppViewModel : ObservableObject
 
 	[ObservableProperty]
 	TRViS.IO.Models.DB.WorkGroup? _SelectedWorkGroup;
-	[ObservableProperty]
 	TRViS.IO.Models.DB.Work? _SelectedWork;
+	public TRViS.IO.Models.DB.Work? SelectedWork
+	{
+		get => _SelectedWork;
+		set
+		{
+			if (SetProperty(ref _SelectedWork, value))
+			{
+				OnSelectedWorkChanged(value);
+			}
+		}
+	}
 
-	[ObservableProperty]
 	TrainData? _SelectedTrainData;
+	public TrainData? SelectedTrainData
+	{
+		get => _SelectedTrainData;
+		set => SetProperty(ref _SelectedTrainData, value);
+	}
 
 	bool _IsBgAppIconVisible = true;
 	public bool IsBgAppIconVisible
@@ -120,7 +134,7 @@ public partial class AppViewModel : ObservableObject
 		}
 	}
 
-	partial void OnSelectedWorkChanged(IO.Models.DB.Work? value)
+	void OnSelectedWorkChanged(IO.Models.DB.Work? value)
 	{
 		logger.Debug("Work: {0}", value?.Id ?? "null");
 		if (value is not null)

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -79,7 +79,7 @@ public partial class DTACMarkerViewModel : ObservableObject
 		);
 
 		ColorList.Clear();
-		ColorList.AddRange(settingFile.MarkerColors.Select(v => new MarkerInfo(v.Key, v.Value.ToColor())));
+		ColorList.AddRange(settingFile.MarkerColors.Select(static v => new MarkerInfo(v.Key, v.Value.ToColor())));
 		if (SelectedMarkerInfo is not null && !ColorList.Contains(SelectedMarkerInfo))
 		{
 			logger.Debug("Current SelectedMarkerInfo is not in ColorList");
@@ -122,7 +122,7 @@ public partial class DTACMarkerViewModel : ObservableObject
 	{
 		logger.Trace("Executing...");
 
-		settingFile.MarkerColors = ColorList.ToDictionary(v => v.Name, v => new ColorSetting(v.Color));
+		settingFile.MarkerColors = ColorList.ToDictionary(static v => v.Name, static v => new ColorSetting(v.Color));
 		settingFile.MarkerTexts = TextList.ToArray();
 
 		logger.Trace("Completed");

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using TRViS.MyAppCustomizables;
 
@@ -7,11 +8,27 @@ public partial class EasterEggPageViewModel : ObservableObject
 {
 	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-	[ObservableProperty]
 	Color _ShellBackgroundColor = Colors.Black;
+	public Color ShellBackgroundColor
+	{
+		// コード生成するとCompiled Bindingが上手く働かないため、手書き。
+		get => _ShellBackgroundColor;
+		set
+		{
+			if (SetProperty(ref _ShellBackgroundColor, value))
+			{
+				SetTitleTextColor();
+			}
+		}
+	}
 
-	[ObservableProperty]
 	Color _ShellTitleTextColor = Colors.White;
+	public Color ShellTitleTextColor
+	{
+		// コード生成するとCompiled Bindingが上手く働かないため、手書き。
+		get => _ShellTitleTextColor;
+		set => SetProperty(ref _ShellTitleTextColor, value);
+	}
 
 	[ObservableProperty]
 	int _Color_Red;
@@ -155,14 +172,6 @@ public partial class EasterEggPageViewModel : ObservableObject
 		MarkerViewModel?.SetToSettings(settingFile);
 
 		await settingFile.SaveToJsonFileAsync();
-	}
-
-	partial void OnShellBackgroundColorChanged(Color value)
-	{
-		if (value is not null)
-		{
-			SetTitleTextColor();
-		}
 	}
 
 	void SetTitleTextColor()

--- a/TRViS/ViewModels/ThirdPartyLicensesViewModel.cs
+++ b/TRViS/ViewModels/ThirdPartyLicensesViewModel.cs
@@ -45,7 +45,7 @@ public partial class ThirdPartyLicensesViewModel : ObservableObject
 
 				foreach (string fileName in
 					Regex.Split(value.license, @"\(|\)| ")
-						.Where(v => !string.IsNullOrWhiteSpace(v) && v != "AND" && v != "OR")
+						.Where(static v => !string.IsNullOrWhiteSpace(v) && v != "AND" && v != "OR")
 				)
 				{
 					list.Add(await LoadLicenseText(value.license));

--- a/iosSim.sh
+++ b/iosSim.sh
@@ -3,7 +3,7 @@
 cd `dirname $0`
 
 TARGET_PROJ="TRViS/TRViS.csproj"
-TARGET_FRAMEWORK="net8.0-ios"
+TARGET_FRAMEWORK="net9.0-ios"
 
 UDID_PATTERN="[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}"
 


### PR DESCRIPTION
- 誤認・トラブル防止のため、ライトモード時は常にアイコンを表示するようにした  
  ダークモードは誤認の恐れがないため、背景を消すことができる。
- .NET9を使うように (min targetが iOS12.2, macCatalyst15になった)
- NativeAOT対応
