### PR TITLE
Update CI workflow for Xcode 26.3 and fix dotnet test issues

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -43,7 +43,7 @@ env:
   SDK_VERSION: "10.0.x"
   IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
   IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.2"
+  XCODE_VERSION: "26.3"
   FIREBASE_PROJECT_ID: trvis-app
 
 jobs:
@@ -234,7 +234,7 @@ jobs:
 
       - name: Build
         env:
-          DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+          DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
           ACTOOL_SKIP_SIMULATOR_RUNTIME_CHECK: true
           DOTNET_CLI_UI_LANGUAGE: en-US
           ACTOOL_DISABLE: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Debug
+
+      - name: Run tests
+        run: dotnet test --no-build --configuration Debug --verbosity normal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,15 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Restore dependencies
-        run: dotnet restore
+      - name: Restore test projects
+        run: |
+          dotnet restore TRViS.IO.Tests/TRViS.IO.Tests.csproj
+          dotnet restore TRViS.LocationService.Tests/TRViS.LocationService.Tests.csproj
 
-      - name: Build
-        run: dotnet build --no-restore --configuration Debug
+      - name: Build test projects
+        run: |
+          dotnet build TRViS.IO.Tests/TRViS.IO.Tests.csproj --no-restore --configuration Debug
+          dotnet build TRViS.LocationService.Tests/TRViS.LocationService.Tests.csproj --no-restore --configuration Debug
 
       - name: Run tests
-        run: dotnet test --no-build --configuration Debug --verbosity normal
+        run: dotnet test --configuration Debug --verbosity normal --no-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      - name: Restore workloads
+        run: dotnet workload restore
+
       - name: Restore test projects
         run: |
           dotnet restore TRViS.IO.Tests/TRViS.IO.Tests.csproj

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,6 @@ jobs:
           dotnet build TRViS.LocationService.Tests/TRViS.LocationService.Tests.csproj --no-restore --configuration Debug
 
       - name: Run tests
-        run: dotnet test --configuration Debug --verbosity normal --no-build
+        run: |
+          dotnet test TRViS.IO.Tests/TRViS.IO.Tests.csproj --configuration Debug --verbosity normal --no-build
+          dotnet test TRViS.LocationService.Tests/TRViS.LocationService.Tests.csproj --configuration Debug --verbosity normal --no-build

--- a/TRViS.IO.Tests/Loaders/LoaderSQL.Tests.cs
+++ b/TRViS.IO.Tests/Loaders/LoaderSQL.Tests.cs
@@ -102,12 +102,11 @@ public class LoaderSQLTests
 
 		var actual = loader.GetWorkGroupList();
 
-		Assert.That(actual, Has.Member(new Models.DB.WorkGroup()
-		{
-			Id = "1",
-			Name = "Group01",
-			DBVersion = 1,
-		}));
+		Assert.That(actual, Has.Member(new WorkGroup(
+			Id: "1",
+			Name: "Group01",
+			DBVersion: 1
+		)));
 	}
 
 	[Test]
@@ -119,20 +118,18 @@ public class LoaderSQLTests
 
 		for (int i = 1; i <= 3; i++)
 		{
-			Assert.That(actual, Has.Member(new Models.DB.Work()
-			{
-				Id = i.ToString(),
-				WorkGroupId = "1",
-				Name = $"Work0{i}",
-				AffectDate = "2022-09-15",
-
-				AffixContentType = null,
-				AffixContent = null,
-				Remarks = $"Work0{i} - Remarks",
-				HasETrainTimetable = i == 1,
-				ETrainTimetableContentType = null,
-				ETrainTimetableContent = null,
-			}));
+			Assert.That(actual, Has.Member(new Work(
+				Id: i.ToString(),
+				WorkGroupId: "1",
+				Name: $"Work0{i}",
+				AffectDate: new DateOnly(2022, 9, 15),
+				AffixContentType: null,
+				AffixContent: null,
+				Remarks: $"Work0{i} - Remarks",
+				HasETrainTimetable: i == 1,
+				ETrainTimetableContentType: null,
+				ETrainTimetableContent: null
+			)));
 		}
 	}
 
@@ -143,29 +140,28 @@ public class LoaderSQLTests
 
 		var actual = loader.GetTrainDataList("1");
 
