### PR TITLE
位置情報ログを出力する実装 / 地図で位置を確認する機能

### DIFF
--- a/TRViS.ILocationService/StaLocationInfo.cs
+++ b/TRViS.ILocationService/StaLocationInfo.cs
@@ -75,5 +75,11 @@ public class StaLocationInfo : ILocationLonLat_deg, IEquatable<StaLocationInfo>
 		=> HashCode.Combine(Location_m, Location_lon_deg, Location_lat_deg, NearbyRadius_m);
 
 	public override string ToString()
+		=> HasLonLatLocation
+			? ToStringWithLonLat()
+			: ToStringWithoutLonLat();
+	private string ToStringWithLonLat()
 		=> $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, {nameof(Location_lon_deg)}: {Location_lon_deg}, {nameof(Location_lat_deg)}: {Location_lat_deg}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
+	private string ToStringWithoutLonLat()
+		=> $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
 }

--- a/TRViS.ILocationService/StaLocationInfo.cs
+++ b/TRViS.ILocationService/StaLocationInfo.cs
@@ -75,7 +75,5 @@ public class StaLocationInfo : ILocationLonLat_deg, IEquatable<StaLocationInfo>
 		=> HashCode.Combine(Location_m, Location_lon_deg, Location_lat_deg, NearbyRadius_m);
 
 	public override string ToString()
-	{
-		return $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, {nameof(Location_lon_deg)}: {Location_lon_deg}, {nameof(Location_lat_deg)}: {Location_lat_deg}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
-	}
+		=> $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, {nameof(Location_lon_deg)}: {Location_lon_deg}, {nameof(Location_lat_deg)}: {Location_lat_deg}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
 }

--- a/TRViS.ILocationService/StaLocationInfo.cs
+++ b/TRViS.ILocationService/StaLocationInfo.cs
@@ -79,7 +79,7 @@ public class StaLocationInfo : ILocationLonLat_deg, IEquatable<StaLocationInfo>
 			? ToStringWithLonLat()
 			: ToStringWithoutLonLat();
 	private string ToStringWithLonLat()
-		=> $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, {nameof(Location_lon_deg)}: {Location_lon_deg}, {nameof(Location_lat_deg)}: {Location_lat_deg}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
+		=> $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, lon: {Location_lon_deg}, lat: {Location_lat_deg}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
 	private string ToStringWithoutLonLat()
 		=> $"{nameof(StaLocationInfo)} {{ {nameof(Location_m)}: {Location_m}, {nameof(NearbyRadius_m)}: {NearbyRadius_m} }}";
 }

--- a/TRViS.IO/Models/TimeData.cs
+++ b/TRViS.IO/Models/TimeData.cs
@@ -5,4 +5,16 @@ public record TimeData(
 	int? Minute,
 	int? Second,
 	string? Text
-);
+)
+{
+	public string GetTimeString()
+	{
+		if (Hour is null && Minute is null && Second is null)
+			return Text ?? string.Empty;
+
+		string hh = Hour?.ToString("D2") ?? string.Empty;
+		string mm = Minute?.ToString("D2") ?? string.Empty;
+		string ss = Second?.ToString("D2") ?? string.Empty;
+		return $"{hh}:{mm}:{ss}";
+	}
+}

--- a/TRViS.LocationService/LonLatLocationService.cs
+++ b/TRViS.LocationService/LonLatLocationService.cs
@@ -25,11 +25,11 @@ public class LonLatLocationService : ILocationService
 		get => _CanUseService;
 		private set
 		{
+			locationServiceLogger.Info("CanUseService Set to: {0}", CanUseService);
 			if (value == _CanUseService)
 				return;
 
 			_CanUseService = value;
-			locationServiceLogger.Info("CanUseService Changed to: {0}", value);
 			CanUseServiceChanged?.Invoke(this, value);
 		}
 	}

--- a/TRViS.LocationService/LonLatLocationService.cs
+++ b/TRViS.LocationService/LonLatLocationService.cs
@@ -5,12 +5,19 @@ namespace TRViS.Services;
 
 public class LonLatLocationService : ILocationService
 {
+	private readonly NLog.Logger locationServiceLogger;
 	public bool IsEnabled { get; set; }
 	public event EventHandler<LocationStateChangedEventArgs>? LocationStateChanged;
 
 	const int CURRENT_STATION_INDEX_NOT_SET = -1;
 	const int DISTANCE_HISTORY_QUEUE_SIZE = 3;
 	readonly Queue<double> DistanceHistoryQueue = new(DISTANCE_HISTORY_QUEUE_SIZE);
+
+	public LonLatLocationService(NLog.Logger logger)
+	{
+		locationServiceLogger = logger;
+		locationServiceLogger.Info("LonLatLocationService Created");
+	}
 
 	private bool _CanUseService = false;
 	public bool CanUseService
@@ -22,6 +29,7 @@ public class LonLatLocationService : ILocationService
 				return;
 
 			_CanUseService = value;
+			locationServiceLogger.Info("CanUseService Changed to: {0}", value);
 			CanUseServiceChanged?.Invoke(this, value);
 		}
 	}
@@ -37,6 +45,18 @@ public class LonLatLocationService : ILocationService
 				return;
 
 			_staLocationInfo = value;
+			if (value is null)
+			{
+				locationServiceLogger.Info("StaLocationInfo Changed to: null");
+			}
+			else
+			{
+				locationServiceLogger.Info("StaLocationInfo Changed to length: {0}", value.Length);
+				for (int i = 0; i < value.Length; i++)
+				{
+					locationServiceLogger.Info("StaLocationInfo[{0}]: {1}", i, _staLocationInfo?[i]);
+				}
+			}
 			CanUseService = _staLocationInfo?.Any(static v => v.HasLonLatLocation) ?? false;
 			ResetLocationInfo();
 		}
@@ -53,6 +73,8 @@ public class LonLatLocationService : ILocationService
 		CurrentStationIndex = GetNextStationIndex(StaLocationInfo ?? Array.Empty<StaLocationInfo>(), CURRENT_STATION_INDEX_NOT_SET);
 		IsRunningToNextStation = false;
 		DistanceHistoryQueue.Clear();
+
+		locationServiceLogger.Info("ResetLocationInfo: CurrentStationIndex: {0}, IsRunningToNextStation: {1}", CurrentStationIndex, IsRunningToNextStation);
 
 		if (invokeEvent)
 		{
@@ -87,12 +109,14 @@ public class LonLatLocationService : ILocationService
 	{
 		if (!CanUseService)
 		{
+			locationServiceLogger.Error("ForceSetLocationInfo({0}, {1}): CanUseService is false", lat_deg, lon_deg);
 			return;
 		}
 
 		ResetLocationInfo(false);
 		if (StaLocationInfo is null)
 		{
+			locationServiceLogger.Error("ForceSetLocationInfo({0}, {1}): StaLocationInfo is null", lat_deg, lon_deg);
 			LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 			return;
 		}
@@ -105,6 +129,7 @@ public class LonLatLocationService : ILocationService
 				CurrentStationIndex = 0;
 			}
 
+			locationServiceLogger.Error("ForceSetLocationInfo({0}, {1}): StaLocationInfo.Length <= 1", lat_deg, lon_deg);
 			LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 			return;
 		}
@@ -115,6 +140,8 @@ public class LonLatLocationService : ILocationService
 				? Utils.CalculateDistance_m(lon_deg, lat_deg, v.Location_lon_deg, v.Location_lat_deg)
 				: double.NaN
 		).ToArray();
+
+		locationServiceLogger.Info("ForceSetLocationInfo({0}, {1}): distanceArray: {2}", lat_deg, lon_deg, string.Join(", ", distanceArray));
 
 		int nearestStationIndex = CURRENT_STATION_INDEX_NOT_SET;
 		int firstStationIndex = CURRENT_STATION_INDEX_NOT_SET;
@@ -139,6 +166,7 @@ public class LonLatLocationService : ILocationService
 		// 全ての駅で位置情報が設定されていない場合
 		if (nearestStationIndex < 0)
 		{
+			locationServiceLogger.Error("ForceSetLocationInfo({0}, {1}): All stations have no location information", lat_deg, lon_deg);
 			LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 			return;
 		}
@@ -146,6 +174,7 @@ public class LonLatLocationService : ILocationService
 		// 有効な駅が1つしかない場合
 		if (firstStationIndex == lastStationIndex)
 		{
+			locationServiceLogger.Warn("ForceSetLocationInfo({0}, {1}): Only one station has location information", lat_deg, lon_deg);
 			CurrentStationIndex = firstStationIndex;
 			IsRunningToNextStation = false;
 			LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
@@ -194,11 +223,13 @@ public class LonLatLocationService : ILocationService
 			}
 		}
 
+		locationServiceLogger.Info("ForceSetLocationInfo({0}, {1}) COMPLETE: CurrentStationIndex: {2}, IsRunningToNextStation: {3}", lat_deg, lon_deg, CurrentStationIndex, IsRunningToNextStation);
 		LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 	}
 
 	public void ForceSetLocationInfo(int stationIndex, bool isRunningToNextStation)
 	{
+		locationServiceLogger.Info("ForceSetLocationInfo(stationIndex: {0}, isRunningToNextStation: {1})", stationIndex, isRunningToNextStation);
 		if (!CanUseService)
 		{
 			return;
@@ -230,16 +261,17 @@ public class LonLatLocationService : ILocationService
 		LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 	}
 
-	double GetDistanceToStationAverage(in StaLocationInfo staLocationInfo, double lon_deg, double lat_deg)
+	double GetDistanceToStationAverage(double distanceToStation)
 	{
-		double distanceToStation = Utils.CalculateDistance_m(lon_deg, lat_deg, staLocationInfo.Location_lon_deg, staLocationInfo.Location_lat_deg);
-
 		if (DistanceHistoryQueue.Count == DISTANCE_HISTORY_QUEUE_SIZE)
 			DistanceHistoryQueue.Dequeue();
 		DistanceHistoryQueue.Enqueue(distanceToStation);
 
 		if (DistanceHistoryQueue.Count < DISTANCE_HISTORY_QUEUE_SIZE)
+		{
+			locationServiceLogger.Debug("GetDistanceToStationAverage({0}): DistanceHistoryQueue.Count < {1}", distanceToStation, DISTANCE_HISTORY_QUEUE_SIZE);
 			return double.NaN;
+		}
 
 		return DistanceHistoryQueue.Average();
 	}
@@ -254,7 +286,10 @@ public class LonLatLocationService : ILocationService
 	public double SetCurrentLocation(double lon_deg, double lat_deg)
 	{
 		if (!CanUseService || StaLocationInfo is null || CurrentStationIndex < 0 || StaLocationInfo.Length <= CurrentStationIndex)
+		{
+			locationServiceLogger.Error("SetCurrentLocation({0}, {1}): CanUseService is false or StaLocationInfo is null or CurrentStationIndex is invalid", lat_deg, lon_deg);
 			return double.NaN;
+		}
 
 		double distance = double.NaN;
 		if (IsRunningToNextStation)
@@ -264,12 +299,14 @@ public class LonLatLocationService : ILocationService
 			int nextStationIndex = GetNextStationIndex(StaLocationInfo, CurrentStationIndex);
 			if (nextStationIndex < 0)
 			{
+				locationServiceLogger.Error("SetCurrentLocation({0}, {1}): IsRunningToNextStation=true: Next station index is invalid", lat_deg, lon_deg);
 				// 入るはずはないけども、念のため。
 				return double.NaN;
 			}
 			StaLocationInfo nextStation = StaLocationInfo[nextStationIndex];
 			distance = Utils.CalculateDistance_m(nextStation, new LocationLonLat_deg(lon_deg, lat_deg));
-			double distanceToNextStationAverage = GetDistanceToStationAverage(nextStation, lon_deg, lat_deg);
+			double distanceToNextStationAverage = GetDistanceToStationAverage(distance);
+			locationServiceLogger.Info("SetCurrentLocation({0}, {1}): IsRunningToNextStation=true: nextStation={2}, distance={3}, distanceToNextStationAverage={4}", lat_deg, lon_deg, nextStation, distance, distanceToNextStationAverage);
 
 			if (!double.IsNaN(distanceToNextStationAverage)
 				&& Utils.IsNearBy(nextStation, distanceToNextStationAverage))
@@ -277,6 +314,7 @@ public class LonLatLocationService : ILocationService
 				DistanceHistoryQueue.Clear();
 				CurrentStationIndex = nextStationIndex;
 				IsRunningToNextStation = false;
+				locationServiceLogger.Info("SetCurrentLocation({0}, {1}): IsRunningToNextStation=true: Arrived at next station: CurrentStationIndex={2}", lat_deg, lon_deg, CurrentStationIndex);
 				LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 			}
 		}
@@ -285,12 +323,14 @@ public class LonLatLocationService : ILocationService
 			StaLocationInfo currentStation = StaLocationInfo[CurrentStationIndex];
 
 			distance = Utils.CalculateDistance_m(currentStation, new LocationLonLat_deg(lon_deg, lat_deg));
-			double distanceFromCurrentStationAverage = GetDistanceToStationAverage(currentStation, lon_deg, lat_deg);
+			double distanceFromCurrentStationAverage = GetDistanceToStationAverage(distance);
+			locationServiceLogger.Info("SetCurrentLocation({0}, {1}): IsRunningToNextStation=false: currentStation={2}, distance={3}, distanceFromCurrentStationAverage={4}", lat_deg, lon_deg, currentStation, distance, distanceFromCurrentStationAverage);
 			if (!double.IsNaN(distanceFromCurrentStationAverage)
 				&& Utils.IsLeaved(currentStation, distanceFromCurrentStationAverage))
 			{
 				DistanceHistoryQueue.Clear();
 				IsRunningToNextStation = true;
+				locationServiceLogger.Info("SetCurrentLocation({0}, {1}): IsRunningToNextStation=false: Departed from current station: CurrentStationIndex={2}", lat_deg, lon_deg, CurrentStationIndex);
 				LocationStateChanged?.Invoke(this, new(CurrentStationIndex, IsRunningToNextStation));
 			}
 		}

--- a/TRViS.LocationService/TRViS.LocationService.csproj
+++ b/TRViS.LocationService/TRViS.LocationService.csproj
@@ -10,5 +10,8 @@
 	<ItemGroup>
 		<ProjectReference Include="..\TRViS.ILocationService\TRViS.ILocationService.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="NLog" Version="5.4.0" />
+	</ItemGroup>
 
 </Project>