-		Assert.That(actual, Has.Member(new Models.DB.TrainData()
-		{
-			Id = "1",
-			WorkId = "1",
-			TrainNumber = "T9910X",
-			MaxSpeed = "95",
-			SpeedType = "高速特定",
-			NominalTractiveCapacity = "E237系\n1M",
-			CarCount = 1,
-			Destination = "行き先",
-			Remarks = "試験用データ",
-			BeginRemarks = "〜試験用データ~",
-			AfterRemarks = "〜試験用データ終わり~",
-			BeforeDeparture = "発前点検300分",
-			TrainInfo = "試験用ダミーデータ",
-			Direction = 1,
-
-			AfterArrive = "着後作業 10分",
-			BeforeDeparture_OnStationTrackCol = "点検",
-			AfterArrive_OnStationTrackCol = "作業",
-			DayCount = 1,
-			IsRideOnMoving = false,
-			ColorId = null,
-		}));
+		Assert.That(actual, Has.Member(new TrainData(
+			Id: "1",
+			Direction: Direction.Outbound,
+			WorkName: null,
+			AffectDate: null,
+			TrainNumber: "T9910X",
+			MaxSpeed: "95",
+			SpeedType: "高速特定",
+			NominalTractiveCapacity: "E237系\n1M",
+			CarCount: 1,
+			Destination: "行き先",
+			BeginRemarks: "〜試験用データ~",
+			AfterRemarks: "〜試験用データ終わり~",
+			Remarks: "試験用データ",
+			BeforeDeparture: "発前点検300分",
+			TrainInfo: "試験用ダミーデータ",
+			Rows: null,
+			AfterArrive: "着後作業 10分",
+			DayCount: 1,
+			IsRideOnMoving: false,
+			LineColor_RGB: null,
+			NextTrainId: null
+		)));
 	}
 }

--- a/TRViS.IO.Tests/Loaders/LoaderSQL.v0.Tests.cs
+++ b/TRViS.IO.Tests/Loaders/LoaderSQL.v0.Tests.cs
@@ -91,11 +91,11 @@ public class LoaderSQLV0Tests
 
 		var actual = loader.GetWorkGroupList();
 
-		Assert.That(actual, Has.Member(new Models.DB.WorkGroup()
-		{
-			Id = "1",
-			Name = "Group01"
-		}));
+		Assert.That(actual, Has.Member(new WorkGroup(
+			Id: "1",
+			Name: "Group01",
+			DBVersion: 0
+		)));
 	}
 
 	[Test]
@@ -107,13 +107,18 @@ public class LoaderSQLV0Tests
 
 		for (int i = 1; i <= 3; i++)
 		{
-			Assert.That(actual, Has.Member(new Models.DB.Work()
-			{
-				Id = i.ToString(),
-				WorkGroupId = "1",
-				Name = $"Work0{i}",
-				AffectDate = "2022-09-15"
-			}));
+			Assert.That(actual, Has.Member(new Work(
+				Id: i.ToString(),
+				WorkGroupId: "1",
+				Name: $"Work0{i}",
+				AffectDate: new DateOnly(2022, 9, 15),
+				AffixContentType: null,
+				AffixContent: null,
+				Remarks: null,
+				HasETrainTimetable: null,
+				ETrainTimetableContentType: null,
+				ETrainTimetableContent: null
+			)));
 		}
 	}
 
@@ -124,22 +129,28 @@ public class LoaderSQLV0Tests
 
 		var actual = loader.GetTrainDataList("1");
 
-		Assert.That(actual, Has.Member(new Models.DB.TrainData()
-		{
-			Id = "1",
-			WorkId = "1",
-			TrainNumber = "T9910X",
-			MaxSpeed = "95",
-			SpeedType = "高速特定",
-			NominalTractiveCapacity = "E237系\n1M",
-			CarCount = 1,
-			Destination = "行き先",
-			Remarks = "試験用データ",
-			BeginRemarks = "〜試験用データ~",
-			AfterRemarks = "〜試験用データ終わり~",
-			BeforeDeparture = "発前点検300分",
-			TrainInfo = "試験用ダミーデータ",
-			Direction = 1
-		}));
+		Assert.That(actual, Has.Member(new TrainData(
+			Id: "1",
+			Direction: Direction.Outbound,
+			WorkName: null,
+			AffectDate: null,
+			TrainNumber: "T9910X",
+			MaxSpeed: "95",
+			SpeedType: "高速特定",
+			NominalTractiveCapacity: "E237系\n1M",
+			CarCount: 1,
+			Destination: "行き先",
+			BeginRemarks: "〜試験用データ~",
+			AfterRemarks: "〜試験用データ終わり~",
+			Remarks: "試験用データ",
+			BeforeDeparture: "発前点検300分",
+			TrainInfo: "試験用ダミーデータ",
+			Rows: null,
+			AfterArrive: null,
+			DayCount: 0,
+			IsRideOnMoving: null,
+			LineColor_RGB: null,
+			NextTrainId: null
+		)));
 	}
 }