--- a/TRViS/App.xaml.cs
+++ b/TRViS/App.xaml.cs
@@ -2,7 +2,7 @@ namespace TRViS;
 
 public partial class App : Application
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	public App()
 	{

--- a/TRViS/App.xaml.cs
+++ b/TRViS/App.xaml.cs
@@ -1,3 +1,5 @@
+using TRViS.Services;
+
 namespace TRViS;
 
 public partial class App : Application

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 
 using TRViS.FirebaseWrapper;
 using TRViS.RootPages;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS;

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -12,7 +12,7 @@ namespace TRViS;
 
 public partial class AppShell : Shell
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	static public string AppVersionString
 		=> $"Version: {AppInfo.Current.VersionString}-{AppInfo.Current.BuildString}";

--- a/TRViS/Controls/HtmlAutoDetectLabel.cs
+++ b/TRViS/Controls/HtmlAutoDetectLabel.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+using TRViS.Services;
+
 namespace TRViS.Controls;
 
 public class HtmlAutoDetectLabel : Label

--- a/TRViS/Controls/HtmlAutoDetectLabel.cs
+++ b/TRViS/Controls/HtmlAutoDetectLabel.cs
@@ -4,7 +4,7 @@ namespace TRViS.Controls;
 
 public class HtmlAutoDetectLabel : Label
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public AppThemeColorBindingExtension? CurrentAppThemeColorBindingExtension { get; set; }
 	public Color? LastTextColor { get; private set; }
 

--- a/TRViS/Controls/MyMap/MyMap.android.cs
+++ b/TRViS/Controls/MyMap/MyMap.android.cs
@@ -1,0 +1,21 @@
+#if ANDROID
+namespace TRViS.Controls;
+
+public class MyMap : MyMapBase
+{
+	public MyMap()
+	{
+		Content = new Label()
+		{
+			Text = "MyMap is not implemented on Android",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+	}
+
+	public override void SetIsLocationServiceEnabled(bool isEnabled) {}
+	public override void SetCurrentLocation(double latitude, double longitude, double accuracy_m) {}
+	public override void SetTimetableRowList(TimetableRow[]? Rows) {}
+}
+
+#endif

--- a/TRViS/Controls/MyMap/MyMap.apple.cs
+++ b/TRViS/Controls/MyMap/MyMap.apple.cs
@@ -1,0 +1,155 @@
+#if IOS || MACCATALYST
+using System.Text;
+
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Layouts;
+using Microsoft.Maui.Maps;
+
+using TRViS.IO.Models;
+using TRViS.Services;
+
+namespace TRViS.Controls;
+
+public class MyMap : MyMapBase
+{
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
+
+	readonly Microsoft.Maui.Controls.Maps.Map map;
+
+	public MyMap()
+	{
+		logger.Trace("MyMap Creating");
+
+		Location centerLocation = new(35.681111, 139.766667); // Tokyo Station
+		map = new(MapSpan.FromCenterAndRadius(centerLocation, Distance.FromMeters(500)))
+		{
+			IsShowingUser = false,
+			MapType = MapType.Street,
+		};
+
+		// ボタン等を追加する準備
+		AbsoluteLayout views = [
+			map,
+		];
+		AbsoluteLayout.SetLayoutFlags(map, AbsoluteLayoutFlags.All);
+		AbsoluteLayout.SetLayoutBounds(map, new Rect(0, 0, 1, 1));
+		Content = views;
+		ZIndex = 1;
+
+		logger.Trace("MyMap Created");
+	}
+
+	Circle? currentLocationCircle;
+	public override void SetCurrentLocation(double latitude, double longitude, double accuracy_m)
+	{
+		logger.Trace("SetCurrentLocation(lat={0}, lon={1}, acc={2})", latitude, longitude, accuracy_m);
+		if (currentLocationCircle is null)
+		{
+			logger.Warn("SetCurrentLocation() called before SetIsLocationServiceEnabled()");
+			return;
+		}
+
+		MainThread.BeginInvokeOnMainThread(() =>
+		{
+			currentLocationCircle.Center = new Location(latitude, longitude);
+			currentLocationCircle.Radius = Distance.FromMeters(accuracy_m);
+			map.MoveToRegion(MapSpan.FromCenterAndRadius(new Location(latitude, longitude), map.VisibleRegion?.Radius ?? Distance.FromMeters(500)));
+		});
+	}
+
+	public override void SetIsLocationServiceEnabled(bool isEnabled)
+	{
+		logger.Trace("SetIsLocationServiceEnabled({0})", isEnabled);
+		if (isEnabled)
+		{
+			if (currentLocationCircle is not null)
+			{
+				return;
+			}
+			currentLocationCircle = new()
+			{
+				Center = new Location(0, 0),
+				Radius = Distance.FromMeters(0),
+				StrokeColor = Colors.Blue,
+				FillColor = Colors.Blue.WithAlpha(0.2f),
+				StrokeWidth = 2,
+			};
+			map.MapElements.Add(currentLocationCircle);
+		}
+		else
+		{
+			if (currentLocationCircle is not null)
+			{
+				map.MapElements.Remove(currentLocationCircle);
+				currentLocationCircle = null;
+			}
+		}
+	}
+
+	public override void SetTimetableRowList(TimetableRow[]? Rows)
+	{
+		logger.Trace("SetTimetableRowList({0})", Rows?.Length ?? 0);
+		map.Pins.Clear();
+		map.MapElements.Clear();
+		if (Rows is null || Rows.Length == 0)
+		{
+			return;
+		}
+		Location? firstLocation = null;
+		double firstLocationOnStationDetectRadius_m = 0;
+		for (int i = 0; i < Rows.Length; i++)
+		{
+			TimetableRow row = Rows[i];
+			if (row.Location.Latitude_deg is null || row.Location.Longitude_deg is null)
+			{
+				continue;
+			}
+
+			Location location = new(row.Location.Latitude_deg.Value, row.Location.Longitude_deg.Value);
+			double onStationDetectRadius_m = row.Location.OnStationDetectRadius_m ?? StaLocationInfo.DefaultNearbyRadius_m;
+			if (firstLocation is null)
+			{
+				firstLocation = location;
+				firstLocationOnStationDetectRadius_m = onStationDetectRadius_m;
+			}
+
+			StringBuilder sb = new();
+			sb.Append("Index: ").Append(i);
+			sb.AppendLine();
+			sb.Append("ID: ").Append(row.Id);
+			sb.AppendLine();
+			sb.Append("(lat:").Append(location.Latitude).Append(", lon:").Append(location.Longitude).Append(')');
+			sb.AppendLine();
+			sb.Append("Arr: ").Append(row.ArriveTime?.GetTimeString());
+			sb.AppendLine();
+			sb.Append("Dep: ").Append(row.DepartureTime?.GetTimeString());
+			sb.AppendLine();
+			sb.Append("Radius_m: ").Append(onStationDetectRadius_m);
+			Pin pin = new()
+			{
+				Label = row.StationName,
+				Address = sb.ToString(),
+				Location = location,
+				Type = PinType.Place,
+			};
+			map.Pins.Add(pin);
+
+			Circle circle = new()
+			{
+				Center = location,
+				Radius = Distance.FromMeters(onStationDetectRadius_m),
+				StrokeColor = Colors.Red,
+				FillColor = Colors.Red.WithAlpha(0.2f),
+				StrokeWidth = 2,
+			};
+			map.MapElements.Add(circle);
+		}
+		if (firstLocation is not null)
+		{
+			double radius = Math.Max(firstLocationOnStationDetectRadius_m * 2, 500);
+			map.MoveToRegion(MapSpan.FromCenterAndRadius(firstLocation, Distance.FromMeters(radius)));
+		}
+	}
+}
+
+#endif

--- a/TRViS/Controls/MyMap/MyMap.windows.cs
+++ b/TRViS/Controls/MyMap/MyMap.windows.cs
@@ -1,0 +1,21 @@
+#if WINDOWS
+namespace TRViS.Controls;
+
+public class MyMap : MyMapBase
+{
+	public MyMap()
+	{
+		Content = new Label()
+		{
+			Text = "MyMap is not implemented on Windows",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+	}
+
+	public override void SetIsLocationServiceEnabled(bool isEnabled) {}
+	public override void SetCurrentLocation(double latitude, double longitude, double accuracy_m) {}
+	public override void SetTimetableRowList(TimetableRow[]? Rows) {}
+}
+
+#endif

--- a/TRViS/Controls/MyMap/MyMapBase.cs
+++ b/TRViS/Controls/MyMap/MyMapBase.cs
@@ -1,0 +1,10 @@
+using TRViS.IO.Models;
+
+namespace TRViS.Controls;
+
+public abstract class MyMapBase : ContentView
+{
+	public abstract void SetIsLocationServiceEnabled(bool isEnabled);
+	public abstract void SetCurrentLocation(double latitude, double longitude, double accuracy_m);
+	public abstract void SetTimetableRowList(TimetableRow[]? Rows);
+}

--- a/TRViS/Controls/SimpleMarkdownLabel.cs
+++ b/TRViS/Controls/SimpleMarkdownLabel.cs
@@ -1,7 +1,8 @@
-using System.Runtime.CompilerServices;
 using System.Text;
 
 using DependencyPropertyGenerator;
+
+using TRViS.Services;
 
 namespace TRViS.Controls;
 

--- a/TRViS/Controls/SimpleMarkdownLabel.cs
+++ b/TRViS/Controls/SimpleMarkdownLabel.cs
@@ -8,7 +8,7 @@ namespace TRViS.Controls;
 [DependencyProperty<string>("MarkdownFileContent")]
 public partial class SimpleMarkdownLabel : Label
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	const int H0_FONT_SIZE = 28;
 	const int HEADER_FONT_SIZE_STEP = 3;

--- a/TRViS/Controls/SimpleMarkdownView.cs
+++ b/TRViS/Controls/SimpleMarkdownView.cs
@@ -1,5 +1,7 @@
 using DependencyPropertyGenerator;
 
+using TRViS.Services;
+
 namespace TRViS.Controls;
 
 [DependencyProperty<ResourceManager.AssetName>("FileName", DefaultValue = ResourceManager.AssetName.UNKNOWN)]

--- a/TRViS/Controls/SimpleMarkdownView.cs
+++ b/TRViS/Controls/SimpleMarkdownView.cs
@@ -5,7 +5,7 @@ namespace TRViS.Controls;
 [DependencyProperty<ResourceManager.AssetName>("FileName", DefaultValue = ResourceManager.AssetName.UNKNOWN)]
 public partial class SimpleMarkdownView : ContentView
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	readonly SimpleMarkdownLabel markdownLabel;
 
 	ResourceManager.AssetName currentFileName = ResourceManager.AssetName.UNKNOWN;

--- a/TRViS/Controls/ToggleButton.cs
+++ b/TRViS/Controls/ToggleButton.cs
@@ -1,5 +1,7 @@
 using DependencyPropertyGenerator;
 
+using TRViS.Services;
+
 namespace TRViS.Controls;
 
 [DependencyProperty<bool>("IsChecked", DefaultBindingMode = DefaultBindingMode.TwoWay)]

--- a/TRViS/Controls/ToggleButton.cs
+++ b/TRViS/Controls/ToggleButton.cs
@@ -6,7 +6,7 @@ namespace TRViS.Controls;
 [DependencyProperty<bool>("IsRadio", DefaultBindingMode = DefaultBindingMode.OneWay)]
 public partial class ToggleButton : ContentView
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public EventHandler<ValueChangedEventArgs<bool>>? IsCheckedChanged;
 
 	public ToggleButton()

--- a/TRViS/DTAC/HakoParts/HeaderView.cs
+++ b/TRViS/DTAC/HakoParts/HeaderView.cs
@@ -1,71 +1,73 @@
+using TRViS.Services;
+
 namespace TRViS.DTAC.HakoParts;
 
 public class HeaderView : Grid
 {
-  private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
-  readonly ColumnDefinition EdgeColumnDefinition = new(0);
+	readonly ColumnDefinition EdgeColumnDefinition = new(0);
 
-  readonly BoxView backgroundBoxView = new();
+	readonly BoxView backgroundBoxView = new();
 
-  readonly Label leftEdgeLabel = DTACElementStyles.HeaderLabelStyle<Label>();
-  readonly Label rightEdgeLabel = DTACElementStyles.HeaderLabelStyle<Label>();
+	readonly Label leftEdgeLabel = DTACElementStyles.HeaderLabelStyle<Label>();
+	readonly Label rightEdgeLabel = DTACElementStyles.HeaderLabelStyle<Label>();
 
-  public HeaderView()
-  {
-    logger.Debug("Creating...");
+	public HeaderView()
+	{
+		logger.Debug("Creating...");
 
-    ColumnDefinitions.Add(EdgeColumnDefinition);
-    ColumnDefinitions.Add(new(new(1, GridUnitType.Star)));
-    ColumnDefinitions.Add(EdgeColumnDefinition);
+		ColumnDefinitions.Add(EdgeColumnDefinition);
+		ColumnDefinitions.Add(new(new(1, GridUnitType.Star)));
+		ColumnDefinitions.Add(EdgeColumnDefinition);
 
-    DTACElementStyles.HeaderBackgroundColor.Apply(backgroundBoxView, BoxView.ColorProperty);
-    Grid.SetColumnSpan(backgroundBoxView, 3);
-    backgroundBoxView.Margin = new(-100, 0);
-    backgroundBoxView.Shadow = new()
-    {
-      Brush = Colors.Black,
-      Offset = new(0, 1),
-      Radius = 1,
-      Opacity = 0.4f,
-    };
-    Children.Add(backgroundBoxView);
+		DTACElementStyles.HeaderBackgroundColor.Apply(backgroundBoxView, BoxView.ColorProperty);
+		Grid.SetColumnSpan(backgroundBoxView, 3);
+		backgroundBoxView.Margin = new(-100, 0);
+		backgroundBoxView.Shadow = new()
+		{
+			Brush = Colors.Black,
+			Offset = new(0, 1),
+			Radius = 1,
+			Opacity = 0.4f,
+		};
+		Children.Add(backgroundBoxView);
 
-    Grid.SetColumn(leftEdgeLabel, 0);
-    Children.Add(leftEdgeLabel);
-    Grid.SetColumn(rightEdgeLabel, 2);
-    Children.Add(rightEdgeLabel);
+		Grid.SetColumn(leftEdgeLabel, 0);
+		Children.Add(leftEdgeLabel);
+		Grid.SetColumn(rightEdgeLabel, 2);
+		Children.Add(rightEdgeLabel);
 
-    logger.Debug("Created");
-  }
+		logger.Debug("Created");
+	}
 
-  public double EdgeWidth
-  {
-    get => EdgeColumnDefinition.Width.Value;
-    set
-    {
-      logger.Debug("value: {0} -> {0}", EdgeColumnDefinition.Width.Value, value);
-      EdgeColumnDefinition.Width = new(value, GridUnitType.Absolute);
-    }
-  }
+	public double EdgeWidth
+	{
+		get => EdgeColumnDefinition.Width.Value;
+		set
+		{
+			logger.Debug("value: {0} -> {0}", EdgeColumnDefinition.Width.Value, value);
+			EdgeColumnDefinition.Width = new(value, GridUnitType.Absolute);
+		}
+	}
 
-  public string? LeftEdgeText
-  {
-    get => leftEdgeLabel.Text;
-    set
-    {
-      logger.Debug("value: {0} -> {0}", leftEdgeLabel.Text, value);
-      leftEdgeLabel.Text = value;
-    }
-  }
+	public string? LeftEdgeText
+	{
+		get => leftEdgeLabel.Text;
+		set
+		{
+			logger.Debug("value: {0} -> {0}", leftEdgeLabel.Text, value);
+			leftEdgeLabel.Text = value;
+		}
+	}
 
-  public string? RightEdgeText
-  {
-    get => rightEdgeLabel.Text;
-    set
-    {
-      logger.Debug("value: {0} -> {0}", rightEdgeLabel.Text, value);
-      rightEdgeLabel.Text = value;
-    }
-  }
+	public string? RightEdgeText
+	{
+		get => rightEdgeLabel.Text;
+		set
+		{
+			logger.Debug("value: {0} -> {0}", rightEdgeLabel.Text, value);
+			rightEdgeLabel.Text = value;
+		}
+	}
 }

--- a/TRViS/DTAC/HakoParts/HeaderView.cs
+++ b/TRViS/DTAC/HakoParts/HeaderView.cs
@@ -2,7 +2,7 @@ namespace TRViS.DTAC.HakoParts;
 
 public class HeaderView : Grid
 {
-  private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+  private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
   readonly ColumnDefinition EdgeColumnDefinition = new(0);
 

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -2,6 +2,7 @@ using Microsoft.Maui.Controls.Shapes;
 
 using TRViS.Controls;
 using TRViS.IO.Models;
+using TRViS.Services;
 
 namespace TRViS.DTAC.HakoParts;
 

--- a/TRViS/DTAC/HakoParts/SimpleRow.cs
+++ b/TRViS/DTAC/HakoParts/SimpleRow.cs
@@ -7,7 +7,7 @@ namespace TRViS.DTAC.HakoParts;
 
 public partial class SimpleRow
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	static readonly Thickness StaNameTrainNumButtonMargin = new(0, 4);
 	static readonly Thickness TrainNumButtonPadding = new(32, 4);
@@ -228,13 +228,15 @@ public partial class SimpleRow
 		FormattedString fs = new();
 
 		double baseTextSize = TimeLabelFontSize_HHMM;
-		fs.Spans.Add(new(){
+		fs.Spans.Add(new()
+		{
 			Text = $"{value.Hour:00}:{value.Minute:00}",
 			FontAttributes = FontAttributes.Bold,
 			FontSize = baseTextSize,
 			FontAutoScalingEnabled = false,
 		});
-		fs.Spans.Add(new(){
+		fs.Spans.Add(new()
+		{
 			Text = value.Second?.ToString("00"),
 			FontSize = TimeLabelFontSize_SS,
 			FontAutoScalingEnabled = false,

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -7,7 +7,7 @@ namespace TRViS.DTAC.HakoParts;
 
 public class SimpleView : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	public const double STA_NAME_TIME_COLUMN_WIDTH = 120;
 	const double TRAIN_NUMBER_ROW_HEIGHT = 72;

--- a/TRViS/DTAC/HakoParts/SimpleView.cs
+++ b/TRViS/DTAC/HakoParts/SimpleView.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 
 using TRViS.IO;
 using TRViS.IO.Models;
+using TRViS.Services;
 
 namespace TRViS.DTAC.HakoParts;
 

--- a/TRViS/DTAC/OpenCloseButton.cs
+++ b/TRViS/DTAC/OpenCloseButton.cs
@@ -1,5 +1,7 @@
 using DependencyPropertyGenerator;
 
+using TRViS.Services;
+
 namespace TRViS.DTAC;
 
 [DependencyProperty<bool>("IsOpen", DefaultBindingMode = DefaultBindingMode.TwoWay)]

--- a/TRViS/DTAC/OpenCloseButton.cs
+++ b/TRViS/DTAC/OpenCloseButton.cs
@@ -7,7 +7,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("TextWhenClosed")]
 public partial class OpenCloseButton : Button
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public event EventHandler<ValueChangedEventArgs<bool>>? IsOpenChanged;
 
 	public OpenCloseButton()

--- a/TRViS/DTAC/PageParts/Hako.xaml.cs
+++ b/TRViS/DTAC/PageParts/Hako.xaml.cs
@@ -9,7 +9,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("WorkSpaceName")]
 public partial class Hako : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	readonly HeaderView headerView = new();
 

--- a/TRViS/DTAC/PageParts/Hako.xaml.cs
+++ b/TRViS/DTAC/PageParts/Hako.xaml.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.DTAC.HakoParts;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/PageParts/Remarks.xaml.cs
+++ b/TRViS/DTAC/PageParts/Remarks.xaml.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/PageParts/Remarks.xaml.cs
+++ b/TRViS/DTAC/PageParts/Remarks.xaml.cs
@@ -10,7 +10,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<double>("BottomSafeAreaHeight")]
 public partial class Remarks : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public const double HEADER_HEIGHT = 64;
 	const double DEFAULT_CONTENT_AREA_HEIGHT = 256;
 	double BottomMargin

--- a/TRViS/DTAC/PageParts/TabButton.xaml.cs
+++ b/TRViS/DTAC/PageParts/TabButton.xaml.cs
@@ -13,7 +13,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("Text")]
 public partial class TabButton : ContentView
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public static readonly Color BASE_COLOR_DISABLED = new(0xDD, 0xDD, 0xDD);
 
 	public static readonly double NORMAL_MODE_WIDTH = 152;

--- a/TRViS/DTAC/PageParts/TabButton.xaml.cs
+++ b/TRViS/DTAC/PageParts/TabButton.xaml.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 
 using DependencyPropertyGenerator;
 
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/PageParts/WithRemarksView.cs
+++ b/TRViS/DTAC/PageParts/WithRemarksView.cs
@@ -1,4 +1,5 @@
 ﻿using DependencyPropertyGenerator;
+
 using TRViS.IO.Models;
 
 namespace TRViS.DTAC;
@@ -8,7 +9,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<IHasRemarksProperty>("RemarksData")]
 public partial class WithRemarksView : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	Remarks RemarksView { get; } = new();
 	RowDefinition RemarksAreaRowDefinition { get; } = new(new(Remarks.HEADER_HEIGHT, GridUnitType.Absolute));
 

--- a/TRViS/DTAC/PageParts/WithRemarksView.cs
+++ b/TRViS/DTAC/PageParts/WithRemarksView.cs
@@ -1,6 +1,7 @@
 ﻿using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/AfterRemarks.cs
+++ b/TRViS/DTAC/TimetableParts/AfterRemarks.cs
@@ -1,4 +1,5 @@
 using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/AfterRemarks.cs
+++ b/TRViS/DTAC/TimetableParts/AfterRemarks.cs
@@ -4,7 +4,7 @@ namespace TRViS.DTAC;
 
 public class AfterRemarks
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	readonly Grid Parent;
 
 	public AfterRemarks(Grid Parent)

--- a/TRViS/DTAC/TimetableParts/BeforeDeparture_AfterArrive.cs
+++ b/TRViS/DTAC/TimetableParts/BeforeDeparture_AfterArrive.cs
@@ -1,6 +1,5 @@
-using Microsoft.Maui.Controls.Shapes;
-
 using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/BeforeDeparture_AfterArrive.cs
+++ b/TRViS/DTAC/TimetableParts/BeforeDeparture_AfterArrive.cs
@@ -6,7 +6,7 @@ namespace TRViS.DTAC;
 
 public class BeforeDeparture_AfterArrive
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public readonly RowDefinition RowDefinition = new(DTACElementStyles.BeforeDeparture_AfterArrive_Height);
 
 	readonly BoxView HeaderBoxView = new()

--- a/TRViS/DTAC/TimetableParts/LocationServiceButton.cs
+++ b/TRViS/DTAC/TimetableParts/LocationServiceButton.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Shapes;
 
 using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/LocationServiceButton.cs
+++ b/TRViS/DTAC/TimetableParts/LocationServiceButton.cs
@@ -8,7 +8,7 @@ namespace TRViS.DTAC;
 
 public class LocationServiceButton : ToggleButton
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	const float CornerRadius = 5;
 	const float SelectedRectMargin = 2;
 	const float SelectedRectThickness = 1;

--- a/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Maui.Views;
 
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
@@ -7,7 +7,7 @@ namespace TRViS.DTAC;
 public partial class MarkerButton : Border
 {
 	DTACMarkerViewModel MarkerSettings { get; }
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public MarkerButton()
 	{
 		logger.Trace("Creating...");

--- a/TRViS/DTAC/TimetableParts/NextTrainButton.cs
+++ b/TRViS/DTAC/TimetableParts/NextTrainButton.cs
@@ -4,7 +4,7 @@ namespace TRViS.DTAC.TimetableParts;
 
 public class NextTrainButton : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	readonly Button _NextTrainButton = new()
 	{
 		FontFamily = DTACElementStyles.DefaultFontFamily,

--- a/TRViS/DTAC/TimetableParts/NextTrainButton.cs
+++ b/TRViS/DTAC/TimetableParts/NextTrainButton.cs
@@ -1,4 +1,5 @@
 using TRViS.IO.Models;
+using TRViS.Services;
 
 namespace TRViS.DTAC.TimetableParts;
 

--- a/TRViS/DTAC/TimetableParts/PageHeader.cs
+++ b/TRViS/DTAC/TimetableParts/PageHeader.cs
@@ -6,7 +6,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<bool>("IsLocationServiceEnabled")]
 public partial class PageHeader : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	static readonly ColumnDefinitionCollection DefaultColumnDefinitions = new()
 	{
 		new ColumnDefinition(new GridLength(1, GridUnitType.Star)),
@@ -120,7 +120,7 @@ public partial class PageHeader : Grid
 	{
 		logger.Info("OpenCloseButton.IsOpen: {0}", newValue);
 		OpenCloseButton.IsOpen = newValue;
-	} 
+	}
 
 	private void OpenCloseButton_IsOpenChanged(object? sender, ValueChangedEventArgs<bool> e)
 	{

--- a/TRViS/DTAC/TimetableParts/PageHeader.cs
+++ b/TRViS/DTAC/TimetableParts/PageHeader.cs
@@ -1,5 +1,7 @@
 using DependencyPropertyGenerator;
 
+using TRViS.Services;
+
 namespace TRViS.DTAC;
 
 [DependencyProperty<bool>("IsOpen")]

--- a/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Maui.Views;
 
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml.cs
@@ -1,11 +1,12 @@
 using CommunityToolkit.Maui.Views;
+
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
 public partial class SelectMarkerPopup : Popup
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public SelectMarkerPopup() : this(InstanceManager.DTACMarkerViewModel) { }
 
 	public SelectMarkerPopup(DTACMarkerViewModel viewModel)

--- a/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml.cs
@@ -1,4 +1,5 @@
 using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/StartEndRunButton.xaml.cs
@@ -4,7 +4,7 @@ namespace TRViS.DTAC;
 
 public partial class StartEndRunButton : ToggleButton
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	static readonly Color GREEN = new(0, 0x80, 0);
 	static readonly Color GREEN_DARK = new(0, 0x70, 0);
 	const float BUTTON_LUMINOUS_DELTA = 0.05f;

--- a/TRViS/DTAC/TimetableParts/TimeCell.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/TimeCell.xaml.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/TimeCell.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/TimeCell.xaml.cs
@@ -1,4 +1,5 @@
 using DependencyPropertyGenerator;
+
 using TRViS.IO.Models;
 
 namespace TRViS.DTAC;
@@ -11,7 +12,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("HHMM", IsReadOnly = true)]
 public partial class TimeCell : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	public TimeCell()
 	{

--- a/TRViS/DTAC/TimetableParts/TimetableHeader.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/TimetableHeader.xaml.cs
@@ -1,5 +1,7 @@
 using DependencyPropertyGenerator;
 
+using TRViS.Services;
+
 namespace TRViS.DTAC;
 
 [DependencyProperty<double>("FontSize_Large")]

--- a/TRViS/DTAC/TimetableParts/TimetableHeader.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/TimetableHeader.xaml.cs
@@ -5,7 +5,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<double>("FontSize_Large")]
 public partial class TimetableHeader : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public TimetableHeader()
 	{
 		logger.Trace("Creating...");

--- a/TRViS/DTAC/TimetableParts/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TimetableParts/TrainInfo_BeforeDeparture.cs
@@ -6,7 +6,7 @@ namespace TRViS.DTAC;
 
 public partial class TrainInfo_BeforeDeparture : Grid
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	static readonly RowDefinitionCollection DefaultRowDefinitions = new()
 	{
 		new RowDefinition(DTACElementStyles.BeforeDeparture_AfterArrive_Height),

--- a/TRViS/DTAC/TimetableParts/TrainInfo_BeforeDeparture.cs
+++ b/TRViS/DTAC/TimetableParts/TrainInfo_BeforeDeparture.cs
@@ -1,6 +1,7 @@
 using Microsoft.Maui.Controls.Shapes;
 
 using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
@@ -6,7 +6,7 @@ namespace TRViS.DTAC;
 
 public partial class VerticalTimetableRow
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	const float BG_ALPHA = 0.3f;
 
 	public enum LocationStates

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
@@ -15,7 +15,7 @@ public partial class VerticalTimetableView : Grid
 		public double PositionY { get; } = PositionY;
 	}
 
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	static public readonly GridLength RowHeight = new(60);
 
 	public event EventHandler? IsBusyChanged;

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/TimetableParts/WorkAffix.cs
+++ b/TRViS/DTAC/TimetableParts/WorkAffix.cs
@@ -4,7 +4,7 @@ namespace TRViS.DTAC;
 
 public class WorkAffix : ContentView
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public WorkAffix()
 	{
 		logger.Trace("Creating...");

--- a/TRViS/DTAC/TimetableParts/WorkAffix.cs
+++ b/TRViS/DTAC/TimetableParts/WorkAffix.cs
@@ -1,4 +1,4 @@
-using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.DTAC;
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -9,7 +9,7 @@ namespace TRViS.DTAC;
 [DependencyProperty<string>("AffectDate")]
 public partial class VerticalStylePage : ContentView
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public const double DATE_AND_START_BUTTON_ROW_HEIGHT = 60;
 	const double TRAIN_INFO_HEADER_ROW_HEIGHT = 54;
 	const double TRAIN_INFO_ROW_HEIGHT = 54;

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.IO.Models;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 
 using TRViS.IO.Models;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.DTAC;

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -7,7 +7,7 @@ namespace TRViS.DTAC;
 
 public partial class ViewHost : ContentPage
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	static public readonly double TITLE_VIEW_HEIGHT = 50;
 	public const string CHANGE_THEME_BUTTON_TEXT_TO_LIGHT = "\xe518";
 	public const string CHANGE_THEME_BUTTON_TEXT_TO_DARK = "\xe51c";

--- a/TRViS/FirebaseWrapper/AnalyticsWrapper.cs
+++ b/TRViS/FirebaseWrapper/AnalyticsWrapper.cs
@@ -14,7 +14,7 @@ public interface IAnalyticsWrapper
 // ref: https://learn.microsoft.com/en-au/answers/questions/2125319/firebase-analytics-not-logging-events-in-maui-net9
 public class AnalyticsWrapper : IAnalyticsWrapper
 {
-	static readonly Logger logger = LogManager.GetCurrentClassLogger();
+	static readonly Logger logger = LoggerService.GetGeneralLogger();
 
 	public void SetIsEnabled(bool isEnabled)
 	{

--- a/TRViS/FirebaseWrapper/AnalyticsWrapper.cs
+++ b/TRViS/FirebaseWrapper/AnalyticsWrapper.cs
@@ -1,5 +1,7 @@
 using NLog;
 
+using TRViS.Services;
+
 namespace TRViS.FirebaseWrapper;
 
 public interface IAnalyticsWrapper

--- a/TRViS/FirebaseWrapper/CrashlysticsWrapper.cs
+++ b/TRViS/FirebaseWrapper/CrashlysticsWrapper.cs
@@ -1,5 +1,7 @@
 using NLog;
 
+using TRViS.Services;
+
 namespace TRViS.FirebaseWrapper;
 
 public interface ICrashlyticsWrapper

--- a/TRViS/FirebaseWrapper/CrashlysticsWrapper.cs
+++ b/TRViS/FirebaseWrapper/CrashlysticsWrapper.cs
@@ -10,7 +10,7 @@ public interface ICrashlyticsWrapper
 
 public class CrashlyticsWrapper : ICrashlyticsWrapper
 {
-	static readonly Logger logger = LogManager.GetCurrentClassLogger();
+	static readonly Logger logger = LoggerService.GetGeneralLogger();
 
 	public void Log(Exception ex, string? message)
 	{

--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -23,7 +23,7 @@ public static class MauiProgram
 		CrashLogFilePath = Path.Combine(DirectoryPathProvider.CrashLogFileDirectory.FullName, CrashLogFileName);
 
 		LoggerService.SetupLoggerService();
-		logger = LogManager.GetCurrentClassLogger();
+		logger = LoggerService.GetGeneralLogger();
 	}
 
 	public static MauiApp CreateMauiApp()

--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -37,6 +37,7 @@ public static class MauiProgram
 			{
 				handlers.AddHandler<Shell, HideShellTabRenderer>();
 			})
+			.UseMauiMaps()
 #endif
 			.ConfigureFonts(static fonts =>
 			{

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+
 using TRViS.ViewModels;
 
 namespace TRViS.MyAppCustomizables;
@@ -11,8 +12,8 @@ public partial class SettingFileStructure
 {
 	[JsonSourceGenerationOptions(WriteIndented = true)]
 	[JsonSerializable(typeof(SettingFileStructure))]
-	internal partial class SourceGenerationContext : JsonSerializerContext {}
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	internal partial class SourceGenerationContext : JsonSerializerContext { }
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	/// <summary>
 	/// タイトルバーの背景色

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.MyAppCustomizables;

--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -45,6 +45,11 @@ public partial class SettingFileStructure
 	/// </summary>
 	public AppTheme? InitialTheme { get; set; } = AppTheme.Unspecified;
 
+	/// <summary>
+	/// 端末を横向きにした際に地図を表示するかどうか (位置情報デバッグ用)
+	/// </summary>
+	public bool ShowMapWhenLandscape { get; set; } = false;
+
 	public override string ToString()
 	{
 		return
@@ -53,6 +58,7 @@ public partial class SettingFileStructure
 			+ $"MarkerTexts: {MarkerTexts},"
 			+ $"LocationServiceInterval: {LocationServiceInterval_Seconds}[s],"
 			+ $"InitialTheme: {InitialTheme},"
+			+ $"ShowMapWhenLandscape: {ShowMapWhenLandscape}"
 		;
 	}
 
@@ -67,6 +73,7 @@ public partial class SettingFileStructure
 			&& MarkerTexts.Equals(v.MarkerTexts)
 			&& LocationServiceInterval_Seconds.Equals(v.LocationServiceInterval_Seconds)
 			&& InitialTheme.Equals(v.InitialTheme)
+			&& ShowMapWhenLandscape.Equals(v.ShowMapWhenLandscape)
 		;
 	}
 
@@ -74,7 +81,7 @@ public partial class SettingFileStructure
 		=> Equals(obj as SettingFileStructure);
 
 	public override int GetHashCode()
-		=> HashCode.Combine(TitleColor, MarkerColors, MarkerTexts, LocationServiceInterval_Seconds, InitialTheme);
+		=> HashCode.Combine(TitleColor, MarkerColors, MarkerTexts, LocationServiceInterval_Seconds, InitialTheme, ShowMapWhenLandscape);
 
 	#region Loaders
 

--- a/TRViS/ResourceManager.cs
+++ b/TRViS/ResourceManager.cs
@@ -1,3 +1,5 @@
+using TRViS.Services;
+
 namespace TRViS;
 
 public class ResourceManager

--- a/TRViS/ResourceManager.cs
+++ b/TRViS/ResourceManager.cs
@@ -2,7 +2,7 @@ namespace TRViS;
 
 public class ResourceManager
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	public static ResourceManager Current { get; } = new();
 
 	public enum AssetName

--- a/TRViS/RootPages/EasterEggPage.xaml
+++ b/TRViS/RootPages/EasterEggPage.xaml
@@ -12,21 +12,39 @@
 			<converters:DoubleToIntConverter x:Key="DoubleToIntConverter"/>
 
 			<Style TargetType="Slider">
-				<Setter Property="Minimum" Value="0"/>
-				<Setter Property="Maximum" Value="255"/>
-				<Setter Property="Margin" Value="4"/>
+				<Setter
+					Property="Minimum"
+					Value="0"/>
+				<Setter
+					Property="Maximum"
+					Value="255"/>
+				<Setter
+					Property="Margin"
+					Value="4"/>
 			</Style>
 
 			<Style TargetType="Border">
-				<Setter Property="Margin" Value="8"/>
-				<Setter Property="Padding" Value="8"/>
-				<Setter Property="Stroke" Value="{AppThemeBinding Default=Black,Dark=White}"/>
+				<Setter
+					Property="Margin"
+					Value="8"/>
+				<Setter
+					Property="Padding"
+					Value="8"/>
+				<Setter
+					Property="Stroke"
+					Value="{AppThemeBinding Default=Black,Dark=White}"/>
 			</Style>
 
 			<Style TargetType="Button">
-				<Setter Property="Margin" Value="8"/>
-				<Setter Property="Padding" Value="8"/>
-				<Setter Property="LineBreakMode" Value="WordWrap" />
+				<Setter
+					Property="Margin"
+					Value="8"/>
+				<Setter
+					Property="Padding"
+					Value="8"/>
+				<Setter
+					Property="LineBreakMode"
+					Value="WordWrap"/>
 			</Style>
 		</ResourceDictionary>
 	</ContentPage.Resources>
@@ -38,23 +56,19 @@
 				HorizontalOptions="Start">
 				<Button
 					Text="Load from..."
-					Clicked="OnLoadFromPickerClicked"
-				/>
+					Clicked="OnLoadFromPickerClicked"/>
 				<Button
 					Text="Save to..."
-					Clicked="OnSaveToPickerClicked"
-				/>
+					Clicked="OnSaveToPickerClicked"/>
 			</HorizontalStackLayout>
 			<HorizontalStackLayout
 				HorizontalOptions="End">
 				<Button
 					Text="Reload Saved"
-					Clicked="OnReloadSavedClicked"
-				/>
+					Clicked="OnReloadSavedClicked"/>
 				<Button
 					Text="Save"
-					Clicked="OnSaveClicked"
-				/>
+					Clicked="OnSaveClicked"/>
 			</HorizontalStackLayout>
 			<Border>
 				<Grid>
@@ -102,29 +116,47 @@
 				</Grid>
 			</Border>
 			<Border>
-				<VerticalStackLayout>
+				<VerticalStackLayout Spacing="8">
+					<Label
+						Text="位置情報の取得間隔"
+						FontSize="Header"/>
 					<Label
 						x:Name="LocationServiceIntervalSettingHeaderLabel"
 						Text="{Binding LocationServiceIntervalSettingHeaderLabel, Mode=OneWay}"
-						FontSize="Header"
-						/>
+						FontSize="Header"/>
 					<ListView
 						VerticalScrollBarVisibility="Never"
 						ItemsSource="{Binding LocationServiceIntervalItems, Mode=OneTime}"
-						SelectedItem="{Binding LocationServiceInterval_Seconds, Mode=TwoWay}"
-					/>
+						SelectedItem="{Binding LocationServiceInterval_Seconds, Mode=TwoWay}"/>
+				</VerticalStackLayout>
+			</Border>
+			<Border x:Name="AdvancedSettingsBorder">
+				<VerticalStackLayout Spacing="8">
+					<Label
+						Text="高度な設定"
+						FontSize="Header"/>
+					<HorizontalStackLayout
+						x:Name="ShowMapWhenLandscapeHeaderLabel"
+						HorizontalOptions="End">
+						<Label
+							Text="横向きにした際に、横に地図を表示する"
+							Margin="0,0,8,0"
+							VerticalOptions="Center"/>
+						<Switch
+							OnColor="GreenYellow"
+							VerticalOptions="Center"
+							IsToggled="{Binding ShowMapWhenLandscape}"/>
+					</HorizontalStackLayout>
 				</VerticalStackLayout>
 			</Border>
 			<Border>
 				<VerticalStackLayout>
 					<Label
 						Text="Log File Path"
-						FontSize="Header"
-						/>
+						FontSize="Header"/>
 					<Label
 						x:Name="LogFilePathLabel"
-						FontSize="Body"
-						/>
+						FontSize="Body"/>
 				</VerticalStackLayout>
 			</Border>
 		</VerticalStackLayout>

--- a/TRViS/RootPages/EasterEggPage.xaml.cs
+++ b/TRViS/RootPages/EasterEggPage.xaml.cs
@@ -19,6 +19,14 @@ public partial class EasterEggPage : ContentPage
 
 		LogFilePathLabel.Text = DirectoryPathProvider.GeneralLogFileDirectory.FullName;
 
+#if IOS || MACCATALYST
+		ShowMapWhenLandscapeHeaderLabel.IsVisible = DeviceInfo.Idiom != DeviceIdiom.Phone;
+#else
+		ShowMapWhenLandscapeHeaderLabel.IsVisible = false;
+#endif
+
+		AdvancedSettingsBorder.IsVisible = ShowMapWhenLandscapeHeaderLabel.IsVisible;
+
 		logger.Trace("EasterEggPage Created");
 	}
 

--- a/TRViS/RootPages/EasterEggPage.xaml.cs
+++ b/TRViS/RootPages/EasterEggPage.xaml.cs
@@ -4,7 +4,7 @@ namespace TRViS.RootPages;
 
 public partial class EasterEggPage : ContentPage
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	EasterEggPageViewModel ViewModel { get; }
 
 	public EasterEggPage()
@@ -16,7 +16,7 @@ public partial class EasterEggPage : ContentPage
 		ViewModel = InstanceManager.EasterEggPageViewModel;
 		BindingContext = ViewModel;
 
-		LogFilePathLabel.Text = DirectoryPathProvider.NormalLogFileDirectory.FullName;
+		LogFilePathLabel.Text = DirectoryPathProvider.GeneralLogFileDirectory.FullName;
 
 		logger.Trace("EasterEggPage Created");
 	}

--- a/TRViS/RootPages/EasterEggPage.xaml.cs
+++ b/TRViS/RootPages/EasterEggPage.xaml.cs
@@ -1,3 +1,4 @@
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.RootPages;

--- a/TRViS/RootPages/FirebaseSettingPage.xaml.cs
+++ b/TRViS/RootPages/FirebaseSettingPage.xaml.cs
@@ -1,4 +1,5 @@
 using TRViS.FirebaseWrapper;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.RootPages;

--- a/TRViS/RootPages/FirebaseSettingPage.xaml.cs
+++ b/TRViS/RootPages/FirebaseSettingPage.xaml.cs
@@ -6,7 +6,7 @@ namespace TRViS.RootPages;
 public partial class FirebaseSettingPage : ContentPage
 {
 	public static readonly string NameOfThisClass = nameof(FirebaseSettingPage);
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	FirebaseSettingViewModel FirebaseSettingViewModel { get; }
 	public FirebaseSettingPage()

--- a/TRViS/RootPages/SelectOnlineResourcePopup.cs
+++ b/TRViS/RootPages/SelectOnlineResourcePopup.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Maui.Views;
 
 using TRViS.IO.RequestInfo;
+using TRViS.Services;
 
 namespace TRViS.RootPages;
 

--- a/TRViS/RootPages/SelectOnlineResourcePopup.cs
+++ b/TRViS/RootPages/SelectOnlineResourcePopup.cs
@@ -1,11 +1,12 @@
 using CommunityToolkit.Maui.Views;
+
 using TRViS.IO.RequestInfo;
 
 namespace TRViS.RootPages;
 
 public class SelectOnlineResourcePopup : Popup
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	readonly Button CloseButton = new()
 	{
@@ -71,7 +72,8 @@ public class SelectOnlineResourcePopup : Popup
 
 		RootStyles.TableTextColor.Apply(AdviceLabel, Label.TextColorProperty);
 
-		UrlHistoryListView.ItemTemplate = new DataTemplate(() => {
+		UrlHistoryListView.ItemTemplate = new DataTemplate(() =>
+		{
 			TextCell cell = new();
 			RootStyles.TableTextColor.Apply(cell, TextCell.TextColorProperty);
 			cell.SetBinding(TextCell.TextProperty, static (string? v) => v);
@@ -106,13 +108,15 @@ public class SelectOnlineResourcePopup : Popup
 		UrlInput.ReturnCommand = DoLoadCommand;
 		LoadButton.Command = DoLoadCommand;
 
-		UrlHistoryListView.ItemTapped += (_, e) => {
+		UrlHistoryListView.ItemTapped += (_, e) =>
+		{
 			logger.Debug("UrlHistoryListView.ItemTapped");
 			UrlInput.Text = e.Item as string;
 			logger.Trace("UrlInput.Text = {0}", UrlInput.Text);
 		};
 
-		UrlInput.TextChanged += (_, e) => {
+		UrlInput.TextChanged += (_, e) =>
+		{
 			logger.Debug("UrlInput.TextChanged -> set UrlHistoryListView.SelectedItem = {0}", e.NewTextValue);
 			UrlHistoryListView.SelectedItem = e.NewTextValue;
 		};
@@ -170,7 +174,7 @@ public class SelectOnlineResourcePopup : Popup
 				? AppLinkInfo.FromAppLink(UrlInput.Text)
 				: new(
 					AppLinkInfo.FileType.Json,
-					Version: new(1,0),
+					Version: new(1, 0),
 					ResourceUri: new(UrlInput.Text)
 				);
 			bool execResult = await InstanceManager.AppViewModel.HandleAppLinkUriAsync(appLinkInfo, CancellationToken.None);

--- a/TRViS/RootPages/SelectTrainPage.xaml.cs
+++ b/TRViS/RootPages/SelectTrainPage.xaml.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Maui.Views;
 
 using TRViS.IO;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.RootPages;

--- a/TRViS/RootPages/SelectTrainPage.xaml.cs
+++ b/TRViS/RootPages/SelectTrainPage.xaml.cs
@@ -8,7 +8,7 @@ namespace TRViS.RootPages;
 public partial class SelectTrainPage : ContentPage
 {
 	public static readonly string NameOfThisClass = nameof(SelectTrainPage);
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	AppViewModel viewModel { get; }
 
 	public SelectTrainPage()

--- a/TRViS/RootPages/ShowMarkdownPage.cs
+++ b/TRViS/RootPages/ShowMarkdownPage.cs
@@ -7,7 +7,7 @@ namespace TRViS.RootPages;
 [DependencyProperty<ResourceManager.AssetName>("FileName", DefaultValue = ResourceManager.AssetName.UNKNOWN)]
 public partial class ShowMarkdownPage : ContentPage
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	readonly SimpleMarkdownView markdownView;
 
 	public ShowMarkdownPage()
@@ -21,7 +21,8 @@ public partial class ShowMarkdownPage : ContentPage
 		scrollView.Content = markdownView;
 		Content = scrollView;
 
-		NavigatedTo += (_, _) => {
+		NavigatedTo += (_, _) =>
+		{
 			logger.Info("NavigatedTo executing with FileName: '{0}'", FileName);
 			markdownView.FileName = FileName;
 		};

--- a/TRViS/RootPages/ShowMarkdownPage.cs
+++ b/TRViS/RootPages/ShowMarkdownPage.cs
@@ -1,6 +1,7 @@
 using DependencyPropertyGenerator;
 
 using TRViS.Controls;
+using TRViS.Services;
 
 namespace TRViS.RootPages;
 

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 
 using TRViS.Controls;
 using TRViS.Models;
+using TRViS.Services;
 using TRViS.ViewModels;
 
 namespace TRViS.RootPages;

--- a/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
+++ b/TRViS/RootPages/ThirdPartyLicenses.xaml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+
 using TRViS.Controls;
 using TRViS.Models;
 using TRViS.ViewModels;
@@ -9,7 +10,7 @@ namespace TRViS.RootPages;
 
 public partial class ThirdPartyLicenses : ContentPage
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 	ThirdPartyLicensesViewModel viewModel { get; }
 	public ThirdPartyLicenses()
 	{
@@ -22,7 +23,8 @@ public partial class ThirdPartyLicenses : ContentPage
 		BindingContext = viewModel;
 
 		viewModel.PropertyChanged += ViewModel_PropertyChanged;
-		LicenseTextArea.PropertyChanged += (_, e) => {
+		LicenseTextArea.PropertyChanged += (_, e) =>
+		{
 			if (e.PropertyName == nameof(Width))
 			{
 				if (LicenseTextArea.Content is not VerticalStackLayout licenses)

--- a/TRViS/Services/AppPreferenceService.cs
+++ b/TRViS/Services/AppPreferenceService.cs
@@ -16,7 +16,7 @@ public enum AppPreferenceKeys
 
 public static class AppPreferenceService
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	static string ToKeyString(in AppPreferenceKeys key)
 	{

--- a/TRViS/Services/LocationService.Gps.cs
+++ b/TRViS/Services/LocationService.Gps.cs
@@ -69,7 +69,24 @@ public partial class LocationService
 			try
 			{
 				loc = await Geolocation.Default.GetLocationAsync(req, token);
-				locationServiceLogger.Info("Location Service Positioning Success (lon: {0}, lat: {1})", loc?.Longitude, loc?.Latitude);
+				if (loc is null)
+				{
+					locationServiceLogger.Warn("Location Service Positioning Failed");
+				}
+				else
+				{
+					locationServiceLogger.Info(
+						"Location Service Positioning Success (lon: {0}, lat: {1}, alt:{2}({3}), accuracy: {4}(alt: {5}), time: {6}, course: {7})",
+						loc.Longitude,
+						loc.Latitude,
+						loc.Altitude,
+						loc.AltitudeReferenceSystem,
+						loc.Accuracy,
+						loc.VerticalAccuracy,
+						loc.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff"),
+						loc.Course
+					);
+				}
 				OnGpsLocationUpdated?.Invoke(this, loc);
 			}
 			catch (Exception ex)

--- a/TRViS/Services/LocationService.Gps.cs
+++ b/TRViS/Services/LocationService.Gps.cs
@@ -3,6 +3,7 @@ namespace TRViS.Services;
 public partial class LocationService
 {
 	static Permissions.LocationWhenInUse LocationWhenInUsePermission { get; } = new();
+	public event EventHandler<Location?>? OnGpsLocationUpdated;
 	async Task GpsPositioningTask(ILocationService service, CancellationToken token)
 	{
 		if (service is not LonLatLocationService gpsService)
@@ -69,6 +70,7 @@ public partial class LocationService
 			{
 				loc = await Geolocation.Default.GetLocationAsync(req, token);
 				locationServiceLogger.Info("Location Service Positioning Success (lon: {0}, lat: {1})", loc?.Longitude, loc?.Latitude);
+				OnGpsLocationUpdated?.Invoke(this, loc);
 			}
 			catch (Exception ex)
 			{

--- a/TRViS/Services/LocationService.cs
+++ b/TRViS/Services/LocationService.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 
-using TRViS.Controls;
 using TRViS.IO.Models;
 using TRViS.ViewModels;
 
@@ -19,6 +18,8 @@ public class ExceptionThrownEventArgs : EventArgs
 public partial class LocationService : IDisposable
 {
 	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
+	private static readonly NLog.Logger locationServiceLogger = LoggerService.GetLocationServiceLogger();
+	private static readonly NLog.Logger lonLatLocationServiceLogger = LoggerService.GetLocationServiceLoggerT<LonLatLocationService>();
 
 	public bool IsEnabled
 	{
@@ -128,6 +129,7 @@ public partial class LocationService : IDisposable
 	public void SetLonLatLocationService()
 	{
 		logger.Trace("Setting LonLatLocationService...");
+		locationServiceLogger.Info("Setting LonLatLocationService...");
 
 		if (IsEnabled)
 		{
@@ -136,7 +138,7 @@ public partial class LocationService : IDisposable
 		}
 
 		ILocationService? currentService = _CurrentService;
-		LonLatLocationService nextService = new();
+		LonLatLocationService nextService = new(lonLatLocationServiceLogger);
 		if (currentService is not null)
 		{
 			currentService.CanUseServiceChanged -= OnCanUseServiceChanged;

--- a/TRViS/Services/LocationService.cs
+++ b/TRViS/Services/LocationService.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+
 using TRViS.Controls;
 using TRViS.IO.Models;
 using TRViS.ViewModels;
@@ -17,7 +18,7 @@ public class ExceptionThrownEventArgs : EventArgs
 
 public partial class LocationService : IDisposable
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	public bool IsEnabled
 	{
@@ -163,7 +164,8 @@ public partial class LocationService : IDisposable
 		CancellationTokenSource nextTokenSource = new();
 		timeProviderCancellation = nextTokenSource;
 		// バックグラウンドで実行し続ける
-		_ = Task.Run(async () => {
+		_ = Task.Run(async () =>
+		{
 			int lastTime_s = -1;
 			while (!nextTokenSource.Token.IsCancellationRequested)
 			{

--- a/TRViS/Services/LogFileManager.cs
+++ b/TRViS/Services/LogFileManager.cs
@@ -1,0 +1,89 @@
+using NLog;
+
+namespace TRViS.Services;
+
+public class LogFileManager(
+	DirectoryInfo logFileDirectoryInfo,
+	string category
+)
+{
+	public readonly DirectoryInfo LogFileDirectoryInfo = logFileDirectoryInfo;
+	public readonly string LogCategory = category;
+
+	public string LogFileDirectoryPath => LogFileDirectoryInfo.FullName;
+	public string CurrentLogFileName => $"{LogCategory}_current.trvis.log";
+	public string ArchiveLogFileNameFormat => $"{LogCategory}.{{0}}.trvis.log";
+	public string ArchiveLogFileNamePattern => $"{LogCategory}.*.trvis.log";
+
+	public string CurrentLogFilePath => Path.Combine(LogFileDirectoryPath, CurrentLogFileName);
+	public const int MAX_ARCHIVE_LOG_FILE_COUNT = 14;
+
+	public bool CreateLogFileDirectoryIfNotExists()
+	{
+		try
+		{
+			if (!LogFileDirectoryInfo.Exists)
+			{
+				LogFileDirectoryInfo.Create();
+			}
+			return true;
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"[{LogCategory}] CreateLogFileDirectoryIfNotExists failed: {ex}");
+			return false;
+		}
+	}
+
+	public Exception? ArchiveLastLogFile()
+	{
+		Console.WriteLine($"[{LogCategory}] ArchiveLastLogFile");
+		try
+		{
+			FileInfo lastLogFile = new(CurrentLogFilePath);
+			if (!lastLogFile.Exists)
+			{
+				Console.WriteLine($"[{LogCategory}] lastLogFile not exists");
+				return null;
+			}
+
+			string archiveLogFileName = string.Format(
+				ArchiveLogFileNameFormat,
+				lastLogFile.CreationTime.ToUniversalTime().ToString("yyyyMMdd.HHmmss")
+			);
+			string archiveLogFilePath = Path.Combine(LogFileDirectoryPath, archiveLogFileName);
+
+			Console.WriteLine($"[{LogCategory}] lastLogFile: {0} -> {1}", lastLogFile.FullName, archiveLogFilePath);
+			File.Move(lastLogFile.FullName, archiveLogFilePath);
+			return null;
+		}
+		catch (Exception ex)
+		{
+			return ex;
+		}
+	}
+
+	public void DeleteOldLogFiles(Logger logger)
+	{
+		logger.Trace("Executing...");
+		try
+		{
+			IEnumerable<FileInfo> oldLogFiles = LogFileDirectoryInfo.EnumerateFiles(
+				ArchiveLogFileNamePattern,
+				SearchOption.TopDirectoryOnly
+			)
+				.OrderByDescending(static fileInfo => fileInfo.LastWriteTime)
+				.Skip(MAX_ARCHIVE_LOG_FILE_COUNT);
+
+			foreach (FileInfo oldLogFile in oldLogFiles)
+			{
+				logger.Info("Deleting oldLogFile: {0}", oldLogFile.FullName);
+				oldLogFile.Delete();
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "DeleteOldLogFiles failed");
+		}
+	}
+}

--- a/TRViS/Services/LoggerService.cs
+++ b/TRViS/Services/LoggerService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 using NLog;
@@ -125,11 +126,28 @@ public static class LoggerService
 	{
 		StackTrace stackTrace = new();
 		StackFrame? stackFrame = stackTrace.GetFrame(2);
-		string className = stackFrame?.GetMethod()?.DeclaringType?.FullName ?? nameof(TRViS);
-		return className;
+		if (stackFrame is null)
+		{
+			return nameof(TRViS);
+		}
+		return DiagnosticMethodInfo.Create(stackFrame)?.DeclaringTypeName ?? nameof(TRViS);
 	}
+
 	public static Logger GetGeneralLogger()
-		=> LogManager.GetLogger($"{GeneralLogFileManager.LogCategory}.{GetCallerClassName()}");
+		=> GetGeneralLogger(GetCallerClassName());
+	public static Logger GetGeneralLogger(Type type)
+		=> GetGeneralLogger(type.FullName ?? nameof(TRViS));
+	public static Logger GetGeneralLoggerT<T>()
+		=> GetGeneralLogger(typeof(T));
+	public static Logger GetGeneralLogger(string className)
+		=> LogManager.GetLogger($"{GeneralLogFileManager.LogCategory}.{className}");
+
 	public static Logger GetLocationServiceLogger()
-		=> LogManager.GetLogger($"{LocationLogFileManager.LogCategory}.{GetCallerClassName()}");
+		=> GetLocationServiceLogger(GetCallerClassName());
+	public static Logger GetLocationServiceLogger(Type type)
+		=> GetLocationServiceLogger(type.FullName ?? nameof(TRViS));
+	public static Logger GetLocationServiceLoggerT<T>()
+		=> GetLocationServiceLogger(typeof(T));
+	public static Logger GetLocationServiceLogger(string className)
+		=> LogManager.GetLogger($"{LocationLogFileManager.LogCategory}.{className}");
 }

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -84,6 +84,11 @@
 			Include="NLog"
 			Version="5.4.0" />
 	</ItemGroup>
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+		<PackageReference
+			Include="Microsoft.Maui.Controls.Maps"
+			Version="9.0.40" />
+	</ItemGroup>
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
 		<!-- <BundleResource Include="GoogleService-Info.plist" />
 		<PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="11.8.0" />

--- a/TRViS/Utils/DirectoryPathProvider.cs
+++ b/TRViS/Utils/DirectoryPathProvider.cs
@@ -2,8 +2,8 @@ namespace TRViS;
 
 public static class DirectoryPathProvider
 {
-  static DirectoryPathProvider()
-  {
+	static DirectoryPathProvider()
+	{
 		string baseDirPath;
 		if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
 		{
@@ -17,10 +17,12 @@ public static class DirectoryPathProvider
 		InternalFilesDirectory = new(Path.Combine(baseDirPath, "TRViS.InternalFiles"));
 
 		CrashLogFileDirectory = new(Path.Combine(InternalFilesDirectory.FullName, "crashlogs"));
-		NormalLogFileDirectory = new(Path.Combine(InternalFilesDirectory.FullName, "logs"));
-  }
+		GeneralLogFileDirectory = new(Path.Combine(InternalFilesDirectory.FullName, "logs"));
+		LocationServiceLogFileDirectory = new(Path.Combine(InternalFilesDirectory.FullName, "loc-logs"));
+	}
 
 	public static readonly DirectoryInfo InternalFilesDirectory;
 	public static readonly DirectoryInfo CrashLogFileDirectory;
-	public static readonly DirectoryInfo NormalLogFileDirectory;
+	public static readonly DirectoryInfo GeneralLogFileDirectory;
+	public static readonly DirectoryInfo LocationServiceLogFileDirectory;
 }

--- a/TRViS/Utils/Utils.common.cs
+++ b/TRViS/Utils/Utils.common.cs
@@ -1,11 +1,13 @@
+using TRViS.Services;
+
 namespace TRViS;
 
 public static partial class Utils
 {
-  private static readonly NLog.Logger logger;
+	private static readonly NLog.Logger logger;
 
-  static Utils()
-  {
-    logger = LoggerService.GetGeneralLogger();
-  }
+	static Utils()
+	{
+		logger = LoggerService.GetGeneralLogger();
+	}
 }

--- a/TRViS/Utils/Utils.common.cs
+++ b/TRViS/Utils/Utils.common.cs
@@ -2,10 +2,10 @@ namespace TRViS;
 
 public static partial class Utils
 {
-	private static readonly NLog.Logger logger;
+  private static readonly NLog.Logger logger;
 
   static Utils()
   {
-    logger = NLog.LogManager.GetCurrentClassLogger();
+    logger = LoggerService.GetGeneralLogger();
   }
 }

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using TRViS.IO;
@@ -10,7 +11,7 @@ namespace TRViS.ViewModels;
 
 public partial class AppViewModel : ObservableObject
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	[ObservableProperty]
 	ILoader? _Loader;

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using TRViS.MyAppCustomizables;
+using TRViS.Services;
 
 namespace TRViS.ViewModels;
 

--- a/TRViS/ViewModels/DTACMarkerViewModel.cs
+++ b/TRViS/ViewModels/DTACMarkerViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+
 using TRViS.MyAppCustomizables;
 
 namespace TRViS.ViewModels;
@@ -7,7 +8,7 @@ public record MarkerInfo(string Name, Color Color);
 
 public partial class DTACMarkerViewModel : ObservableObject
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	public static readonly IReadOnlyList<MarkerInfo> ColorListDefaultValue = new List<MarkerInfo>()
 	{

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -1,12 +1,14 @@
 using System.ComponentModel;
+
 using CommunityToolkit.Mvvm.ComponentModel;
+
 using TRViS.MyAppCustomizables;
 
 namespace TRViS.ViewModels;
 
 public partial class EasterEggPageViewModel : ObservableObject
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	Color _ShellBackgroundColor = Colors.Black;
 	public Color ShellBackgroundColor
@@ -64,7 +66,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 		LocationServiceIntervalSettingHeaderLabel = $"Location Service Interval: {value:F2} [s]";
 	}
 
-    public DTACMarkerViewModel MarkerViewModel { get; }
+	public DTACMarkerViewModel MarkerViewModel { get; }
 
 	public EasterEggPageViewModel()
 	{

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -41,6 +41,9 @@ public partial class EasterEggPageViewModel : ObservableObject
 	[ObservableProperty]
 	double _LocationServiceInterval_Seconds = 1;
 
+	[ObservableProperty]
+	bool _ShowMapWhenLandscape = false;
+
 	public IReadOnlyList<double> LocationServiceIntervalItems { get; } = new List<double>()
 	{
 		0.1,
@@ -141,6 +144,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 		Color_Green = settingFile.TitleColor.Green;
 		Color_Blue = settingFile.TitleColor.Blue;
 		LocationServiceInterval_Seconds = settingFile.LocationServiceInterval_Seconds;
+		ShowMapWhenLandscape = settingFile.ShowMapWhenLandscape;
 
 		MarkerViewModel?.UpdateList(settingFile);
 
@@ -167,7 +171,8 @@ public partial class EasterEggPageViewModel : ObservableObject
 		SettingFileStructure settingFile = new()
 		{
 			TitleColor = new(ShellBackgroundColor),
-			LocationServiceInterval_Seconds = LocationServiceInterval_Seconds
+			LocationServiceInterval_Seconds = LocationServiceInterval_Seconds,
+			ShowMapWhenLandscape = ShowMapWhenLandscape,
 		};
 
 		MarkerViewModel?.SetToSettings(settingFile);

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -1,8 +1,7 @@
-using System.ComponentModel;
-
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using TRViS.MyAppCustomizables;
+using TRViS.Services;
 
 namespace TRViS.ViewModels;
 

--- a/TRViS/ViewModels/FirebaseSettingViewModel.cs
+++ b/TRViS/ViewModels/FirebaseSettingViewModel.cs
@@ -6,7 +6,7 @@ namespace TRViS.ViewModels;
 
 public partial class FirebaseSettingViewModel : ObservableObject, IFirebaseSetting
 {
-	private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
 	[ObservableProperty]
 	public partial bool IsEnabled { get; set; }


### PR DESCRIPTION
デバイスによって、位置情報の精度が異なる場合があります。
現状、プライバシー保護の観点から位置情報をログに出していません。しかし、うまく次の駅に進まないといった事象が発生することがあり、その場合の原因の切り分けが難しい状態になっていました。

通常ログのINFO以上に位置情報を出すのはプライバシー的に避けたいため、位置情報ログを独立して出すようにします。
位置情報ログはファイル名を分けるだけでなくディレクトリも分け、不意の流出を防ぎます。

---

関連して、いちいちログを見るのは大変なため、iPad/macOS限定で、横向きで表示した場合に右側の余白部分に地図を表示し、以下の情報を確認できるようにします。

- 駅位置/駅情報
- 駅の検知半径
- 現在位置と精度の半径

なお、測位に失敗した場合の表示は面倒なので今回は実装していません。