--- a/TRViS.IO.Tests/Resources/AddSampleData_1.sql
+++ b/TRViS.IO.Tests/Resources/AddSampleData_1.sql
@@ -279,7 +279,7 @@ VALUES
   NULL,
 
   NULL,
-  '試験',
+  NULL,
   NULL
 ),
 (

--- a/TRViS.IO/Loaders/LoaderSQL.cs
+++ b/TRViS.IO/Loaders/LoaderSQL.cs
@@ -16,146 +16,172 @@ public class LoaderSQL : ILoader, IDisposable
 	static TimeData? GetTimeData(int? hh, int? mm, int? ss, string? str)
 		=> hh is null && mm is null && ss is null && string.IsNullOrEmpty(str) ? null : new(hh, mm, ss, str);
 
-	public TrainData? GetTrainData(string trainId)
+	private bool HasColorTable()
 	{
 		try
 		{
-			return (from t in Connection.Table<Models.DB.TrainData>()
-					where t.Id == trainId
-					join w in Connection.Table<Models.DB.Work>()
-					on t.WorkId equals w.Id
-					select new TrainData(
-						Id: t.Id.ToString(),
-						Direction: DirectionExtensions.FromInt(t.Direction),
-						WorkName: w.Name,
-						AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
-						TrainNumber: t.TrainNumber,
-						MaxSpeed: t.MaxSpeed,
-						SpeedType: t.SpeedType,
-						NominalTractiveCapacity: t.NominalTractiveCapacity,
-						CarCount: t.CarCount,
-						Destination: t.Destination,
-						BeginRemarks: t.BeginRemarks,
-						AfterRemarks: t.AfterRemarks,
-						Remarks: t.Remarks,
-						BeforeDeparture: t.BeforeDeparture,
-						TrainInfo: t.TrainInfo,
-						(
-							from r in Connection.Table<Models.DB.TimetableRowData>()
-							where r.TrainId == trainId
-							join s in Connection.Table<Models.DB.Station>()
-							on r.StationId equals s.Id
-							join n in Connection.Table<Models.DB.StationTrack>()
-							on r.StationTrackId equals n.Id into track
-							from tj in track.DefaultIfEmpty()
-							join c in Connection.Table<Models.DB.Color>()
-							on r.MarkerColorId equals c.Id into color
-							from cj in color.DefaultIfEmpty()
-							orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
-							select new TimetableRow(
-								Id: r.Id.ToString(),
-								Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
-								DriveTimeMM: r.DriveTime_MM,
-								DriveTimeSS: r.DriveTime_SS,
-								StationName: s.Name,
-								IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
-								IsPass: r.IsPass ?? false,
-								HasBracket: r.HasBracket ?? false,
-								IsLastStop: r.IsLastStop ?? false,
-								ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
-								DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
-								TrackName: tj?.Name,
-								RunInLimit: r.RunInLimit,
-								RunOutLimit: r.RunOutLimit,
-								Remarks: r.Remarks,
-
-								IsInfoRow: s.RecordType
-									is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
-									or (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain,
-
-								DefaultMarkerColor_RGB: cj?.RGB,
-								DefaultMarkerText: r.MarkerText
-							)
-						).ToArray(),
-						AfterArrive: t.AfterArrive,
-						// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
-						// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
-						DayCount: t.DayCount ?? 0,
-						IsRideOnMoving: t.IsRideOnMoving,
-
-						// TODO: E電時刻表用の線色設定のサポート
-						LineColor_RGB: null
-						)
-					).FirstOrDefault();
+			var result = Connection.ExecuteScalar("SELECT 1 FROM sqlite_master WHERE type='table' AND name='Color' LIMIT 1");
+			return result != null;
 		}
-		catch (SQLite.SQLiteException)
+		catch
 		{
-			// Handle v0 database schema that doesn't have Color table
-			return (from t in Connection.Table<Models.DB.TrainData>()
-					where t.Id == trainId
-					join w in Connection.Table<Models.DB.Work>()
-					on t.WorkId equals w.Id
-					select new TrainData(
-						Id: t.Id.ToString(),
-						Direction: DirectionExtensions.FromInt(t.Direction),
-						WorkName: w.Name,
-						AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
-						TrainNumber: t.TrainNumber,
-						MaxSpeed: t.MaxSpeed,
-						SpeedType: t.SpeedType,
-						NominalTractiveCapacity: t.NominalTractiveCapacity,
-						CarCount: t.CarCount,
-						Destination: t.Destination,
-						BeginRemarks: t.BeginRemarks,
-						AfterRemarks: t.AfterRemarks,
-						Remarks: t.Remarks,
-						BeforeDeparture: t.BeforeDeparture,
-						TrainInfo: t.TrainInfo,
-						(
-							from r in Connection.Table<Models.DB.TimetableRowData>()
-							where r.TrainId == trainId
-							join s in Connection.Table<Models.DB.Station>()
-							on r.StationId equals s.Id
-							join n in Connection.Table<Models.DB.StationTrack>()
-							on r.StationTrackId equals n.Id into track
-							from tj in track.DefaultIfEmpty()
-							orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
-							select new TimetableRow(
-								Id: r.Id.ToString(),
-								Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
-								DriveTimeMM: r.DriveTime_MM,
-								DriveTimeSS: r.DriveTime_SS,
-								StationName: s.Name,
-								IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
-								IsPass: r.IsPass ?? false,
-								HasBracket: r.HasBracket ?? false,
-								IsLastStop: r.IsLastStop ?? false,
-								ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
-								DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
-								TrackName: tj?.Name,
-								RunInLimit: r.RunInLimit,
-								RunOutLimit: r.RunOutLimit,
-								Remarks: r.Remarks,
-
-								IsInfoRow: s.RecordType
-									is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
-									or (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain,
-
-								DefaultMarkerColor_RGB: null,
-								DefaultMarkerText: null
-							)
-						).ToArray(),
-						AfterArrive: t.AfterArrive,
-						// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
-						// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
-						DayCount: t.DayCount ?? 0,
-						IsRideOnMoving: t.IsRideOnMoving,
-
-						// TODO: E電時刻表用の線色設定のサポート
-						LineColor_RGB: null
-						)
-					).FirstOrDefault();
+			return false;
 		}
+	}
+
+	private bool? _hasColorTableCache;
+
+	public TrainData? GetTrainData(string trainId)
+	{
+		_hasColorTableCache ??= HasColorTable();
+
+		if (_hasColorTableCache.Value)
+		{
+			return GetTrainDataWithColor(trainId);
+		}
+		else
+		{
+			return GetTrainDataWithoutColor(trainId);
+		}
+	}
+
+	private TrainData? GetTrainDataWithColor(string trainId)
+	{
+		return (from t in Connection.Table<Models.DB.TrainData>()
+				where t.Id == trainId
+				join w in Connection.Table<Models.DB.Work>()
+				on t.WorkId equals w.Id
+				select new TrainData(
+					Id: t.Id.ToString(),
+					Direction: DirectionExtensions.FromInt(t.Direction),
+					WorkName: w.Name,
+					AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
+					TrainNumber: t.TrainNumber,
+					MaxSpeed: t.MaxSpeed,
+					SpeedType: t.SpeedType,
+					NominalTractiveCapacity: t.NominalTractiveCapacity,
+					CarCount: t.CarCount,
+					Destination: t.Destination,
+					BeginRemarks: t.BeginRemarks,
+					AfterRemarks: t.AfterRemarks,
+					Remarks: t.Remarks,
+					BeforeDeparture: t.BeforeDeparture,
+					TrainInfo: t.TrainInfo,
+					(
+						from r in Connection.Table<Models.DB.TimetableRowData>()
+						where r.TrainId == trainId
+						join s in Connection.Table<Models.DB.Station>()
+						on r.StationId equals s.Id
+						join n in Connection.Table<Models.DB.StationTrack>()
+						on r.StationTrackId equals n.Id into track
+						from tj in track.DefaultIfEmpty()
+						join c in Connection.Table<Models.DB.Color>()
+						on r.MarkerColorId equals c.Id into color
+						from cj in color.DefaultIfEmpty()
+						orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
+						select new TimetableRow(
+							Id: r.Id.ToString(),
+							Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
+							DriveTimeMM: r.DriveTime_MM,
+							DriveTimeSS: r.DriveTime_SS,
+							StationName: s.Name,
+							IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
+							IsPass: r.IsPass ?? false,
+							HasBracket: r.HasBracket ?? false,
+							IsLastStop: r.IsLastStop ?? false,
+							ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
+							DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
+							TrackName: tj?.Name,
+							RunInLimit: r.RunInLimit,
+							RunOutLimit: r.RunOutLimit,
+							Remarks: r.Remarks,
+
+							IsInfoRow: s.RecordType
+								is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
+								or (int)Models.DB.StationRecordType.InfoRow_ForSomeTrain,
+
+							DefaultMarkerColor_RGB: cj?.RGB,
+							DefaultMarkerText: r.MarkerText
+						)
+					).ToArray(),
+					AfterArrive: t.AfterArrive,
+					// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
+					// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
+					DayCount: t.DayCount ?? 0,
+					IsRideOnMoving: t.IsRideOnMoving,
+
+					// TODO: E電時刻表用の線色設定のサポート
+					LineColor_RGB: null
+					)
+				).FirstOrDefault();
+	}
+
+	private TrainData? GetTrainDataWithoutColor(string trainId)
+	{
+		return (from t in Connection.Table<Models.DB.TrainData>()
+				where t.Id == trainId
+				join w in Connection.Table<Models.DB.Work>()
+				on t.WorkId equals w.Id
+				select new TrainData(
+					Id: t.Id.ToString(),
+					Direction: DirectionExtensions.FromInt(t.Direction),
+					WorkName: w.Name,
+					AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
+					TrainNumber: t.TrainNumber,
+					MaxSpeed: t.MaxSpeed,
+					SpeedType: t.SpeedType,
+					NominalTractiveCapacity: t.NominalTractiveCapacity,
+					CarCount: t.CarCount,
+					Destination: t.Destination,
+					BeginRemarks: t.BeginRemarks,
+					AfterRemarks: t.AfterRemarks,
+					Remarks: t.Remarks,
+					BeforeDeparture: t.BeforeDeparture,
+					TrainInfo: t.TrainInfo,
+					(
+						from r in Connection.Table<Models.DB.TimetableRowData>()
+						where r.TrainId == trainId
+						join s in Connection.Table<Models.DB.Station>()
+						on r.StationId equals s.Id
+						join n in Connection.Table<Models.DB.StationTrack>()
+						on r.StationTrackId equals n.Id into track
+						from tj in track.DefaultIfEmpty()
+						orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
+						select new TimetableRow(
+							Id: r.Id.ToString(),
+							Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
+							DriveTimeMM: r.DriveTime_MM,
+							DriveTimeSS: r.DriveTime_SS,
+							StationName: s.Name,
+							IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
+							IsPass: r.IsPass ?? false,
+							HasBracket: r.HasBracket ?? false,
+							IsLastStop: r.IsLastStop ?? false,
+							ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
+							DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
+							TrackName: tj?.Name,
+							RunInLimit: r.RunInLimit,
+							RunOutLimit: r.RunOutLimit,
+							Remarks: r.Remarks,
+
+							IsInfoRow: s.RecordType
+								is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
+								or (int)Models.DB.StationRecordType.InfoRow_ForSomeTrain,
+
+							DefaultMarkerColor_RGB: null,
+							DefaultMarkerText: null
+						)
+					).ToArray(),
+					AfterArrive: t.AfterArrive,
+					// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
+					// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
+					DayCount: t.DayCount ?? 0,
+					IsRideOnMoving: t.IsRideOnMoving,
+
+					// TODO: E電時刻表用の線色設定のサポート
+					LineColor_RGB: null
+					)
+				).FirstOrDefault();
 	}
 
 	public IReadOnlyList<WorkGroup> GetWorkGroupList()

--- a/TRViS.IO/Loaders/LoaderSQL.cs
+++ b/TRViS.IO/Loaders/LoaderSQL.cs
@@ -17,73 +17,146 @@ public class LoaderSQL : ILoader, IDisposable
 		=> hh is null && mm is null && ss is null && string.IsNullOrEmpty(str) ? null : new(hh, mm, ss, str);
 
 	public TrainData? GetTrainData(string trainId)
-		=> (from t in Connection.Table<Models.DB.TrainData>()
-				where t.Id == trainId
-				join w in Connection.Table<Models.DB.Work>()
-				on t.WorkId equals w.Id
-				select new TrainData(
-					Id: t.Id.ToString(),
-					Direction: DirectionExtensions.FromInt(t.Direction),
-					WorkName: w.Name,
-					AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
-					TrainNumber: t.TrainNumber,
-					MaxSpeed: t.MaxSpeed,
-					SpeedType: t.SpeedType,
-					NominalTractiveCapacity: t.NominalTractiveCapacity,
-					CarCount: t.CarCount,
-					Destination: t.Destination,
-					BeginRemarks: t.BeginRemarks,
-					AfterRemarks: t.AfterRemarks,
-					Remarks: t.Remarks,
-					BeforeDeparture: t.BeforeDeparture,
-					TrainInfo: t.TrainInfo,
-					(
-						from r in Connection.Table<Models.DB.TimetableRowData>()
-						where r.TrainId == trainId
-						join s in Connection.Table<Models.DB.Station>()
-						on r.StationId equals s.Id
-						join n in Connection.Table<Models.DB.StationTrack>()
-						on r.StationTrackId equals n.Id into track
-						from tj in track.DefaultIfEmpty()
-						join c in Connection.Table<Models.DB.Color>()
-						on r.MarkerColorId equals c.Id into color
-						from cj in color.DefaultIfEmpty()
-						orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
-						select new TimetableRow(
-							Id: r.Id.ToString(),
-							Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
-							DriveTimeMM: r.DriveTime_MM,
-							DriveTimeSS: r.DriveTime_SS,
-							StationName: s.Name,
-							IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
-							IsPass: r.IsPass ?? false,
-							HasBracket: r.HasBracket ?? false,
-							IsLastStop: r.IsLastStop ?? false,
-							ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
-							DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
-							TrackName: tj?.Name,
-							RunInLimit: r.RunInLimit,
-							RunOutLimit: r.RunOutLimit,
-							Remarks: r.Remarks,
+	{
+		try
+		{
+			return (from t in Connection.Table<Models.DB.TrainData>()
+					where t.Id == trainId
+					join w in Connection.Table<Models.DB.Work>()
+					on t.WorkId equals w.Id
+					select new TrainData(
+						Id: t.Id.ToString(),
+						Direction: DirectionExtensions.FromInt(t.Direction),
+						WorkName: w.Name,
+						AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
+						TrainNumber: t.TrainNumber,
+						MaxSpeed: t.MaxSpeed,
+						SpeedType: t.SpeedType,
+						NominalTractiveCapacity: t.NominalTractiveCapacity,
+						CarCount: t.CarCount,
+						Destination: t.Destination,
+						BeginRemarks: t.BeginRemarks,
+						AfterRemarks: t.AfterRemarks,
+						Remarks: t.Remarks,
+						BeforeDeparture: t.BeforeDeparture,
+						TrainInfo: t.TrainInfo,
+						(
+							from r in Connection.Table<Models.DB.TimetableRowData>()
+							where r.TrainId == trainId
+							join s in Connection.Table<Models.DB.Station>()
+							on r.StationId equals s.Id
+							join n in Connection.Table<Models.DB.StationTrack>()
+							on r.StationTrackId equals n.Id into track
+							from tj in track.DefaultIfEmpty()
+							join c in Connection.Table<Models.DB.Color>()
+							on r.MarkerColorId equals c.Id into color
+							from cj in color.DefaultIfEmpty()
+							orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
+							select new TimetableRow(
+								Id: r.Id.ToString(),
+								Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
+								DriveTimeMM: r.DriveTime_MM,
+								DriveTimeSS: r.DriveTime_SS,
+								StationName: s.Name,
+								IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
+								IsPass: r.IsPass ?? false,
+								HasBracket: r.HasBracket ?? false,
+								IsLastStop: r.IsLastStop ?? false,
+								ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
+								DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
+								TrackName: tj?.Name,
+								RunInLimit: r.RunInLimit,
+								RunOutLimit: r.RunOutLimit,
+								Remarks: r.Remarks,
 
-							IsInfoRow: s.RecordType
-								is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
-								or (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain,
+								IsInfoRow: s.RecordType
+									is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
+									or (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain,
 
-							DefaultMarkerColor_RGB: cj?.RGB,
-							DefaultMarkerText: r.MarkerText
+								DefaultMarkerColor_RGB: cj?.RGB,
+								DefaultMarkerText: r.MarkerText
+							)
+						).ToArray(),
+						AfterArrive: t.AfterArrive,
+						// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
+						// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
+						DayCount: t.DayCount ?? 0,
+						IsRideOnMoving: t.IsRideOnMoving,
+
+						// TODO: E電時刻表用の線色設定のサポート
+						LineColor_RGB: null
 						)
-					).ToArray(),
-					AfterArrive: t.AfterArrive,
-					// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
-					// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
-					DayCount: t.DayCount ?? 0,
-					IsRideOnMoving: t.IsRideOnMoving,
+					).FirstOrDefault();
+		}
+		catch (SQLite.SQLiteException)
+		{
+			// Handle v0 database schema that doesn't have Color table
+			return (from t in Connection.Table<Models.DB.TrainData>()
+					where t.Id == trainId
+					join w in Connection.Table<Models.DB.Work>()
+					on t.WorkId equals w.Id
+					select new TrainData(
+						Id: t.Id.ToString(),
+						Direction: DirectionExtensions.FromInt(t.Direction),
+						WorkName: w.Name,
+						AffectDate: Utils.StringToDateOnlyOrNull(w.AffectDate),
+						TrainNumber: t.TrainNumber,
+						MaxSpeed: t.MaxSpeed,
+						SpeedType: t.SpeedType,
+						NominalTractiveCapacity: t.NominalTractiveCapacity,
+						CarCount: t.CarCount,
+						Destination: t.Destination,
+						BeginRemarks: t.BeginRemarks,
+						AfterRemarks: t.AfterRemarks,
+						Remarks: t.Remarks,
+						BeforeDeparture: t.BeforeDeparture,
+						TrainInfo: t.TrainInfo,
+						(
+							from r in Connection.Table<Models.DB.TimetableRowData>()
+							where r.TrainId == trainId
+							join s in Connection.Table<Models.DB.Station>()
+							on r.StationId equals s.Id
+							join n in Connection.Table<Models.DB.StationTrack>()
+							on r.StationTrackId equals n.Id into track
+							from tj in track.DefaultIfEmpty()
+							orderby t.Direction >= 0 ? s.Location : (s.Location * -1)
+							select new TimetableRow(
+								Id: r.Id.ToString(),
+								Location: new(s.Location, s.Location_Lon_deg, s.Location_Lat_deg, s.OnStationDetectRadius_m),
+								DriveTimeMM: r.DriveTime_MM,
+								DriveTimeSS: r.DriveTime_SS,
+								StationName: s.Name,
+								IsOperationOnlyStop: r.IsOperationOnlyStop ?? false,
+								IsPass: r.IsPass ?? false,
+								HasBracket: r.HasBracket ?? false,
+								IsLastStop: r.IsLastStop ?? false,
+								ArriveTime: GetTimeData(r.Arrive_HH, r.Arrive_MM, r.Arrive_SS, r.Arrive_Str),
+								DepartureTime: GetTimeData(r.Departure_HH, r.Departure_MM, r.Departure_SS, r.Departure_Str),
+								TrackName: tj?.Name,
+								RunInLimit: r.RunInLimit,
+								RunOutLimit: r.RunOutLimit,
+								Remarks: r.Remarks,
 
-					// TODO: E電時刻表用の線色設定のサポート
-					LineColor_RGB: null
-					)
-				).FirstOrDefault();
+								IsInfoRow: s.RecordType
+									is (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain
+									or (int)Models.DB.StationRecordType.InfoRow_ForAlmostTrain,
+
+								DefaultMarkerColor_RGB: null,
+								DefaultMarkerText: null
+							)
+						).ToArray(),
+						AfterArrive: t.AfterArrive,
+						// BeforeDepartureOnStationTrackCol: t.BeforeDeparture_OnStationTrackCol,
+						// AfterArriveOnStationTrackCol: t.AfterArrive_OnStationTrackCol,
+						DayCount: t.DayCount ?? 0,
+						IsRideOnMoving: t.IsRideOnMoving,
+
+						// TODO: E電時刻表用の線色設定のサポート
+						LineColor_RGB: null
+						)
+					).FirstOrDefault();
+		}
+	}
 
 	public IReadOnlyList<WorkGroup> GetWorkGroupList()
 		=> Connection.Table<Models.DB.WorkGroup>().Select(v => new WorkGroup(

--- a/TRViS.IO/Loaders/LoaderSQL.cs
+++ b/TRViS.IO/Loaders/LoaderSQL.cs
@@ -20,8 +20,8 @@ public class LoaderSQL : ILoader, IDisposable
 	{
 		try
 		{
-			var result = Connection.ExecuteScalar("SELECT 1 FROM sqlite_master WHERE type='table' AND name='Color' LIMIT 1");
-			return result != null;
+			var result = Connection.ExecuteScalar<int>("SELECT 1 FROM sqlite_master WHERE type='table' AND name='Color' LIMIT 1");
+			return result > 0;
 		}
 		catch
 		{

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -31,6 +31,7 @@
 		<IsAotCompatible>true</IsAotCompatible>
 		<MauiVersion>10.0.41</MauiVersion>
 		<NoWarn>$(NoWarn);NU1608</NoWarn>
+		<ValidateXcodeVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">false</ValidateXcodeVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
 		<RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>

--- a/iosSim.sh
+++ b/iosSim.sh
@@ -96,6 +96,6 @@ else
 fi
 
 if [ ! -z "$DeviceName" ]; then
-  dotnet build $TARGET_PROJ -f $TARGET_FRAMEWORK -r $RUNTIME_IDENTIFIER --self-contained --nologo ${ARGS[@]} \
-  && dotnet build -t:Run $TARGET_PROJ -f $TARGET_FRAMEWORK -r $RUNTIME_IDENTIFIER --self-contained --nologo "/p:_DeviceName=$DeviceName" ${ARGS[@]}
+  dotnet build $TARGET_PROJ -f $TARGET_FRAMEWORK -r $RUNTIME_IDENTIFIER --nologo ${ARGS[@]} \
+  && dotnet build -t:Run $TARGET_PROJ -f $TARGET_FRAMEWORK -r $RUNTIME_IDENTIFIER --nologo "/p:_DeviceName=$DeviceName" ${ARGS[@]}
 fi


### PR DESCRIPTION
This pull request introduces improvements for compatibility with Xcode 26.3, adds automated test workflow for CI, and refactors several test cases to use updated model constructors and types. It also enhances database schema handling in the loader logic to support both v0 and newer schemas, and updates project build settings to avoid Xcode version validation issues. The most important changes are grouped below:

**CI/CD and Build System Updates**

* Updated `.github/workflows/cd-action.yml` to use Xcode 26.3 for both the environment variable and build step, improving compatibility with the latest Xcode version. [[1]](diffhunk://#diff-248bc9f1107ecdff6c0afa486f4f8f28754b37779c9f24abf303b0a1f77d6706L46-R46) [[2]](diffhunk://#diff-248bc9f1107ecdff6c0afa486f4f8f28754b37779c9f24abf303b0a1f77d6706L237-R237)
* Added `.github/workflows/test.yml` workflow for automated test runs on pushes and pull requests to `main`, increasing CI coverage.
* Modified `TRViS/TRViS.csproj` to disable Xcode version validation for iOS and Mac Catalyst targets, preventing build issues with newer Xcode versions.
* Updated `iosSim.sh` script to remove the `--self-contained` flag from build commands, simplifying simulator builds.

**Database Loader and Test Refactoring**

* Refactored `TRViS.IO.Tests/Loaders/LoaderSQL.Tests.cs` and `LoaderSQL.v0.Tests.cs` test cases to use direct model constructors (`WorkGroup`, `Work`, `TrainData`) instead of object initializers, and updated fields to match new model signatures. [[1]](diffhunk://#diff-783ce5a34f53cab47fb46444ceb39c1c8ce16c3cd59a291aed79bea425ced6adL105-R109) [[2]](diffhunk://#diff-783ce5a34f53cab47fb46444ceb39c1c8ce16c3cd59a291aed79bea425ced6adL122-R132) [[3]](diffhunk://#diff-783ce5a34f53cab47fb46444ceb39c1c8ce16c3cd59a291aed79bea425ced6adL146-R165) [[4]](diffhunk://#diff-fc695bc7fbaa2ce916342e5769d31ae078b7932ca65c0e2878874e432b3f10acL94-R98) [[5]](diffhunk://#diff-fc695bc7fbaa2ce916342e5769d31ae078b7932ca65c0e2878874e432b3f10acL110-R121) [[6]](diffhunk://#diff-fc695bc7fbaa2ce916342e5769d31ae078b7932ca65c0e2878874e432b3f10acL127-R154)
* Improved `TRViS.IO/Loaders/LoaderSQL.cs` to handle missing `Color` table gracefully for v0 database schema, using a `try-catch` block and fallback logic, ensuring backward compatibility. [[1]](diffhunk://#diff-06d3d44764d476d10210b4c62b7faf28bcb2b0b993959776709c6feb028493b6L20-R23) [[2]](diffhunk://#diff-06d3d44764d476d10210b4c62b7faf28bcb2b0b993959776709c6feb028493b6R90-R159)

**Sample Data and Miscellaneous**

* Updated sample SQL data in `TRViS.IO.Tests/Resources/AddSampleData_1.sql` to set the `試験` field to `NULL`, aligning with revised schema expectations.