### PR TITLE
feat(network-sync): リアルタイム編集対応とサーバー駆動の操作プロトコルを追加

### DIFF
--- a/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
+++ b/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
@@ -1,0 +1,251 @@
+using TRViS.IO;
+using TRViS.IO.Models;
+
+namespace TRViS.Core.Tests;
+
+/// <summary>
+/// <see cref="TimetableSelectionManager"/> の選択保持/フォールバック挙動 (#214) を検証する。
+/// テスト用の <see cref="FakeLoader"/> を介して各階層のリストを差し替え、
+/// Refresh() で選択 Id が維持されること、消えた階層から先頭にフォールバックすることを確認する。
+/// </summary>
+public class TimetableSelectionManagerTests
+{
+	[Fact]
+	public void Refresh_PreservesSelection_WhenAllIdsStillPresent()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		// 初期化時に WorkGroup0 → Work0 → Train0 が選択される
+		manager.SelectedWork = loader.WorkLists["wg-1"][1]; // Work1 へ移動
+		manager.SelectedTrainData = loader.TrainListsByWorkId["w-1-1"][1]; // 2 つ目の Train
+
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-1-1", manager.SelectedTrainData?.Id);
+
+		// Loader 側で Train の中身を更新 (TrainNumber を変える)
+		var data = BuildSampleData();
+		var updated = data.TrainListsByWorkId["w-1-1"][1] with { TrainNumber = "UPDATED" };
+		data.TrainListsByWorkId["w-1-1"] = [data.TrainListsByWorkId["w-1-1"][0], updated];
+		data.TrainDataById["t-1-1-1"] = updated;
+		loader.Setup(data);
+
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-1-1", manager.SelectedTrainData?.Id);
+		Assert.Equal("UPDATED", manager.SelectedTrainData?.TrainNumber);
+	}
+
+	[Fact]
+	public void Refresh_FallsBackToFirstTrain_WhenSelectedTrainRemoved()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		manager.SelectedTrainData = loader.TrainListsByWorkId["w-1-0"][1];
+		Assert.Equal("t-1-0-1", manager.SelectedTrainData?.Id);
+
+		// 2 つ目の Train を消す
+		var data = BuildSampleData();
+		data.TrainListsByWorkId["w-1-0"] = [data.TrainListsByWorkId["w-1-0"][0]];
+		data.TrainDataById.Remove("t-1-0-1");
+		loader.Setup(data);
+
+		manager.Refresh();
+
+		Assert.Equal("t-1-0-0", manager.SelectedTrainData?.Id);
+	}
+
+	[Fact]
+	public void Refresh_FallsBackToFirstWork_WhenSelectedWorkRemoved()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		manager.SelectedWork = loader.WorkLists["wg-1"][1];
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+
+		// Work[1] を消す
+		var data = BuildSampleData();
+		data.WorkLists["wg-1"] = [data.WorkLists["wg-1"][0]];
+		data.TrainListsByWorkId.Remove("w-1-1");
+		loader.Setup(data);
+
+		manager.Refresh();
+
+		Assert.Equal("w-1-0", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-0-0", manager.SelectedTrainData?.Id);
+	}
+
+	[Fact]
+	public void Refresh_FallsBackToFirstWorkGroup_WhenSelectedWorkGroupRemoved()
+	{
+		var loader = new FakeLoader();
+		var data = BuildSampleData();
+		data.WorkGroups.Add(new WorkGroup("wg-2", "WG2"));
+		data.WorkLists["wg-2"] = [new Work("w-2-0", "wg-2", "Work2-0")];
+		data.TrainListsByWorkId["w-2-0"] = [SimpleTrain("t-2-0-0")];
+		data.TrainDataById["t-2-0-0"] = data.TrainListsByWorkId["w-2-0"][0];
+		loader.Setup(data);
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		manager.SelectedWorkGroup = loader.WorkGroups[1]; // wg-2 を選択
+
+		// wg-2 を消す
+		data = BuildSampleData();
+		loader.Setup(data);
+
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-0", manager.SelectedWork?.Id);
+	}
+
+	[Fact]
+	public void OnWorkChanged_NormalSelection_FallsBackToFirstTrain()
+	{
+		// 通常の Work 選択切り替え (Refresh ではない経路) では先頭 Train が選択される
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		manager.SelectedWork = loader.WorkLists["wg-1"][1];
+
+		Assert.Equal("t-1-1-0", manager.SelectedTrainData?.Id);
+	}
+
+	[Fact]
+	public void EmptyWorkGroupList_ClearsAllChildren()
+	{
+		// #214 コメント: WorkGroup リストが空のとき、Work / Train も空でなければならない。
+		var loader = new FakeLoader();
+		loader.Setup(new SampleData()); // 全部空
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+
+		Assert.Null(manager.SelectedWorkGroup);
+		Assert.Null(manager.SelectedWork);
+		Assert.Null(manager.SelectedTrainData);
+		Assert.Null(manager.WorkList);
+		Assert.Null(manager.OrderedTrainDataList);
+	}
+
+	[Fact]
+	public void Refresh_WhenNewWorkGroupListBecomesEmpty_ClearsChildren()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		Assert.NotNull(manager.SelectedWorkGroup);
+		Assert.NotNull(manager.SelectedWork);
+		Assert.NotNull(manager.SelectedTrainData);
+
+		// Loader が空のリストを返すように切り替え、Refresh で再評価する
+		loader.Setup(new SampleData());
+		manager.Refresh();
+
+		Assert.Null(manager.SelectedWorkGroup);
+		Assert.Null(manager.SelectedWork);
+		Assert.Null(manager.SelectedTrainData);
+		Assert.Null(manager.WorkList);
+		Assert.Null(manager.OrderedTrainDataList);
+	}
+
+	[Fact]
+	public void Refresh_WhenNewWorkListBecomesEmpty_ClearsTrainSelection()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		Assert.NotNull(manager.SelectedWork);
+		Assert.NotNull(manager.SelectedTrainData);
+
+		// WorkGroup は維持しつつ、Work リストを空にする
+		var data = BuildSampleData();
+		data.WorkLists["wg-1"] = [];
+		data.TrainListsByWorkId.Clear();
+		data.TrainDataById.Clear();
+		loader.Setup(data);
+
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Null(manager.SelectedWork);
+		Assert.Null(manager.SelectedTrainData);
+		Assert.Null(manager.OrderedTrainDataList);
+	}
+
+	// ----- ヘルパー -----
+
+	private static TrainData SimpleTrain(string id) =>
+		new(id, Direction.Outbound, TrainNumber: id);
+
+	private sealed class SampleData
+	{
+		public List<WorkGroup> WorkGroups { get; } = [];
+		public Dictionary<string, List<Work>> WorkLists { get; } = [];
+		public Dictionary<string, List<TrainData>> TrainListsByWorkId { get; } = [];
+		public Dictionary<string, TrainData> TrainDataById { get; } = [];
+	}
+
+	private static SampleData BuildSampleData()
+	{
+		var d = new SampleData();
+		d.WorkGroups.Add(new WorkGroup("wg-1", "WG1"));
+		d.WorkLists["wg-1"] =
+		[
+			new Work("w-1-0", "wg-1", "Work1-0"),
+			new Work("w-1-1", "wg-1", "Work1-1"),
+		];
+		d.TrainListsByWorkId["w-1-0"] =
+		[
+			SimpleTrain("t-1-0-0"),
+			SimpleTrain("t-1-0-1"),
+		];
+		d.TrainListsByWorkId["w-1-1"] =
+		[
+			SimpleTrain("t-1-1-0"),
+			SimpleTrain("t-1-1-1"),
+		];
+		foreach (var workTrains in d.TrainListsByWorkId.Values)
+			foreach (var t in workTrains)
+				d.TrainDataById[t.Id] = t;
+		return d;
+	}
+
+	private sealed class FakeLoader : ILoader
+	{
+		public List<WorkGroup> WorkGroups { get; private set; } = [];
+		public Dictionary<string, List<Work>> WorkLists { get; private set; } = [];
+		public Dictionary<string, List<TrainData>> TrainListsByWorkId { get; private set; } = [];
+		public Dictionary<string, TrainData> TrainDataById { get; private set; } = [];
+
+		public void Setup(SampleData data)
+		{
+			WorkGroups = data.WorkGroups;
+			WorkLists = data.WorkLists;
+			TrainListsByWorkId = data.TrainListsByWorkId;
+			TrainDataById = data.TrainDataById;
+		}
+
+		public TrainData? GetTrainData(string trainId) =>
+			TrainDataById.TryGetValue(trainId, out var t) ? t : null;
+
+		public IReadOnlyList<WorkGroup> GetWorkGroupList() => WorkGroups;
+
+		public IReadOnlyList<Work> GetWorkList(string workGroupId) =>
+			WorkLists.TryGetValue(workGroupId, out var list) ? list : [];
+
+		public IReadOnlyList<TrainData> GetTrainDataList(string workId) =>
+			TrainListsByWorkId.TryGetValue(workId, out var list) ? list : [];
+
+		public void Dispose() { }
+	}
+}

--- a/TRViS.Core/TimetableSelectionManager.cs
+++ b/TRViS.Core/TimetableSelectionManager.cs
@@ -108,7 +108,46 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		_selectedWorkGroup = null;
 		RaisePropertyChanged(nameof(SelectedWorkGroup));
 		WorkGroupList = loader?.GetWorkGroupList();
-		SelectedWorkGroup = WorkGroupList?.FirstOrDefault();
+		var first = WorkGroupList?.FirstOrDefault();
+		SelectedWorkGroup = first;
+		// WorkGroup が空 (= ダイヤが空) の場合、setter の早期 return により OnWorkGroupChanged が
+		// 呼ばれず、配下の Work/Train が古い状態のままになる。明示的に空に揃える。
+		if (first is null)
+			ClearChildSelectionsBelowWorkGroup();
+	}
+
+	/// <summary>
+	/// SelectedWorkGroup が null のときに、配下の WorkList / SelectedWork /
+	/// OrderedTrainDataList / SelectedTrainData を明示的に空にする。
+	/// 「親が空ならば子も必ず空」の不変条件を保つ。
+	/// </summary>
+	private void ClearChildSelectionsBelowWorkGroup()
+	{
+		WorkList = null;
+		if (_selectedWork is not null)
+		{
+			_selectedWork = null;
+			RaisePropertyChanged(nameof(SelectedWork));
+		}
+		OrderedTrainDataList = null;
+		if (_selectedTrainData is not null)
+		{
+			_selectedTrainData = null;
+			RaisePropertyChanged(nameof(SelectedTrainData));
+		}
+	}
+
+	/// <summary>
+	/// SelectedWork が null のときに、配下の OrderedTrainDataList / SelectedTrainData を明示的に空にする。
+	/// </summary>
+	private void ClearChildSelectionsBelowWork()
+	{
+		OrderedTrainDataList = null;
+		if (_selectedTrainData is not null)
+		{
+			_selectedTrainData = null;
+			RaisePropertyChanged(nameof(SelectedTrainData));
+		}
 	}
 
 	private void OnWorkGroupChanged(WorkGroup? workGroup)
@@ -129,18 +168,48 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 
 	private void OnWorkChanged(Work? work)
 	{
-		if (work is not null && _loader is not null)
-		{
-			var trainDataList = _loader.GetTrainDataList(work.Id);
-			var orderedList = BuildOrderedTrainDataList(trainDataList, _loader);
-			OrderedTrainDataList = orderedList;
-			SelectedTrainData = orderedList.Count > 0 ? orderedList[0] : null;
-		}
-		else
+		// 通常のWork選択切り替え時: 先頭の列車を自動選択する
+		RefreshTrainDataForWork(work, preserveSelection: false);
+	}
+
+	/// <summary>
+	/// 指定の Work に紐づく <see cref="OrderedTrainDataList"/> を再構築する。
+	/// </summary>
+	/// <param name="work">対象のWork。null の場合はリスト/選択を null にする。</param>
+	/// <param name="preserveSelection">
+	/// true の場合、現在の <see cref="SelectedTrainData"/> の Id が新リスト内に存在すれば
+	/// そのまま選択を維持する (リアルタイム更新時の挙動)。
+	/// false の場合、常に先頭の列車を選択する。
+	/// </param>
+	private void RefreshTrainDataForWork(Work? work, bool preserveSelection)
+	{
+		if (work is null || _loader is null)
 		{
 			OrderedTrainDataList = null;
 			SelectedTrainData = null;
+			return;
 		}
+
+		var trainDataList = _loader.GetTrainDataList(work.Id);
+		var orderedList = BuildOrderedTrainDataList(trainDataList, _loader);
+		OrderedTrainDataList = orderedList;
+
+		if (preserveSelection)
+		{
+			// 既存の選択を Id で引き直し、まだ存在すれば最新インスタンスに更新する
+			string? previousId = _selectedTrainData?.Id;
+			if (previousId is not null)
+			{
+				var matched = orderedList.FirstOrDefault(t => t.Id == previousId);
+				if (matched is not null)
+				{
+					SelectedTrainData = matched;
+					return;
+				}
+			}
+		}
+
+		SelectedTrainData = orderedList.Count > 0 ? orderedList[0] : null;
 	}
 
 	// ---------- Refresh / Reset ----------
@@ -149,6 +218,11 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 	/// Re-reads lists from the current Loader, preserving valid current selections.
 	/// Falls back to the first item when the current selection is no longer present.
 	/// </summary>
+	/// <remarks>
+	/// リアルタイム編集対応: 各階層で現在の選択 Id がまだ存在すれば保持し、
+	/// その階層のオブジェクトは最新インスタンスに差し替える。
+	/// 選択を保持する場合は public setter を経由しない (cascade を避けるため)。
+	/// </remarks>
 	public void Refresh()
 	{
 		if (_loader is null)
@@ -157,29 +231,57 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		var newWorkGroupList = _loader.GetWorkGroupList();
 		WorkGroupList = newWorkGroupList;
 
-		bool workGroupStillValid = _selectedWorkGroup is not null
-			&& newWorkGroupList.Any(wg => wg.Id == _selectedWorkGroup.Id);
+		string? prevWorkGroupId = _selectedWorkGroup?.Id;
+		var matchedWorkGroup = prevWorkGroupId is null
+			? null
+			: newWorkGroupList.FirstOrDefault(wg => wg.Id == prevWorkGroupId);
 
-		if (!workGroupStillValid)
+		if (matchedWorkGroup is null)
 		{
-			SelectedWorkGroup = newWorkGroupList.FirstOrDefault();
+			// 既存選択が消えた → 先頭にフォールバック (cascade で配下も再構築される)
+			var fallback = newWorkGroupList.FirstOrDefault();
+			SelectedWorkGroup = fallback;
+			// WorkGroup が空ならば、setter の早期 return で配下が初期化されないため明示的に空にする
+			if (fallback is null)
+				ClearChildSelectionsBelowWorkGroup();
 			return;
 		}
 
-		var newWorkList = _loader.GetWorkList(_selectedWorkGroup!.Id);
+		// WorkGroup を維持: setter を経由するとカスケードして配下が初期化されるため、
+		// フィールドに直接代入して PropertyChanged だけを発火させる。
+		if (!Equals(_selectedWorkGroup, matchedWorkGroup))
+		{
+			_selectedWorkGroup = matchedWorkGroup;
+			RaisePropertyChanged(nameof(SelectedWorkGroup));
+		}
+
+		var newWorkList = _loader.GetWorkList(matchedWorkGroup.Id);
 		WorkList = newWorkList;
 
-		bool workStillValid = _selectedWork is not null
-			&& newWorkList.Any(w => w.Id == _selectedWork.Id);
+		string? prevWorkId = _selectedWork?.Id;
+		var matchedWork = prevWorkId is null
+			? null
+			: newWorkList.FirstOrDefault(w => w.Id == prevWorkId);
 
-		if (!workStillValid)
+		if (matchedWork is null)
 		{
-			SelectedWork = newWorkList.FirstOrDefault();
+			var fallback = newWorkList.FirstOrDefault();
+			SelectedWork = fallback;
+			// Work が空ならば、配下の Train も明示的に空にする
+			if (fallback is null)
+				ClearChildSelectionsBelowWork();
 			return;
 		}
 
-		// Work is still valid — refresh TrainData list
-		OnWorkChanged(_selectedWork);
+		// Work を維持: 同様にフィールド直接代入で cascade を避ける。
+		if (!Equals(_selectedWork, matchedWork))
+		{
+			_selectedWork = matchedWork;
+			RaisePropertyChanged(nameof(SelectedWork));
+		}
+
+		// Train リストは再構築しつつ、Id が一致すれば選択を保持する。
+		RefreshTrainDataForWork(matchedWork, preserveSelection: true);
 	}
 
 	/// <summary>

--- a/TRViS.DTAC.Logic.Tests/HakoPresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/HakoPresenterTests.cs
@@ -57,6 +57,8 @@ public class HakoPresenterTests
 			}
 		}
 
+		public string? HeaderTimeFormat { get; set; }
+
 		public event PropertyChangedEventHandler? PropertyChanged;
 	}
 
@@ -67,6 +69,8 @@ public class HakoPresenterTests
 	}
 
 	private static Work MakeWork(string name) => new Work(Id: "w1", WorkGroupId: "wg1", Name: name);
+	private static Work MakeWorkWithAffectDateText(string name, string affectDateText)
+		=> new Work(Id: "w1", WorkGroupId: "wg1", Name: name, AffectDateText: affectDateText);
 	private static WorkGroup MakeWorkGroup(string name) => new WorkGroup(Id: "wg1", Name: name);
 	private static TrainData MakeTrainData(DateOnly? affectDate = null, int dayCount = 0)
 		=> new TrainData(
@@ -195,6 +199,30 @@ public class HakoPresenterTests
 	public void AffectDateLabelTextPrefix_HasExpectedValue()
 	{
 		Assert.Equal("行路施行日\n", HakoPresenter.AffectDateLabelTextPrefix);
+	}
+
+	// --- AffectDateText override (任意の文字列) ---
+
+	[Fact]
+	public void SelectedWork_WithAffectDateText_DisplaysOverrideText()
+	{
+		var (presenter, appViewModel) = CreatePresenter();
+		appViewModel.SelectedWork = MakeWorkWithAffectDateText("列車A", "ダイヤA");
+
+		Assert.Equal(HakoPresenter.AffectDateLabelTextPrefix + "ダイヤA",
+			presenter.CurrentState.AffectDateText);
+	}
+
+	[Fact]
+	public void SelectedWork_WithAffectDateText_OverridesTrainAffectDate()
+	{
+		var (presenter, appViewModel) = CreatePresenter();
+		appViewModel.SelectedWork = MakeWorkWithAffectDateText("列車A", "緊急ダイヤ");
+		appViewModel.SelectedTrainData = MakeTrainData(affectDate: new DateOnly(2025, 5, 3));
+
+		// Work.AffectDateText が優先され、TrainData.AffectDate の日付は使われない
+		Assert.Equal(HakoPresenter.AffectDateLabelTextPrefix + "緊急ダイヤ",
+			presenter.CurrentState.AffectDateText);
 	}
 
 	// --- Dispose ---

--- a/TRViS.DTAC.Logic.Tests/NextTrainButtonPresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/NextTrainButtonPresenterTests.cs
@@ -52,6 +52,8 @@ public class NextTrainButtonPresenterTests
 			}
 		}
 
+		public string? HeaderTimeFormat { get; set; }
+
 		public event PropertyChangedEventHandler? PropertyChanged;
 	}
 

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -114,6 +114,8 @@ public class VerticalStylePagePresenterTests
 			}
 		}
 
+		public string? HeaderTimeFormat { get; set; }
+
 		public event PropertyChangedEventHandler? PropertyChanged;
 	}
 

--- a/TRViS.DTAC.Logic.Tests/ViewHostPresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/ViewHostPresenterTests.cs
@@ -57,6 +57,20 @@ public class ViewHostPresenterTests
             }
         }
 
+        private string? _headerTimeFormat;
+        public string? HeaderTimeFormat
+        {
+            get => _headerTimeFormat;
+            set
+            {
+                if (_headerTimeFormat != value)
+                {
+                    _headerTimeFormat = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HeaderTimeFormat)));
+                }
+            }
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
     }
 
@@ -167,6 +181,45 @@ public class ViewHostPresenterTests
         timeProvider.RaiseTimeChanged(0);
 
         Assert.Equal("00:00:00", presenter.CurrentState.TimeLabelText);
+    }
+
+    [Fact]
+    public void HeaderTimeFormat_HHmm_ShortensTimeLabel()
+    {
+        var (presenter, appViewModel, timeProvider) = CreatePresenter();
+
+        appViewModel.HeaderTimeFormat = "HH:mm";
+        timeProvider.RaiseTimeChanged(3723);
+
+        Assert.Equal("01:02", presenter.CurrentState.TimeLabelText);
+    }
+
+    [Fact]
+    public void HeaderTimeFormat_ChangedAfterTimeReceived_RereformatsExistingTime()
+    {
+        var (presenter, appViewModel, timeProvider) = CreatePresenter();
+
+        timeProvider.RaiseTimeChanged(3723);
+        Assert.Equal("01:02:03", presenter.CurrentState.TimeLabelText);
+
+        // フォーマット切り替え後、既存時刻が新フォーマットで再描画される
+        appViewModel.HeaderTimeFormat = "HH:mm";
+        Assert.Equal("01:02", presenter.CurrentState.TimeLabelText);
+
+        // null に戻すと既定 (HH:mm:ss) に戻る
+        appViewModel.HeaderTimeFormat = null;
+        Assert.Equal("01:02:03", presenter.CurrentState.TimeLabelText);
+    }
+
+    [Fact]
+    public void HeaderTimeFormat_UnknownFormat_FallsBackToDefault()
+    {
+        var (presenter, appViewModel, timeProvider) = CreatePresenter();
+
+        appViewModel.HeaderTimeFormat = "completely-unknown";
+        timeProvider.RaiseTimeChanged(3723);
+
+        Assert.Equal("01:02:03", presenter.CurrentState.TimeLabelText);
     }
 
     #endregion

--- a/TRViS.DTAC.Logic/Abstractions/IAppViewModelProvider.cs
+++ b/TRViS.DTAC.Logic/Abstractions/IAppViewModelProvider.cs
@@ -25,6 +25,12 @@ public interface IAppViewModelProvider
 	TrainData? SelectedTrainData { get; }
 
 	/// <summary>
+	/// サーバーから指定された、タイトルバー時刻表示のフォーマット。
+	/// 例: "HH:mm:ss" / "HH:mm" / null は実装側既定 ("HH:mm:ss")。
+	/// </summary>
+	string? HeaderTimeFormat { get; }
+
+	/// <summary>
 	/// Fired when any property changes.
 	/// </summary>
 	event PropertyChangedEventHandler? PropertyChanged;

--- a/TRViS.DTAC.Logic/Formatters/AffectDateFormatter.cs
+++ b/TRViS.DTAC.Logic/Formatters/AffectDateFormatter.cs
@@ -29,4 +29,17 @@ internal static class AffectDateFormatter
 			return string.Empty;
 		}
 	}
+
+	/// <summary>
+	/// 「施行日」表示用のフォーマット。
+	/// <paramref name="overrideText"/> に非空の文字列が渡された場合、そのまま採用する
+	/// (= 日付として解釈できない任意文字列を表示できる)。
+	/// 渡されなかった場合は <see cref="FormatAffectDateOnly"/> と同等のフォールバック動作。
+	/// </summary>
+	public static string FormatAffectDateOrText(string? overrideText, DateOnly? affectDate, int dayCount)
+	{
+		if (!string.IsNullOrEmpty(overrideText))
+			return overrideText;
+		return FormatAffectDateOnly(affectDate, dayCount);
+	}
 }

--- a/TRViS.DTAC.Logic/Presenter/HakoPresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/HakoPresenter.cs
@@ -44,7 +44,8 @@ public sealed class HakoPresenter : IDisposable
 		_workSpaceName = _appViewModel.SelectedWorkGroup?.Name;
 		_currentState.WorkInfoText = BuildWorkInfoText();
 
-		string affectDate = AffectDateFormatter.FormatAffectDateOnly(
+		string affectDate = AffectDateFormatter.FormatAffectDateOrText(
+			_appViewModel.SelectedWork?.AffectDateText,
 			_appViewModel.SelectedTrainData?.AffectDate,
 			_appViewModel.SelectedTrainData?.DayCount ?? 0);
 		_currentState.AffectDateText = AffectDateLabelTextPrefix + affectDate;
@@ -55,8 +56,12 @@ public sealed class HakoPresenter : IDisposable
 		switch (e.PropertyName)
 		{
 			case nameof(IAppViewModelProvider.SelectedWork):
+				// Work が変わると WorkInfo と AffectDate (= AffectDateText) の両方に影響しうるので、
+				// 1 回の StateChanged にまとめて変更フラグを立てる。
 				_workName = _appViewModel.SelectedWork?.Name;
-				UpdateWorkInfoText();
+				_currentState.WorkInfoText = BuildWorkInfoText();
+				UpdateAffectDateText();
+				RaiseStateChanged(HakoStateSection.WorkInfo | HakoStateSection.AffectDate);
 				break;
 			case nameof(IAppViewModelProvider.SelectedWorkGroup):
 				_workSpaceName = _appViewModel.SelectedWorkGroup?.Name;
@@ -70,12 +75,18 @@ public sealed class HakoPresenter : IDisposable
 
 	private void OnTrainDataChanged()
 	{
+		UpdateAffectDateText();
+		RaiseStateChanged(HakoStateSection.AffectDate);
+	}
+
+	private void UpdateAffectDateText()
+	{
 		var trainData = _appViewModel.SelectedTrainData;
-		string affectDate = AffectDateFormatter.FormatAffectDateOnly(
+		string affectDate = AffectDateFormatter.FormatAffectDateOrText(
+			_appViewModel.SelectedWork?.AffectDateText,
 			trainData?.AffectDate,
 			trainData?.DayCount ?? 0);
 		_currentState.AffectDateText = AffectDateLabelTextPrefix + affectDate;
-		RaiseStateChanged(HakoStateSection.AffectDate);
 	}
 
 	// ---------- Helpers ----------

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -56,7 +56,10 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 
 	private void OnAppViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		if (e.PropertyName == nameof(IAppViewModelProvider.SelectedTrainData))
+		// SelectedTrainData が変わったとき、または SelectedWork が変わったとき (= AffectDateText
+		// が更新された可能性があるとき) に施行日表示を再評価する。
+		if (e.PropertyName == nameof(IAppViewModelProvider.SelectedTrainData)
+			|| e.PropertyName == nameof(IAppViewModelProvider.SelectedWork))
 			SetSelectedTrainData(_appViewModelProvider.SelectedTrainData);
 	}
 
@@ -103,7 +106,8 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 
 	private void SetSelectedTrainData(TrainData? trainData)
 	{
-		string affectDate = AffectDateFormatter.FormatAffectDateOnly(
+		string affectDate = AffectDateFormatter.FormatAffectDateOrText(
+			_appViewModelProvider.SelectedWork?.AffectDateText,
 			trainData?.AffectDate,
 			trainData?.DayCount ?? 0);
 

--- a/TRViS.DTAC.Logic/Presenter/ViewHostPresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/ViewHostPresenter.cs
@@ -39,6 +39,8 @@ public sealed class ViewHostPresenter : IDisposable
         _currentState.TitleText = _appViewModel.SelectedWork?.Name ?? string.Empty;
     }
 
+    private int _lastTotalSeconds = 0;
+
     private void OnAppViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         switch (e.PropertyName)
@@ -47,19 +49,42 @@ public sealed class ViewHostPresenter : IDisposable
                 _currentState.TitleText = _appViewModel.SelectedWork?.Name ?? string.Empty;
                 RaiseStateChanged(ViewHostStateSection.TitleText);
                 break;
+            case nameof(IAppViewModelProvider.HeaderTimeFormat):
+                // フォーマット切り替え時に、現在の時刻を新フォーマットで再描画する
+                _currentState.TimeLabelText = FormatTimeLabel(_lastTotalSeconds);
+                RaiseStateChanged(ViewHostStateSection.TimeLabel);
+                break;
         }
     }
 
     private void OnTimeChanged(object? sender, int totalSeconds)
     {
+        _lastTotalSeconds = totalSeconds;
+        _currentState.TimeLabelText = FormatTimeLabel(totalSeconds);
+        RaiseStateChanged(ViewHostStateSection.TimeLabel);
+    }
+
+    /// <summary>
+    /// タイトルバーに表示する時刻文字列を、サーバー指示のフォーマット
+    /// (<see cref="IAppViewModelProvider.HeaderTimeFormat"/>) で組み立てる。
+    /// 未指定 (null) の場合は既定 "HH:mm:ss"。
+    /// </summary>
+    private string FormatTimeLabel(int totalSeconds)
+    {
         bool isMinus = totalSeconds < 0;
         int hour = Math.Abs(totalSeconds / 3600);
         int minute = Math.Abs((totalSeconds % 3600) / 60);
         int second = Math.Abs(totalSeconds % 60);
+        string sign = isMinus ? "-" : string.Empty;
 
-        string text = (isMinus ? "-" : string.Empty) + $"{hour:D2}:{minute:D2}:{second:D2}";
-        _currentState.TimeLabelText = text;
-        RaiseStateChanged(ViewHostStateSection.TimeLabel);
+        // 既知パターンは固定実装で速く・割り切れない過剰一般化を避ける。
+        // 不明なフォーマットは "HH:mm:ss" にフォールバック。
+        return _appViewModel.HeaderTimeFormat switch
+        {
+            "HH:mm" or "HH:MM" => sign + $"{hour:D2}:{minute:D2}",
+            "HH:mm:ss" or "HH:MM:SS" or null or "" => sign + $"{hour:D2}:{minute:D2}:{second:D2}",
+            _ => sign + $"{hour:D2}:{minute:D2}:{second:D2}",
+        };
     }
 
     private void RaiseStateChanged(ViewHostStateSection changed)

--- a/TRViS.IO.ILoader/JsonModelsConverter.cs
+++ b/TRViS.IO.ILoader/JsonModelsConverter.cs
@@ -54,6 +54,11 @@ public static partial class JsonModelsConverter
 			: jsonWork.Id;
 
 		DateOnly? affectDate = StringToDateOnlyUtil.StringToDateOnlyOrNull(jsonWork.AffectDate);
+		// JSON 上の AffectDate が日付として解釈できなかった場合は、その文字列をそのまま
+		// AffectDateText に格納する。空文字列は無視。
+		string? affectDateText = (affectDate is null && !string.IsNullOrEmpty(jsonWork.AffectDate))
+			? jsonWork.AffectDate
+			: null;
 
 		return new(
 			Id: workId,
@@ -65,7 +70,8 @@ public static partial class JsonModelsConverter
 			Remarks: jsonWork.Remarks,
 			HasETrainTimetable: jsonWork.HasETrainTimetable,
 			ETrainTimetableContentType: jsonWork.ETrainTimetableContentType,
-			ETrainTimetableContent: null  // JSONには含まれない
+			ETrainTimetableContent: null,  // JSONには含まれない
+			AffectDateText: affectDateText
 		);
 	}
 

--- a/TRViS.IO.ILoader/Models/Work.cs
+++ b/TRViS.IO.ILoader/Models/Work.cs
@@ -10,7 +10,11 @@ public record Work(
 	string? Remarks = null,
 	bool? HasETrainTimetable = null,
 	int? ETrainTimetableContentType = null,
-	byte[]? ETrainTimetableContent = null
+	byte[]? ETrainTimetableContent = null,
+	// 「施行日」に日付ではない任意の文字列を表示したい場合のテキスト。
+	// 設定されていればこちらが優先表示される (UI 側のレンダリング規約)。
+	// JSON 上の AffectDate が日付として解釈できない場合、ConvertWork が自動で埋める。
+	string? AffectDateText = null
 ) : IHasRemarksProperty
 {
 }

--- a/TRViS.IO/Loaders/LoaderJson.cs
+++ b/TRViS.IO/Loaders/LoaderJson.cs
@@ -107,18 +107,24 @@ public class LoaderJson : ILoader
 			{
 				WorkData workData = workList[workIndex];
 				string workId = workIdList[workIdIndex++];
+				DateOnly? affectDate = Utils.StringToDateOnlyOrNull(workData.AffectDate);
+				// 日付として解釈できない任意の文字列は AffectDateText に格納する
+				string? affectDateText = (affectDate is null && !string.IsNullOrEmpty(workData.AffectDate))
+					? workData.AffectDate
+					: null;
 				WorkData[workId] = new(
 					WorkGroupId: workGroupId,
 					Id: workId,
 					Name: workData.Name,
 
-					AffectDate: Utils.StringToDateOnlyOrNull(workData.AffectDate),
+					AffectDate: affectDate,
 					AffixContent: null, // workData.AffixContent,
 					AffixContentType: workData.AffixContentType,
 					ETrainTimetableContent: null, // workData.ETrainTimetableContent,
 					ETrainTimetableContentType: workData.ETrainTimetableContentType,
 					HasETrainTimetable: workData.HasETrainTimetable,
-					Remarks: workData.Remarks
+					Remarks: workData.Remarks,
+					AffectDateText: affectDateText
 				);
 				WorkGroupIdByWorkId[workId] = workGroupId;
 				System.Diagnostics.Debug.WriteLine($"\tWork: {workId} {workData.Name}");

--- a/TRViS.IO/Loaders/LoaderSQL.cs
+++ b/TRViS.IO/Loaders/LoaderSQL.cs
@@ -192,19 +192,28 @@ public class LoaderSQL : ILoader, IDisposable
 		)).ToList();
 
 	public IReadOnlyList<Work> GetWorkList(string workGroupId)
-		=> Connection.Table<Models.DB.Work>().Where(v => v.WorkGroupId == workGroupId).Select(v => new Work(
-			v.Id,
-			v.WorkGroupId,
-			v.Name,
-			Utils.StringToDateOnlyOrNull(v.AffectDate),
+		=> Connection.Table<Models.DB.Work>().Where(v => v.WorkGroupId == workGroupId).Select(v =>
+		{
+			DateOnly? affectDate = Utils.StringToDateOnlyOrNull(v.AffectDate);
+			// 日付として解釈できない任意の文字列は AffectDateText に格納する
+			string? affectDateText = (affectDate is null && !string.IsNullOrEmpty(v.AffectDate))
+				? v.AffectDate
+				: null;
+			return new Work(
+				v.Id,
+				v.WorkGroupId,
+				v.Name,
+				affectDate,
 
-			v.AffixContentType,
-			v.AffixContent,
-			v.Remarks,
-			v.HasETrainTimetable,
-			v.ETrainTimetableContentType,
-			v.ETrainTimetableContent
-		)).ToList();
+				v.AffixContentType,
+				v.AffixContent,
+				v.Remarks,
+				v.HasETrainTimetable,
+				v.ETrainTimetableContentType,
+				v.ETrainTimetableContent,
+				AffectDateText: affectDateText
+			);
+		}).ToList();
 
 	public IReadOnlyList<TrainData> GetTrainDataList(string workId)
 		=> Connection.Table<Models.DB.TrainData>().Where(v => v.WorkId == workId).Select(v => new TrainData(

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -44,6 +44,13 @@ public partial class LocationService : IDisposable
 	public event EventHandler<int>? TimeChanged;
 	public event EventHandler<Exception>? ExceptionThrown;
 	public event EventHandler<TimetableData>? TimetableUpdated;
+	public event EventHandler<ServerInfo>? ServerInfoUpdated;
+	public event EventHandler<DiagramInfo>? DiagramInfoUpdated;
+	public event EventHandler<SelectTrainCommand>? TrainSelectionRequested;
+	public event EventHandler<OperationCommand>? OperationCommandReceived;
+	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
+	public event EventHandler<NotificationData>? NotificationReceived;
+	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
 
 	/// <summary>
 	/// GPS位置情報が更新された際に発生するイベント。
@@ -152,6 +159,36 @@ void OnIsEnabledChanged(bool value)
 		TimetableUpdated?.Invoke(sender, timetableData);
 	}
 
+	void OnServerInfoUpdated(object? sender, ServerInfo info) => ServerInfoUpdated?.Invoke(sender, info);
+	void OnDiagramInfoUpdated(object? sender, DiagramInfo info) => DiagramInfoUpdated?.Invoke(sender, info);
+	void OnTrainSelectionRequested(object? sender, SelectTrainCommand cmd) => TrainSelectionRequested?.Invoke(sender, cmd);
+
+	/// <summary>
+	/// 運行操作コマンドを受信したときの処理。
+	/// 位置情報サービスの有効/無効はここで適用し、運行開始/終了は AppViewModel 側に委譲する。
+	/// </summary>
+	void OnOperationCommandReceived(object? sender, OperationCommand cmd)
+	{
+		logger.Info("OperationCommandReceived: Action={0}", cmd.Action);
+		switch (cmd.Action)
+		{
+			case OperationCommandType.EnableLocationService:
+			case OperationCommandType.StartOperation:
+				// StartOperation は位置情報サービスを ON にすることで運行を開始する
+				IsEnabled = true;
+				break;
+			case OperationCommandType.DisableLocationService:
+			case OperationCommandType.EndOperation:
+				IsEnabled = false;
+				break;
+		}
+		OperationCommandReceived?.Invoke(sender, cmd);
+	}
+
+	void OnHeaderColorChangeRequested(object? sender, HeaderColorCommand cmd) => HeaderColorChangeRequested?.Invoke(sender, cmd);
+	void OnNotificationReceived(object? sender, NotificationData n) => NotificationReceived?.Invoke(sender, n);
+	void OnTimeFormatChangeRequested(object? sender, TimeFormatCommand cmd) => TimeFormatChangeRequested?.Invoke(sender, cmd);
+
 	void OnNetworkSyncServiceCanStartChanged(object? sender, bool canStart)
 	{
 		logger.Debug("NetworkSyncServiceCanStartChanged: {0}", canStart);
@@ -225,6 +262,13 @@ void OnIsEnabledChanged(bool value)
 		{
 			networkSyncService.TimeChanged -= OnTimeChanged;
 			networkSyncService.TimetableUpdated -= OnTimetableUpdated;
+			networkSyncService.ServerInfoUpdated -= OnServerInfoUpdated;
+			networkSyncService.DiagramInfoUpdated -= OnDiagramInfoUpdated;
+			networkSyncService.TrainSelectionRequested -= OnTrainSelectionRequested;
+			networkSyncService.OperationCommandReceived -= OnOperationCommandReceived;
+			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
+			networkSyncService.NotificationReceived -= OnNotificationReceived;
+			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
 		}
 		if (currentService is IDisposable disposable)
 			disposable.Dispose();
@@ -335,6 +379,13 @@ void OnIsEnabledChanged(bool value)
 		nextService.LocationStateChanged += OnLocationStateChanged;
 		nextService.TimeChanged += OnTimeChanged;
 		nextService.TimetableUpdated += OnTimetableUpdated;
+		nextService.ServerInfoUpdated += OnServerInfoUpdated;
+		nextService.DiagramInfoUpdated += OnDiagramInfoUpdated;
+		nextService.TrainSelectionRequested += OnTrainSelectionRequested;
+		nextService.OperationCommandReceived += OnOperationCommandReceived;
+		nextService.HeaderColorChangeRequested += OnHeaderColorChangeRequested;
+		nextService.NotificationReceived += OnNotificationReceived;
+		nextService.TimeFormatChangeRequested += OnTimeFormatChangeRequested;
 		nextService.ConnectionClosed += OnNetworkSyncServiceConnectionClosed;
 		nextService.ConnectionFailed += OnNetworkSyncServiceConnectionFailed;
 		nextService.CanStartChanged += OnNetworkSyncServiceCanStartChanged;
@@ -360,6 +411,13 @@ void OnIsEnabledChanged(bool value)
 		{
 			networkSyncService.TimeChanged -= OnTimeChanged;
 			networkSyncService.TimetableUpdated -= OnTimetableUpdated;
+			networkSyncService.ServerInfoUpdated -= OnServerInfoUpdated;
+			networkSyncService.DiagramInfoUpdated -= OnDiagramInfoUpdated;
+			networkSyncService.TrainSelectionRequested -= OnTrainSelectionRequested;
+			networkSyncService.OperationCommandReceived -= OnOperationCommandReceived;
+			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
+			networkSyncService.NotificationReceived -= OnNotificationReceived;
+			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
 			networkSyncService.ConnectionClosed -= OnNetworkSyncServiceConnectionClosed;
 			networkSyncService.ConnectionFailed -= OnNetworkSyncServiceConnectionFailed;
 			networkSyncService.CanStartChanged -= OnNetworkSyncServiceCanStartChanged;

--- a/TRViS.NetworkSyncService.IntegrationTests/Dockerfile
+++ b/TRViS.NetworkSyncService.IntegrationTests/Dockerfile
@@ -12,6 +12,8 @@ COPY TRViS.IO.ILoader/TRViS.IO.ILoader.csproj \
      TRViS.IO.ILoader/
 COPY TRViS.ILocationService/TRViS.ILocationService.csproj \
      TRViS.ILocationService/
+COPY TRViS.Core/TRViS.Core.csproj \
+     TRViS.Core/
 
 RUN dotnet restore TRViS.NetworkSyncService.IntegrationTests/TRViS.NetworkSyncService.IntegrationTests.csproj
 

--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
@@ -131,6 +131,160 @@ public sealed class ReferenceServerClient : IDisposable
 	}
 
 	// ================================================================
+	// サーバー情報・ダイヤ情報
+	// ================================================================
+
+	public async Task<ServerInfoDto> GetServerInfoAsync(CancellationToken ct = default)
+	{
+		var resp = await _http.GetAsync("/control/server-info", ct);
+		resp.EnsureSuccessStatusCode();
+		return JsonSerializer.Deserialize<ServerInfoDto>(
+			await resp.Content.ReadAsStringAsync(ct), JsonOptions)!;
+	}
+
+	public async Task SetServerInfoAsync(
+		string? name = null,
+		string? admin = null,
+		string? version = null,
+		string? protocolVersion = null,
+		CancellationToken ct = default)
+	{
+		var payload = new
+		{
+			Name = name,
+			Admin = admin,
+			Version = version,
+			ProtocolVersion = protocolVersion,
+		};
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/server-info", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastServerInfoAsync(CancellationToken ct = default)
+	{
+		var resp = await _http.PostAsync("/control/broadcast-server-info", null, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task<DiagramListDto> GetDiagramsAsync(CancellationToken ct = default)
+	{
+		var resp = await _http.GetAsync("/control/diagrams", ct);
+		resp.EnsureSuccessStatusCode();
+		return JsonSerializer.Deserialize<DiagramListDto>(
+			await resp.Content.ReadAsStringAsync(ct), JsonOptions)!;
+	}
+
+	public async Task SetDiagramAsync(
+		string id,
+		string? name = null,
+		string? description = null,
+		string[]? workGroupIds = null,
+		bool makeCurrent = false,
+		CancellationToken ct = default)
+	{
+		var payload = new
+		{
+			Id = id,
+			Name = name,
+			Description = description,
+			WorkGroupIds = workGroupIds,
+			MakeCurrent = makeCurrent,
+		};
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/diagrams", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastDiagramAsync(string? diagramId = null, CancellationToken ct = default)
+	{
+		string url = diagramId is null
+			? "/control/broadcast-diagram"
+			: $"/control/broadcast-diagram?id={Uri.EscapeDataString(diagramId)}";
+		var resp = await _http.PostAsync(url, null, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task<List<ReceivedRequestDto>> GetReceivedRequestsAsync(CancellationToken ct = default)
+	{
+		var resp = await _http.GetAsync("/control/received-requests", ct);
+		resp.EnsureSuccessStatusCode();
+		return JsonSerializer.Deserialize<List<ReceivedRequestDto>>(
+			await resp.Content.ReadAsStringAsync(ct), JsonOptions)!;
+	}
+
+	public async Task ClearReceivedRequestsAsync(CancellationToken ct = default)
+	{
+		using var req = new HttpRequestMessage(HttpMethod.Delete, "/control/received-requests");
+		var resp = await _http.SendAsync(req, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	// ================================================================
+	// リモートコマンド配信
+	// ================================================================
+
+	public async Task BroadcastSelectTrainAsync(
+		string? workGroupId = null,
+		string? workId = null,
+		string? trainId = null,
+		CancellationToken ct = default)
+	{
+		var payload = new { WorkGroupId = workGroupId, WorkId = workId, TrainId = trainId };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-select-train", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastOperationCommandAsync(string action, CancellationToken ct = default)
+	{
+		var payload = new { Action = action };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-operation-command", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastHeaderColorAsync(
+		bool resetToDefault = false,
+		int? color_RGB = null,
+		CancellationToken ct = default)
+	{
+		var payload = new { ResetToDefault = resetToDefault, Color_RGB = color_RGB };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-header-color", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastNotificationAsync(
+		string? id = null,
+		string? title = null,
+		string? body = null,
+		int priority = 0,
+		string? issuedAt = null,
+		CancellationToken ct = default)
+	{
+		var payload = new { Id = id, Title = title, Body = body, Priority = priority, IssuedAt = issuedAt };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-notification", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastTimeFormatAsync(string? format = null, CancellationToken ct = default)
+	{
+		var payload = new { Format = format };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-time-format", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	// ================================================================
 	// ユーティリティ
 	// ================================================================
 
@@ -180,4 +334,23 @@ public sealed record ServerStateDto(
 	[property: JsonPropertyName("Time_ms")] long Time_ms,
 	[property: JsonPropertyName("Location_m")] double? Location_m,
 	[property: JsonPropertyName("CanStart")] bool CanStart
+);
+
+public sealed record ServerInfoDto(
+	[property: JsonPropertyName("Name")] string? Name,
+	[property: JsonPropertyName("Admin")] string? Admin,
+	[property: JsonPropertyName("Version")] string? Version,
+	[property: JsonPropertyName("ProtocolVersion")] string? ProtocolVersion
+);
+
+public sealed record DiagramListDto(
+	[property: JsonPropertyName("CurrentDiagramId")] string? CurrentDiagramId,
+	[property: JsonPropertyName("Diagrams")] DiagramEntryDto[] Diagrams
+);
+
+public sealed record DiagramEntryDto(
+	[property: JsonPropertyName("Id")] string Id,
+	[property: JsonPropertyName("Name")] string? Name,
+	[property: JsonPropertyName("Description")] string? Description,
+	[property: JsonPropertyName("WorkGroupIds")] string[]? WorkGroupIds
 );

--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/TestData.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/TestData.cs
@@ -141,4 +141,131 @@ public static class TestData
 		  ]
 		}
 		""";
+
+	/// <summary>
+	/// Train スコープ配信用 (リアルタイム編集): TrainNumber は維持しつつ、行の TrackName を変更する。
+	/// AC-1 (TimetableRow の番線変更がリアルタイム反映される) のテストで使う。
+	/// </summary>
+	public const string UpdatedTrackName = "TRACK-X-UPDATED";
+	public static readonly string TrainScopeJson_TrackNameOnly = $$"""
+		{
+		  "Id": "{{TrainId}}",
+		  "TrainNumber": "T-001",
+		  "Direction": 1,
+		  "TimetableRows": [
+		    {
+		      "StationName": "テスト駅A",
+		      "Location_m": 0.0,
+		      "Longitude_deg": 135.0,
+		      "Latitude_deg": 35.0,
+		      "OnStationDetectRadius_m": 300.0,
+		      "Departure": "10:00:00",
+		      "TrackName": "{{UpdatedTrackName}}"
+		    },
+		    {
+		      "StationName": "テスト駅B",
+		      "Location_m": 1000.0,
+		      "Longitude_deg": 135.01,
+		      "Latitude_deg": 35.01,
+		      "OnStationDetectRadius_m": 300.0,
+		      "Arrive": "10:10:00",
+		      "Departure": "10:12:00"
+		    },
+		    {
+		      "StationName": "テスト駅C",
+		      "Location_m": 2000.0,
+		      "Longitude_deg": 135.02,
+		      "Latitude_deg": 35.02,
+		      "OnStationDetectRadius_m": 300.0,
+		      "Arrive": "10:20:00"
+		    }
+		  ]
+		}
+		""";
+
+	/// <summary>
+	/// Work スコープ配信用 (フル): 配下の Trains 配列を含む完全な Work データ。
+	/// AC-2 / AC-5 の検証で、配下の Trains キャッシュが再構築されることを確認する。
+	/// </summary>
+	public static readonly string WorkScopeJsonFull = $$"""
+		{
+		  "Id": "{{WorkId}}",
+		  "Name": "統合テスト用 Work (フル更新)",
+		  "AffectDate": "20240301",
+		  "Trains": [
+		    {
+		      "Id": "{{TrainId}}",
+		      "TrainNumber": "T-001-Work",
+		      "Direction": 1,
+		      "TimetableRows": [
+		        {
+		          "StationName": "テスト駅A",
+		          "Location_m": 0.0,
+		          "Longitude_deg": 135.0,
+		          "Latitude_deg": 35.0,
+		          "OnStationDetectRadius_m": 300.0,
+		          "Departure": "10:00:00"
+		        }
+		      ]
+		    },
+		    {
+		      "Id": "{{TrainId2}}",
+		      "TrainNumber": "T-002-Work",
+		      "Direction": -1,
+		      "TimetableRows": [
+		        {
+		          "StationName": "テスト駅C",
+		          "Location_m": 2000.0,
+		          "Longitude_deg": 135.02,
+		          "Latitude_deg": 35.02,
+		          "OnStationDetectRadius_m": 300.0,
+		          "Departure": "11:00:00"
+		        }
+		      ]
+		    }
+		  ]
+		}
+		""";
+
+	/// <summary>
+	/// WorkGroup スコープ配信用 (フル): 配下の Works/Trains 構造を含む完全な WorkGroup データ。
+	/// AC-3 / AC-5 の検証で、配下の Works/Trains キャッシュが再構築されることを確認する。
+	/// </summary>
+	public static readonly string WorkGroupScopeJsonFull = $$"""
+		{
+		  "Id": "{{WorkGroupId}}",
+		  "Name": "統合テスト用 WorkGroup (フル更新)",
+		  "DBVersion": 3,
+		  "Works": [
+		    {
+		      "Id": "{{WorkId}}",
+		      "Name": "統合テスト用 Work (WG経由)",
+		      "AffectDate": "20240401",
+		      "Trains": [
+		        {
+		          "Id": "{{TrainId}}",
+		          "TrainNumber": "T-001-WG",
+		          "Direction": 1,
+		          "TimetableRows": [
+		            {
+		              "StationName": "テスト駅A",
+		              "Location_m": 0.0,
+		              "Longitude_deg": 135.0,
+		              "Latitude_deg": 35.0,
+		              "OnStationDetectRadius_m": 300.0,
+		              "Departure": "10:00:00"
+		            }
+		          ]
+		        },
+		        {
+		          "Id": "{{TrainId2}}",
+		          "TrainNumber": "T-002-WG",
+		          "Direction": -1,
+		          "TimetableRows": []
+		        }
+		      ]
+		    }
+		  ]
+		}
+		""";
 }

--- a/TRViS.NetworkSyncService.IntegrationTests/TRViS.NetworkSyncService.IntegrationTests.csproj
+++ b/TRViS.NetworkSyncService.IntegrationTests/TRViS.NetworkSyncService.IntegrationTests.csproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <!-- クライアント側のテスト対象 -->
     <ProjectReference Include="..\TRViS.NetworkSyncService\TRViS.NetworkSyncService.csproj" />
+    <!-- TimetableSelectionManager (Refresh 経路) の AC 検証で使用 -->
+    <ProjectReference Include="..\TRViS.Core\TRViS.Core.csproj" />
     <!-- ローカル開発時: in-process でサーバーを起動するために参照 -->
     <ProjectReference Include="..\TRViS.ReferenceServer\TRViS.ReferenceServer.csproj" />
   </ItemGroup>

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -2,7 +2,9 @@ using System.Net.WebSockets;
 
 using NUnit.Framework;
 
+using TRViS.Core;
 using TRViS.IO;
+using TRViS.IO.Models;
 using TRViS.LocationService.Abstractions;
 using TRViS.NetworkSyncService;
 using TRViS.NetworkSyncService.IntegrationTests.Helpers;
@@ -485,8 +487,10 @@ public class WebSocketIntegrationTests
 	// ================================================================
 
 	[Test]
-	public async Task Timetable_Update_CurrentTrain_ResetsLocationState()
+	public async Task Timetable_Update_CurrentTrain_DoesNotResetLocationState()
 	{
+		// リアルタイム編集対応 (#214): 自スコープと一致する Train 更新を受信しても
+		// 位置情報 (StationIndex) は維持されなければならない。
 		var service = await ConnectServiceAsync();
 		try
 		{
@@ -495,12 +499,12 @@ public class WebSocketIntegrationTests
 
 			// 位置を駅2 (index=1) に設定
 			service.ForceSetLocationInfo(1, false);
+			int locationChangedCount = 0;
+			service.LocationStateChanged += (_, _) => locationChangedCount++;
 
-			// 現在選択中の Train ID で時刻表更新を受信したとき → リセットされる
-			// LocationStateChanged が index=0 で発火することを検証
-			var locationTask = WaitForEventAsync<LocationStateChangedEventArgs>(
-				h => service.LocationStateChanged += h,
-				h => service.LocationStateChanged -= h
+			var timetableTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
 			);
 
 			await _control.BroadcastTimetableAsync(
@@ -509,9 +513,12 @@ public class WebSocketIntegrationTests
 				trainId: TestData.TrainId
 			);
 
-			var state = await locationTask;
-			Assert.That(state.NewStationIndex, Is.EqualTo(0));
-			Assert.That(state.IsRunningToNextStation, Is.False);
+			await timetableTask;
+			await Task.Delay(300); // リセットが起きないことを確認するための猶予
+
+			Assert.That(locationChangedCount, Is.EqualTo(0));
+			Assert.That(service.CurrentStationIndex, Is.EqualTo(1));
+			Assert.That(service.IsRunningToNextStation, Is.False);
 		}
 		finally
 		{
@@ -585,8 +592,10 @@ public class WebSocketIntegrationTests
 	}
 
 	[Test]
-	public async Task Timetable_WorkGroupScope_MatchingWorkGroup_ResetsLocationState()
+	public async Task Timetable_WorkGroupScope_MatchingWorkGroup_DoesNotResetLocationState()
 	{
+		// リアルタイム編集対応 (#214): 自スコープと一致する WorkGroup 更新を受信しても
+		// 位置情報 (StationIndex) は維持されなければならない。
 		var service = await ConnectServiceAsync();
 		try
 		{
@@ -594,21 +603,25 @@ public class WebSocketIntegrationTests
 			service.WorkGroupId = TestData.WorkGroupId;
 
 			service.ForceSetLocationInfo(1, false);
+			int locationChangedCount = 0;
+			service.LocationStateChanged += (_, _) => locationChangedCount++;
 
-			var locationTask = WaitForEventAsync<LocationStateChangedEventArgs>(
-				h => service.LocationStateChanged += h,
-				h => service.LocationStateChanged -= h
+			var timetableTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
 			);
 
-			// 現在選択中の WorkGroupId と一致する WorkGroup スコープ更新 → リセットされる
 			await _control.BroadcastTimetableAsync(
 				TestData.WorkGroupScopeJson,
 				workGroupId: TestData.WorkGroupId
 			);
 
-			var state = await locationTask;
-			Assert.That(state.NewStationIndex, Is.EqualTo(0));
-			Assert.That(state.IsRunningToNextStation, Is.False);
+			await timetableTask;
+			await Task.Delay(300);
+
+			Assert.That(locationChangedCount, Is.EqualTo(0));
+			Assert.That(service.CurrentStationIndex, Is.EqualTo(1));
+			Assert.That(service.IsRunningToNextStation, Is.False);
 		}
 		finally
 		{
@@ -653,8 +666,10 @@ public class WebSocketIntegrationTests
 	}
 
 	[Test]
-	public async Task Timetable_WorkScope_MatchingWork_ResetsLocationState()
+	public async Task Timetable_WorkScope_MatchingWork_DoesNotResetLocationState()
 	{
+		// リアルタイム編集対応 (#214): 自スコープと一致する Work 更新を受信しても
+		// 位置情報 (StationIndex) は維持されなければならない。
 		var service = await ConnectServiceAsync();
 		try
 		{
@@ -662,22 +677,26 @@ public class WebSocketIntegrationTests
 			service.WorkId = TestData.WorkId;
 
 			service.ForceSetLocationInfo(1, false);
+			int locationChangedCount = 0;
+			service.LocationStateChanged += (_, _) => locationChangedCount++;
 
-			var locationTask = WaitForEventAsync<LocationStateChangedEventArgs>(
-				h => service.LocationStateChanged += h,
-				h => service.LocationStateChanged -= h
+			var timetableTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
 			);
 
-			// 現在選択中の WorkId と一致する Work スコープ更新 → リセットされる
 			await _control.BroadcastTimetableAsync(
 				TestData.WorkScopeJson,
 				workGroupId: TestData.WorkGroupId,
 				workId: TestData.WorkId
 			);
 
-			var state = await locationTask;
-			Assert.That(state.NewStationIndex, Is.EqualTo(0));
-			Assert.That(state.IsRunningToNextStation, Is.False);
+			await timetableTask;
+			await Task.Delay(300);
+
+			Assert.That(locationChangedCount, Is.EqualTo(0));
+			Assert.That(service.CurrentStationIndex, Is.EqualTo(1));
+			Assert.That(service.IsRunningToNextStation, Is.False);
 		}
 		finally
 		{
@@ -966,6 +985,904 @@ public class WebSocketIntegrationTests
 		{
 			await DisconnectAsync(service1);
 			await DisconnectAsync(service2);
+		}
+	}
+
+	// ================================================================
+	// 受け入れ基準 AC-1..AC-7 (#214 リアルタイム編集サポート)
+	//
+	// SelectionManager + WebSocketNetworkSyncService の ILoader 実装を組み合わせて、
+	// 自スコープ更新で選択が維持されつつ最新データが反映されることを検証する。
+	// ================================================================
+
+	private static async Task SeedAllScopeAsync(WebSocketNetworkSyncService service, ReferenceServerClient control)
+	{
+		var task = WaitForEventAsync<TimetableData>(
+			h => service.TimetableUpdated += h,
+			h => service.TimetableUpdated -= h
+		);
+		await control.BroadcastTimetableAsync(TestData.AllScopeJson);
+		await task;
+	}
+
+	[Test]
+	public async Task AC1_TrainScope_SamePayload_PreservesSelectionAndUpdatesContent()
+	{
+		// AC-1: 表示中の Train(Tx) と一致する Scope.Train 更新で
+		//   - SelectedTrainData?.Id が維持される
+		//   - 行の TrackName が新しい値で反映される
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var manager = new TimetableSelectionManager { Loader = service };
+			Assert.That(manager.SelectedTrainData, Is.Not.Null);
+			// TrainId のいずれかが選択される。Tx をテスト対象として明示的に選択する。
+			manager.SelectedTrainData = manager.OrderedTrainDataList!.First(t => t.Id == TestData.TrainId);
+
+			// AppViewModel.OnTimetableUpdated と同じ流れで Refresh を駆動する
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.TrainScopeJson_TrackNameOnly,
+				workId: TestData.WorkId,
+				trainId: TestData.TrainId
+			);
+			await ttTask;
+			await Task.Delay(100); // Refresh のハンドラが走り切るのを待つ
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(manager.SelectedTrainData, Is.Not.Null);
+				Assert.That(manager.SelectedTrainData!.Id, Is.EqualTo(TestData.TrainId));
+				// 行 0 の TrackName が更新値になっていること (=再描画の素材が手元にある)
+				Assert.That(manager.SelectedTrainData!.Rows, Is.Not.Null);
+				Assert.That(manager.SelectedTrainData!.Rows![0].TrackName, Is.EqualTo(TestData.UpdatedTrackName));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC2_WorkScope_PreservesTrainSelectionWhenStillPresent()
+	{
+		// AC-2: AC-1 の状態で Scope.Work (=現在の Wx) を受信しても、
+		//   SelectedTrainData?.Id が新ペイロードに存在する限り、選択は Tx のまま維持される。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var manager = new TimetableSelectionManager { Loader = service };
+			manager.SelectedTrainData = manager.OrderedTrainDataList!.First(t => t.Id == TestData.TrainId);
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.WorkScopeJsonFull,
+				workGroupId: TestData.WorkGroupId,
+				workId: TestData.WorkId
+			);
+			await ttTask;
+			await Task.Delay(100);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(manager.SelectedWork?.Id, Is.EqualTo(TestData.WorkId));
+				Assert.That(manager.SelectedTrainData?.Id, Is.EqualTo(TestData.TrainId));
+				// 配下キャッシュも更新されているはず
+				Assert.That(manager.SelectedTrainData!.TrainNumber, Is.EqualTo("T-001-Work"));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC3_WorkGroupScope_PreservesAllSelectionsWhenStillPresent()
+	{
+		// AC-3: Scope.WorkGroup(=現在の WGx) が届き、配下が変化しても、
+		//   引き続き存在する Work / Train であれば選択が保持される。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var manager = new TimetableSelectionManager { Loader = service };
+			manager.SelectedTrainData = manager.OrderedTrainDataList!.First(t => t.Id == TestData.TrainId);
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.WorkGroupScopeJsonFull,
+				workGroupId: TestData.WorkGroupId
+			);
+			await ttTask;
+			await Task.Delay(100);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(manager.SelectedWorkGroup?.Id, Is.EqualTo(TestData.WorkGroupId));
+				Assert.That(manager.SelectedWork?.Id, Is.EqualTo(TestData.WorkId));
+				Assert.That(manager.SelectedTrainData?.Id, Is.EqualTo(TestData.TrainId));
+				Assert.That(manager.SelectedTrainData!.TrainNumber, Is.EqualTo("T-001-WG"));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC4_DifferentTrainScope_DoesNotChangeCurrentSelection()
+	{
+		// AC-4: 異なる Train への Scope.Train 更新は、現在表示中の Train の選択を変更しない。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var manager = new TimetableSelectionManager { Loader = service };
+			manager.SelectedTrainData = manager.OrderedTrainDataList!.First(t => t.Id == TestData.TrainId);
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+
+			var beforeTrainNumber = manager.SelectedTrainData!.TrainNumber;
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			// 別 Train (TrainId2) への更新
+			await _control.BroadcastTimetableAsync(
+				TestData.TrainScopeJson,
+				workId: TestData.WorkId,
+				trainId: TestData.TrainId2
+			);
+			await ttTask;
+			await Task.Delay(100);
+
+			// 現在の選択 Train は変わらない
+			Assert.That(manager.SelectedTrainData?.Id, Is.EqualTo(TestData.TrainId));
+			Assert.That(manager.SelectedTrainData!.TrainNumber, Is.EqualTo(beforeTrainNumber));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC5_WorkGroupScope_PropagatesToDescendantCaches()
+	{
+		// AC-5: Scope.WorkGroup 受信後に、Loader.GetTrainDataList(workId) /
+		//   GetTrainData(trainId) が新データを返す (配下キャッシュが更新済み)。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.WorkGroupScopeJsonFull,
+				workGroupId: TestData.WorkGroupId
+			);
+			await ttTask;
+			await Task.Delay(100);
+
+			var loader = (ILoader)service;
+
+			var trains = loader.GetTrainDataList(TestData.WorkId);
+			Assert.That(trains, Has.Count.EqualTo(2), "WorkGroup 配下の Trains が再構築されること");
+
+			var t1 = loader.GetTrainData(TestData.TrainId);
+			Assert.That(t1, Is.Not.Null);
+			Assert.That(t1!.TrainNumber, Is.EqualTo("T-001-WG"));
+
+			var t2 = loader.GetTrainData(TestData.TrainId2);
+			Assert.That(t2, Is.Not.Null);
+			Assert.That(t2!.TrainNumber, Is.EqualTo("T-002-WG"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC5_WorkScope_PropagatesToDescendantCaches()
+	{
+		// AC-5 補足: Scope.Work 受信後にも配下の Trains キャッシュが更新される。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.WorkScopeJsonFull,
+				workGroupId: TestData.WorkGroupId,
+				workId: TestData.WorkId
+			);
+			await ttTask;
+			await Task.Delay(100);
+
+			var loader = (ILoader)service;
+			var t1 = loader.GetTrainData(TestData.TrainId);
+			Assert.That(t1, Is.Not.Null);
+			Assert.That(t1!.TrainNumber, Is.EqualTo("T-001-Work"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC6_AllScope_PreservesIdsWhenStillPresent()
+	{
+		// AC-6: Scope.All 受信時に、現在の SelectedWorkGroup/Work/Train の各 Id が
+		//   新ペイロードに存在すれば、それぞれ保持される。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var manager = new TimetableSelectionManager { Loader = service };
+			manager.SelectedTrainData = manager.OrderedTrainDataList!.First(t => t.Id == TestData.TrainId);
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+
+			// 同じ Id を持つ All スコープを再配信する
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await ttTask;
+			await Task.Delay(100);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(manager.SelectedWorkGroup?.Id, Is.EqualTo(TestData.WorkGroupId));
+				Assert.That(manager.SelectedWork?.Id, Is.EqualTo(TestData.WorkId));
+				Assert.That(manager.SelectedTrainData?.Id, Is.EqualTo(TestData.TrainId));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AC6_AllScope_FallsBackWhenIdsDisappear()
+	{
+		// AC-6 補足: 既存選択の Id が新ペイロードに存在しなくなった階層から先頭にフォールバック。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await SeedAllScopeAsync(service, _control);
+
+			var manager = new TimetableSelectionManager { Loader = service };
+			manager.SelectedTrainData = manager.OrderedTrainDataList!.First(t => t.Id == TestData.TrainId);
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+
+			// 全く別の WorkGroup を含む全体更新を送る
+			string altJson = $$"""
+				[
+				  {
+				    "Id": "wg-other",
+				    "Name": "別 WG",
+				    "DBVersion": 1,
+				    "Works": [
+				      {
+				        "Id": "w-other",
+				        "Name": "別 Work",
+				        "AffectDate": "20260101",
+				        "Trains": [
+				          {
+				            "Id": "t-other",
+				            "TrainNumber": "OTHER-1",
+				            "Direction": 1,
+				            "TimetableRows": []
+				          }
+				        ]
+				      }
+				    ]
+				  }
+				]
+				""";
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(altJson);
+			await ttTask;
+			await Task.Delay(100);
+
+			// 既存選択は消えたので、新ペイロードの先頭にフォールバック
+			Assert.Multiple(() =>
+			{
+				Assert.That(manager.SelectedWorkGroup?.Id, Is.EqualTo("wg-other"));
+				Assert.That(manager.SelectedWork?.Id, Is.EqualTo("w-other"));
+				Assert.That(manager.SelectedTrainData?.Id, Is.EqualTo("t-other"));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
+	// サーバー情報・ダイヤ情報 (将来拡張)
+	// ================================================================
+
+	[Test]
+	public async Task ServerInfo_RequestFromClient_ReceivesResponse()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			await _control.SetServerInfoAsync(
+				name: "Test Server",
+				admin: "admin@example.com",
+				version: "1.2.3",
+				protocolVersion: "1.0"
+			);
+
+			var infoTask = WaitForEventAsync<ServerInfo>(
+				h => service.ServerInfoUpdated += h,
+				h => service.ServerInfoUpdated -= h
+			);
+
+			await service.RequestServerInfoAsync();
+			var info = await infoTask;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(info.Name, Is.EqualTo("Test Server"));
+				Assert.That(info.Admin, Is.EqualTo("admin@example.com"));
+				Assert.That(info.Version, Is.EqualTo("1.2.3"));
+				Assert.That(info.ProtocolVersion, Is.EqualTo("1.0"));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task ServerInfo_BroadcastFromControl_AllClientsReceive()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			await _control.SetServerInfoAsync(name: "Pushed", version: "9.9.9");
+
+			var infoTask = WaitForEventAsync<ServerInfo>(
+				h => service.ServerInfoUpdated += h,
+				h => service.ServerInfoUpdated -= h
+			);
+			await _control.BroadcastServerInfoAsync();
+
+			var info = await infoTask;
+			Assert.That(info.Name, Is.EqualTo("Pushed"));
+			Assert.That(info.Version, Is.EqualTo("9.9.9"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task DiagramInfo_RequestFromClient_ReceivesResponse()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			await _control.SetDiagramAsync(
+				id: "diag-1",
+				name: "今日のダイヤ",
+				description: "平日朝ラッシュ",
+				workGroupIds: new[] { TestData.WorkGroupId },
+				makeCurrent: true
+			);
+
+			var infoTask = WaitForEventAsync<DiagramInfo>(
+				h => service.DiagramInfoUpdated += h,
+				h => service.DiagramInfoUpdated -= h
+			);
+			await service.RequestDiagramInfoAsync();
+			var info = await infoTask;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(info.Id, Is.EqualTo("diag-1"));
+				Assert.That(info.Name, Is.EqualTo("今日のダイヤ"));
+				Assert.That(info.Description, Is.EqualTo("平日朝ラッシュ"));
+				Assert.That(info.WorkGroupIds, Is.Not.Null);
+				Assert.That(info.WorkGroupIds, Has.Length.EqualTo(1));
+				Assert.That(info.WorkGroupIds![0], Is.EqualTo(TestData.WorkGroupId));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task DiagramInfo_RequestSpecificDiagram_ReceivesThatDiagram()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			await _control.SetDiagramAsync(id: "diag-A", name: "ダイヤ A", makeCurrent: true);
+			await _control.SetDiagramAsync(id: "diag-B", name: "ダイヤ B");
+
+			var infoTask = WaitForEventAsync<DiagramInfo>(
+				h => service.DiagramInfoUpdated += h,
+				h => service.DiagramInfoUpdated -= h
+			);
+			await service.RequestDiagramInfoAsync(diagramId: "diag-B");
+			var info = await infoTask;
+
+			Assert.That(info.Id, Is.EqualTo("diag-B"));
+			Assert.That(info.Name, Is.EqualTo("ダイヤ B"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task DiagramInfo_BroadcastFromControl_AllClientsReceive()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			await _control.SetDiagramAsync(id: "diag-bcast", name: "Broadcast", makeCurrent: true);
+
+			var infoTask = WaitForEventAsync<DiagramInfo>(
+				h => service.DiagramInfoUpdated += h,
+				h => service.DiagramInfoUpdated -= h
+			);
+			await _control.BroadcastDiagramAsync();
+
+			var info = await infoTask;
+			Assert.That(info.Id, Is.EqualTo("diag-bcast"));
+			Assert.That(info.Name, Is.EqualTo("Broadcast"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task ServerInfo_ServerLogsClientRequest()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			await _control.ClearReceivedRequestsAsync();
+
+			await service.RequestServerInfoAsync();
+			await ReferenceServerClient.WaitForConditionAsync(
+				async () => (await _control.GetReceivedRequestsAsync()).Any(r => r.MessageType == "RequestServerInfo"),
+				timeoutMs: 3000
+			);
+			var requests = await _control.GetReceivedRequestsAsync();
+			Assert.That(requests.Any(r => r.MessageType == "RequestServerInfo"), Is.True);
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
+	// リモートコマンド (Server → Client)
+	// ================================================================
+
+	[Test]
+	public async Task SelectTrain_BroadcastFromServer_ClientReceivesEvent()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<SelectTrainCommand>(
+				h => service.TrainSelectionRequested += h,
+				h => service.TrainSelectionRequested -= h
+			);
+
+			await _control.BroadcastSelectTrainAsync(
+				workGroupId: TestData.WorkGroupId,
+				workId: TestData.WorkId,
+				trainId: TestData.TrainId
+			);
+
+			var cmd = await task;
+			Assert.Multiple(() =>
+			{
+				Assert.That(cmd.WorkGroupId, Is.EqualTo(TestData.WorkGroupId));
+				Assert.That(cmd.WorkId, Is.EqualTo(TestData.WorkId));
+				Assert.That(cmd.TrainId, Is.EqualTo(TestData.TrainId));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task OperationCommand_StartOperation_ClientReceivesEvent()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<OperationCommand>(
+				h => service.OperationCommandReceived += h,
+				h => service.OperationCommandReceived -= h
+			);
+
+			await _control.BroadcastOperationCommandAsync("StartOperation");
+			var cmd = await task;
+
+			Assert.That(cmd.Action, Is.EqualTo(OperationCommandType.StartOperation));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task OperationCommand_AllActions_AreReceivedCorrectly()
+	{
+		var actions = new[]
+		{
+			("StartOperation", OperationCommandType.StartOperation),
+			("EndOperation", OperationCommandType.EndOperation),
+			("EnableLocationService", OperationCommandType.EnableLocationService),
+			("DisableLocationService", OperationCommandType.DisableLocationService),
+		};
+
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			foreach (var (str, expected) in actions)
+			{
+				var task = WaitForEventAsync<OperationCommand>(
+					h => service.OperationCommandReceived += h,
+					h => service.OperationCommandReceived -= h
+				);
+				await _control.BroadcastOperationCommandAsync(str);
+				var cmd = await task;
+				Assert.That(cmd.Action, Is.EqualTo(expected), $"Action='{str}'");
+			}
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task HeaderColor_SpecificColor_ClientReceivesRgb()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<HeaderColorCommand>(
+				h => service.HeaderColorChangeRequested += h,
+				h => service.HeaderColorChangeRequested -= h
+			);
+
+			await _control.BroadcastHeaderColorAsync(resetToDefault: false, color_RGB: 0x336699);
+			var cmd = await task;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(cmd.ResetToDefault, Is.False);
+				Assert.That(cmd.Color_RGB, Is.EqualTo(0x336699));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task HeaderColor_ResetToDefault_ClientReceivesResetFlag()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<HeaderColorCommand>(
+				h => service.HeaderColorChangeRequested += h,
+				h => service.HeaderColorChangeRequested -= h
+			);
+
+			await _control.BroadcastHeaderColorAsync(resetToDefault: true);
+			var cmd = await task;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(cmd.ResetToDefault, Is.True);
+				Assert.That(cmd.Color_RGB, Is.Null);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task Notification_BroadcastFromServer_ClientReceivesAllFields()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<NotificationData>(
+				h => service.NotificationReceived += h,
+				h => service.NotificationReceived -= h
+			);
+
+			await _control.BroadcastNotificationAsync(
+				id: "n-1",
+				title: "通告タイトル",
+				body: "本文です",
+				priority: 1,
+				issuedAt: "2026-05-08T12:34:56+09:00"
+			);
+			var n = await task;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(n.Id, Is.EqualTo("n-1"));
+				Assert.That(n.Title, Is.EqualTo("通告タイトル"));
+				Assert.That(n.Body, Is.EqualTo("本文です"));
+				Assert.That(n.Priority, Is.EqualTo(1));
+				Assert.That(n.IssuedAt, Is.Not.Null);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task TimeFormat_BroadcastSpecificFormat_ClientReceivesFormat()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<TimeFormatCommand>(
+				h => service.TimeFormatChangeRequested += h,
+				h => service.TimeFormatChangeRequested -= h
+			);
+
+			await _control.BroadcastTimeFormatAsync(format: "HH:mm");
+			var cmd = await task;
+
+			Assert.That(cmd.Format, Is.EqualTo("HH:mm"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task TimeFormat_BroadcastNullResetsFormat()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<TimeFormatCommand>(
+				h => service.TimeFormatChangeRequested += h,
+				h => service.TimeFormatChangeRequested -= h
+			);
+
+			await _control.BroadcastTimeFormatAsync(format: null);
+			var cmd = await task;
+
+			// Format=null は端末既定にリセット
+			Assert.That(cmd.Format, Is.Null);
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
+	// 施行日テキスト (任意文字列)
+	// ================================================================
+
+	[Test]
+	public async Task AffectDate_NonDateString_ExposedAsAffectDateText()
+	{
+		// 「施行日」に日付以外の任意文字列が来たとき、Work.AffectDateText に格納される。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			string customJson = $$"""
+				[
+				  {
+				    "Id": "wg-affect",
+				    "Name": "施行日テスト WG",
+				    "DBVersion": 1,
+				    "Works": [
+				      {
+				        "Id": "w-affect",
+				        "Name": "施行日テスト Work",
+				        "AffectDate": "ダイヤA",
+				        "Trains": []
+				      }
+				    ]
+				  }
+				]
+				""";
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(customJson);
+			await ttTask;
+			await Task.Delay(50);
+
+			var loader = (ILoader)service;
+			var work = loader.GetWorkList("wg-affect").FirstOrDefault();
+			Assert.That(work, Is.Not.Null);
+			Assert.That(work!.AffectDate, Is.Null, "日付として解釈できないのでDateOnlyはnull");
+			Assert.That(work.AffectDateText, Is.EqualTo("ダイヤA"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task AffectDate_ValidDateString_AffectDateTextRemainsNull()
+	{
+		// 通常の日付 (YYYYMMDD など) が来たときは AffectDate に入り、AffectDateText は null。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await ttTask;
+			await Task.Delay(50);
+
+			var loader = (ILoader)service;
+			var work = loader.GetWorkList(TestData.WorkGroupId).First();
+			Assert.That(work.AffectDate, Is.Not.Null);
+			Assert.That(work.AffectDateText, Is.Null);
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
+	// 空ダイヤのカスケード (#214 コメント対応)
+	// ================================================================
+
+	[Test]
+	public async Task EmptyTimetable_AllScope_CascadesToEmptyChildren()
+	{
+		// Issue #214 コメント: ダイヤ (WorkGroup) が空のとき、配下の Work/Train も空でなければならない。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			// まず通常データをロードして、選択を持たせる
+			await SeedAllScopeAsync(service, _control);
+			var manager = new TimetableSelectionManager { Loader = service };
+			service.TimetableUpdated += (_, _) => manager.Refresh();
+			Assert.That(manager.SelectedTrainData, Is.Not.Null);
+
+			// 次に空配列を配信する
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync("[]");
+			await ttTask;
+			await Task.Delay(100);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(manager.WorkGroupList, Is.Not.Null);
+				Assert.That(manager.WorkGroupList!.Count, Is.EqualTo(0));
+				Assert.That(manager.SelectedWorkGroup, Is.Null);
+				Assert.That(manager.SelectedWork, Is.Null);
+				Assert.That(manager.SelectedTrainData, Is.Null);
+				Assert.That(manager.WorkList, Is.Null);
+				Assert.That(manager.OrderedTrainDataList, Is.Null);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
 		}
 	}
 }

--- a/TRViS.NetworkSyncService/DiagramInfo.cs
+++ b/TRViS.NetworkSyncService/DiagramInfo.cs
@@ -1,0 +1,30 @@
+namespace TRViS.NetworkSyncService;
+
+/// <summary>
+/// ダイヤ情報。
+/// WorkGroupよりも上の概念として「ダイヤ」を定義し、
+/// その識別子・名称や所属するWorkGroupなどを取得する。
+/// </summary>
+public class DiagramInfo
+{
+	/// <summary>
+	/// ダイヤの識別子
+	/// </summary>
+	public string? Id { get; set; }
+
+	/// <summary>
+	/// ダイヤの名称
+	/// </summary>
+	public string? Name { get; set; }
+
+	/// <summary>
+	/// ダイヤの説明文 / 補足
+	/// </summary>
+	public string? Description { get; set; }
+
+	/// <summary>
+	/// このダイヤに含まれる WorkGroup の ID 一覧。
+	/// サーバーが提供する場合のみ設定される。
+	/// </summary>
+	public string[]? WorkGroupIds { get; set; }
+}

--- a/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
@@ -109,6 +109,13 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	public event EventHandler<LocationStateChangedEventArgs>? LocationStateChanged;
 	public event EventHandler<int>? TimeChanged;
 	public event EventHandler<TimetableData>? TimetableUpdated;
+	public event EventHandler<ServerInfo>? ServerInfoUpdated;
+	public event EventHandler<DiagramInfo>? DiagramInfoUpdated;
+	public event EventHandler<SelectTrainCommand>? TrainSelectionRequested;
+	public event EventHandler<OperationCommand>? OperationCommandReceived;
+	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
+	public event EventHandler<NotificationData>? NotificationReceived;
+	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
 	public event EventHandler? ConnectionClosed;
 	public event EventHandler? ConnectionFailed;
 	public event EventHandler<bool>? CanStartChanged;
@@ -119,6 +126,22 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	/// Get the latest synced data from the service
 	/// </summary>
 	protected abstract Task<SyncedData> GetSyncedDataAsync(CancellationToken token);
+
+	/// <summary>
+	/// サーバー情報を要求する。
+	/// 結果は <see cref="ServerInfoUpdated"/> イベントで通知される。
+	/// </summary>
+	public virtual Task RequestServerInfoAsync(CancellationToken cancellationToken = default)
+		=> Task.CompletedTask;
+
+	/// <summary>
+	/// ダイヤ情報を要求する。
+	/// </summary>
+	/// <param name="diagramId">取得対象のダイヤID。null を渡すと現在のダイヤを取得する</param>
+	/// <param name="cancellationToken">キャンセルトークン</param>
+	/// <remarks>結果は <see cref="DiagramInfoUpdated"/> イベントで通知される。</remarks>
+	public virtual Task RequestDiagramInfoAsync(string? diagramId = null, CancellationToken cancellationToken = default)
+		=> Task.CompletedTask;
 
 	/// <summary>
 	/// Called when WorkGroupId property changes
@@ -215,18 +238,63 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	protected void RaiseTimetableUpdated(TimetableData timetableData)
 	{
 		Logger.Info("RaiseTimetableUpdated: WorkGroupId={0}, WorkId={1}, TrainId={2}, Scope={3}", timetableData.WorkGroupId, timetableData.WorkId, timetableData.TrainId, timetableData.Scope);
-		// 時刻表の変更スコープに応じて、表示継続可能か判定する
-		bool canContinue = CanContinueCurrentTimetable(timetableData);
+		// 時刻表の変更スコープに応じて、現在の位置情報をリセットすべきか判定する。
+		// リアルタイム編集対応のため、自スコープの一致更新では位置情報を維持する。
+		bool shouldResetLocation = ShouldResetLocationOnTimetableUpdate(timetableData);
 
-		if (!canContinue)
+		if (shouldResetLocation)
 		{
-			// 表示継続不可の場合は初期状態に戻す
-			Logger.Warn("RaiseTimetableUpdated: Cannot continue current timetable, resetting location info");
+			// 全体更新など影響範囲が大きい場合のみ初期状態に戻す
+			Logger.Warn("RaiseTimetableUpdated: Resetting location info due to global scope update");
 			ResetLocationInfo();
 		}
 
 		// 時刻表更新イベントを外部に通知
 		TimetableUpdated?.Invoke(this, timetableData);
+	}
+
+	protected void RaiseServerInfoUpdated(ServerInfo serverInfo)
+	{
+		Logger.Info("RaiseServerInfoUpdated: Name={0}, Version={1}", serverInfo.Name, serverInfo.Version);
+		ServerInfoUpdated?.Invoke(this, serverInfo);
+	}
+
+	protected void RaiseDiagramInfoUpdated(DiagramInfo diagramInfo)
+	{
+		Logger.Info("RaiseDiagramInfoUpdated: Id={0}, Name={1}", diagramInfo.Id, diagramInfo.Name);
+		DiagramInfoUpdated?.Invoke(this, diagramInfo);
+	}
+
+	protected void RaiseTrainSelectionRequested(SelectTrainCommand command)
+	{
+		Logger.Info("RaiseTrainSelectionRequested: WorkGroupId={0}, WorkId={1}, TrainId={2}",
+			command.WorkGroupId, command.WorkId, command.TrainId);
+		TrainSelectionRequested?.Invoke(this, command);
+	}
+
+	protected void RaiseOperationCommandReceived(OperationCommand command)
+	{
+		Logger.Info("RaiseOperationCommandReceived: Action={0}", command.Action);
+		OperationCommandReceived?.Invoke(this, command);
+	}
+
+	protected void RaiseHeaderColorChangeRequested(HeaderColorCommand command)
+	{
+		Logger.Info("RaiseHeaderColorChangeRequested: ResetToDefault={0}, Color_RGB={1}",
+			command.ResetToDefault, command.Color_RGB);
+		HeaderColorChangeRequested?.Invoke(this, command);
+	}
+
+	protected void RaiseNotificationReceived(NotificationData notification)
+	{
+		Logger.Info("RaiseNotificationReceived: Id={0}, Title={1}", notification.Id, notification.Title);
+		NotificationReceived?.Invoke(this, notification);
+	}
+
+	protected void RaiseTimeFormatChangeRequested(TimeFormatCommand command)
+	{
+		Logger.Info("RaiseTimeFormatChangeRequested: Format={0}", command.Format);
+		TimeFormatChangeRequested?.Invoke(this, command);
 	}
 
 	protected void RaiseConnectionClosed()
@@ -239,21 +307,24 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 		ConnectionFailed?.Invoke(this, EventArgs.Empty);
 	}
 
-	private bool CanContinueCurrentTimetable(TimetableData timetableData)
+	/// <summary>
+	/// 時刻表の更新を受信したとき、位置情報を初期状態にリセットすべきかを判定する。
+	/// リアルタイム編集対応のため、自スコープと一致する更新では位置情報を維持する
+	/// (例: 編集中の Train が更新されても駅 index を保持する)。
+	/// 全体更新 (<see cref="TimetableScopeType.All"/>) の場合のみリセットする。
+	/// </summary>
+	private bool ShouldResetLocationOnTimetableUpdate(TimetableData timetableData)
 	{
-		// 変更スコープに基づいて判定する
 		return timetableData.Scope switch
 		{
-			TimetableScopeType.All => false,
-			// WorkGroup単位の変更：現在の選択がこのWorkGroupと異なる場合のみ継続可能
-			TimetableScopeType.WorkGroup => _WorkGroupId != timetableData.WorkGroupId,
-
-			// Work単位の変更：現在の選択がこのWorkと異なる場合のみ継続可能
-			TimetableScopeType.Work => _WorkId != timetableData.WorkId,
-
-			// Train単位の変更：現在の選択がこのTrainと異なる場合のみ継続可能
-			TimetableScopeType.Train => _TrainId != timetableData.TrainId,
-
+			// 全体更新: 構造が変わるため位置情報をリセットする
+			TimetableScopeType.All => true,
+			// WorkGroup / Work / Train 単位の更新: 自スコープと一致するか否かに関わらず維持する。
+			//   - 一致する場合 → ユーザーが今見ているデータの再描画を期待しているのでリセットしない
+			//   - 一致しない場合 → そもそも現在の表示と無関係なのでリセットしない
+			TimetableScopeType.WorkGroup => false,
+			TimetableScopeType.Work => false,
+			TimetableScopeType.Train => false,
 			_ => false,
 		};
 	}

--- a/TRViS.NetworkSyncService/RemoteCommands.cs
+++ b/TRViS.NetworkSyncService/RemoteCommands.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace TRViS.NetworkSyncService;
+
+/// <summary>
+/// サーバーから列車選択を指示するコマンド。
+/// 受信側は WorkGroupId / WorkId / TrainId に対応する列車を選択する。
+/// 任意のフィールドが null の場合、その階層は変更しない (将来拡張用)。
+/// </summary>
+public class SelectTrainCommand
+{
+	public string? WorkGroupId { get; set; }
+	public string? WorkId { get; set; }
+	public string? TrainId { get; set; }
+}
+
+/// <summary>
+/// 運行操作コマンドの種別。
+/// </summary>
+public enum OperationCommandType
+{
+	/// <summary>運行開始 (位置情報サービスを有効にして運行モードに入る)</summary>
+	StartOperation,
+	/// <summary>運行終了</summary>
+	EndOperation,
+	/// <summary>位置情報サービスを有効化する</summary>
+	EnableLocationService,
+	/// <summary>位置情報サービスを無効化する</summary>
+	DisableLocationService,
+}
+
+/// <summary>
+/// サーバーから送られる運行操作コマンド。
+/// </summary>
+public class OperationCommand
+{
+	public OperationCommandType Action { get; set; }
+}
+
+/// <summary>
+/// タイトルバー (ヘッダ) の色変更要求。
+/// <see cref="ResetToDefault"/> が true のとき、端末の設定値に戻す。
+/// false のとき、<see cref="Color_RGB"/> の RGB 値 (0xRRGGBB) を適用する。
+/// </summary>
+public class HeaderColorCommand
+{
+	public bool ResetToDefault { get; set; }
+	public int? Color_RGB { get; set; }
+}
+
+/// <summary>
+/// 通告 (任意のお知らせ) を表すデータ。
+/// 画面実装は別途行うが、プロトコル/イベントとしては受信できるようにする。
+/// </summary>
+public class NotificationData
+{
+	public string? Id { get; set; }
+	public string? Title { get; set; }
+	public string? Body { get; set; }
+	/// <summary>0=通常, 1=重要 等。サーバ任意。</summary>
+	public int Priority { get; set; }
+	public DateTimeOffset? IssuedAt { get; set; }
+}
+
+/// <summary>
+/// タイトルバー部分の時刻表示フォーマット指定。
+/// 例: "HH:mm:ss" / "HH:mm" / null は端末既定。
+/// </summary>
+public class TimeFormatCommand
+{
+	public string? Format { get; set; }
+}

--- a/TRViS.NetworkSyncService/ServerInfo.cs
+++ b/TRViS.NetworkSyncService/ServerInfo.cs
@@ -1,0 +1,27 @@
+namespace TRViS.NetworkSyncService;
+
+/// <summary>
+/// サーバーから受け取るサーバー情報
+/// </summary>
+public class ServerInfo
+{
+	/// <summary>
+	/// サーバー名
+	/// </summary>
+	public string? Name { get; set; }
+
+	/// <summary>
+	/// 管理者名 / 連絡先
+	/// </summary>
+	public string? Admin { get; set; }
+
+	/// <summary>
+	/// サーバー実装バージョン
+	/// </summary>
+	public string? Version { get; set; }
+
+	/// <summary>
+	/// サーバーが対応するプロトコルバージョン
+	/// </summary>
+	public string? ProtocolVersion { get; set; }
+}

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -37,7 +37,26 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	private const string MESSAGE_TYPE_JSON_KEY = "MessageType";
 	private const string MESSAGE_TYPE_SYNCED_DATA = "SyncedData";
 	private const string MESSAGE_TYPE_TIMETABLE = "Timetable";
+	private const string MESSAGE_TYPE_SERVER_INFO = "ServerInfo";
+	private const string MESSAGE_TYPE_DIAGRAM_INFO = "DiagramInfo";
+	private const string MESSAGE_TYPE_REQUEST_SERVER_INFO = "RequestServerInfo";
+	private const string MESSAGE_TYPE_REQUEST_DIAGRAM_INFO = "RequestDiagramInfo";
+	private const string MESSAGE_TYPE_SELECT_TRAIN = "SelectTrain";
+	private const string MESSAGE_TYPE_OPERATION_COMMAND = "OperationCommand";
+	private const string MESSAGE_TYPE_HEADER_COLOR = "HeaderColor";
+	private const string MESSAGE_TYPE_NOTIFICATION = "Notification";
+	private const string MESSAGE_TYPE_TIME_FORMAT = "TimeFormat";
 	private const string TIMETABLE_DATA_JSON_KEY = "Data";
+
+	// ServerInfo / DiagramInfo のJSONキー
+	private const string SERVER_NAME_JSON_KEY = "Name";
+	private const string SERVER_ADMIN_JSON_KEY = "Admin";
+	private const string SERVER_VERSION_JSON_KEY = "Version";
+	private const string SERVER_PROTOCOL_VERSION_JSON_KEY = "ProtocolVersion";
+	private const string DIAGRAM_ID_JSON_KEY = "DiagramId";
+	private const string DIAGRAM_NAME_JSON_KEY = "Name";
+	private const string DIAGRAM_DESCRIPTION_JSON_KEY = "Description";
+	private const string DIAGRAM_WORK_GROUP_IDS_JSON_KEY = "WorkGroupIds";
 
 	private ClientWebSocket _WebSocket;
 	private readonly Uri _Uri;
@@ -232,6 +251,34 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			{
 				ProcessTimetableMessage(root);
 			}
+			else if (messageType == MESSAGE_TYPE_SERVER_INFO)
+			{
+				ProcessServerInfoMessage(root);
+			}
+			else if (messageType == MESSAGE_TYPE_DIAGRAM_INFO)
+			{
+				ProcessDiagramInfoMessage(root);
+			}
+			else if (messageType == MESSAGE_TYPE_SELECT_TRAIN)
+			{
+				ProcessSelectTrainMessage(root);
+			}
+			else if (messageType == MESSAGE_TYPE_OPERATION_COMMAND)
+			{
+				ProcessOperationCommandMessage(root);
+			}
+			else if (messageType == MESSAGE_TYPE_HEADER_COLOR)
+			{
+				ProcessHeaderColorMessage(root);
+			}
+			else if (messageType == MESSAGE_TYPE_NOTIFICATION)
+			{
+				ProcessNotificationMessage(root);
+			}
+			else if (messageType == MESSAGE_TYPE_TIME_FORMAT)
+			{
+				ProcessTimeFormatMessage(root);
+			}
 		}
 		catch (JsonException ex)
 		{
@@ -336,6 +383,126 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		RaiseTimetableUpdated(timetableData);
 	}
 
+	private void ProcessServerInfoMessage(JsonElement root)
+	{
+		var info = new ServerInfo();
+		if (root.TryGetProperty(SERVER_NAME_JSON_KEY, out var n) && n.ValueKind != JsonValueKind.Null)
+			info.Name = n.GetString();
+		if (root.TryGetProperty(SERVER_ADMIN_JSON_KEY, out var a) && a.ValueKind != JsonValueKind.Null)
+			info.Admin = a.GetString();
+		if (root.TryGetProperty(SERVER_VERSION_JSON_KEY, out var v) && v.ValueKind != JsonValueKind.Null)
+			info.Version = v.GetString();
+		if (root.TryGetProperty(SERVER_PROTOCOL_VERSION_JSON_KEY, out var pv) && pv.ValueKind != JsonValueKind.Null)
+			info.ProtocolVersion = pv.GetString();
+
+		RaiseServerInfoUpdated(info);
+	}
+
+	private void ProcessDiagramInfoMessage(JsonElement root)
+	{
+		var info = new DiagramInfo();
+		if (root.TryGetProperty(DIAGRAM_ID_JSON_KEY, out var id) && id.ValueKind != JsonValueKind.Null)
+			info.Id = id.GetString();
+		if (root.TryGetProperty(DIAGRAM_NAME_JSON_KEY, out var n) && n.ValueKind != JsonValueKind.Null)
+			info.Name = n.GetString();
+		if (root.TryGetProperty(DIAGRAM_DESCRIPTION_JSON_KEY, out var d) && d.ValueKind != JsonValueKind.Null)
+			info.Description = d.GetString();
+		if (root.TryGetProperty(DIAGRAM_WORK_GROUP_IDS_JSON_KEY, out var wgIds) && wgIds.ValueKind == JsonValueKind.Array)
+		{
+			var list = new List<string>();
+			foreach (var elem in wgIds.EnumerateArray())
+			{
+				if (elem.ValueKind == JsonValueKind.String)
+				{
+					var s = elem.GetString();
+					if (s is not null) list.Add(s);
+				}
+			}
+			info.WorkGroupIds = [.. list];
+		}
+
+		RaiseDiagramInfoUpdated(info);
+	}
+
+	private void ProcessSelectTrainMessage(JsonElement root)
+	{
+		var cmd = new SelectTrainCommand
+		{
+			WorkGroupId = TryGetStringProperty(root, WORK_GROUP_ID_JSON_KEY),
+			WorkId = TryGetStringProperty(root, WORK_ID_JSON_KEY),
+			TrainId = TryGetStringProperty(root, TRAIN_ID_JSON_KEY),
+		};
+		RaiseTrainSelectionRequested(cmd);
+	}
+
+	private void ProcessOperationCommandMessage(JsonElement root)
+	{
+		string? action = TryGetStringProperty(root, "Action");
+		if (action is null)
+		{
+			logger.Warn("ProcessOperationCommandMessage: Missing 'Action' field");
+			return;
+		}
+		if (!Enum.TryParse<OperationCommandType>(action, ignoreCase: true, out var parsed))
+		{
+			logger.Warn("ProcessOperationCommandMessage: Unknown Action '{0}'", action);
+			return;
+		}
+		RaiseOperationCommandReceived(new OperationCommand { Action = parsed });
+	}
+
+	private void ProcessHeaderColorMessage(JsonElement root)
+	{
+		var cmd = new HeaderColorCommand();
+		if (root.TryGetProperty("ResetToDefault", out var rd))
+		{
+			cmd.ResetToDefault = rd.ValueKind == JsonValueKind.True;
+		}
+		if (root.TryGetProperty("Color_RGB", out var color) && color.ValueKind == JsonValueKind.Number)
+		{
+			if (color.TryGetInt32(out int rgb))
+				cmd.Color_RGB = rgb;
+		}
+		RaiseHeaderColorChangeRequested(cmd);
+	}
+
+	private void ProcessNotificationMessage(JsonElement root)
+	{
+		var n = new NotificationData
+		{
+			Id = TryGetStringProperty(root, "Id"),
+			Title = TryGetStringProperty(root, "Title"),
+			Body = TryGetStringProperty(root, "Body"),
+		};
+		if (root.TryGetProperty("Priority", out var p) && p.ValueKind == JsonValueKind.Number
+			&& p.TryGetInt32(out int prio))
+			n.Priority = prio;
+		if (root.TryGetProperty("IssuedAt", out var t) && t.ValueKind == JsonValueKind.String)
+		{
+			string? s = t.GetString();
+			if (s is not null && DateTimeOffset.TryParse(s, System.Globalization.CultureInfo.InvariantCulture,
+				System.Globalization.DateTimeStyles.RoundtripKind, out var dto))
+				n.IssuedAt = dto;
+		}
+		RaiseNotificationReceived(n);
+	}
+
+	private void ProcessTimeFormatMessage(JsonElement root)
+	{
+		var cmd = new TimeFormatCommand
+		{
+			Format = TryGetStringProperty(root, "Format"),
+		};
+		RaiseTimeFormatChangeRequested(cmd);
+	}
+
+	private static string? TryGetStringProperty(JsonElement root, string name)
+	{
+		if (root.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
+			return prop.GetString();
+		return null;
+	}
+
 	private void CacheTimetableData(TimetableData timetableData)
 	{
 		try
@@ -380,8 +547,8 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 							timetableData.JsonData,
 							JsonDeserializeOptions
 						);
-						var workGroup = JsonModelsConverter.ConvertWorkGroup(jsonModels!);
-						_WorkGroupCache[timetableData.WorkGroupId] = workGroup;
+						if (jsonModels is not null)
+							CacheWorkGroupSubtree(timetableData.WorkGroupId, jsonModels);
 					}
 					break;
 
@@ -393,14 +560,8 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 							timetableData.JsonData,
 							JsonDeserializeOptions
 						);
-						var work = JsonModelsConverter.ConvertWork(jsonModels!, timetableData.WorkGroupId);
-
-						if (!_WorkListCache.ContainsKey(timetableData.WorkGroupId))
-							_WorkListCache[timetableData.WorkGroupId] = [];
-
-						// 既存のWorkを削除して追加（更新）
-						_WorkListCache[timetableData.WorkGroupId].RemoveAll(w => w.Id == timetableData.WorkId);
-						_WorkListCache[timetableData.WorkGroupId].Add(work);
+						if (jsonModels is not null)
+							CacheWorkSubtree(timetableData.WorkGroupId, timetableData.WorkId, jsonModels);
 					}
 					break;
 
@@ -441,20 +602,7 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		{
 			// JsonModelsConverterを使用してWorkGroupを変換
 			var workGroup = JsonModelsConverter.ConvertWorkGroup(workGroupData);
-			_WorkGroupCache[workGroup.Id] = workGroup;
-			logger.Debug("CacheConvertedWorkGroup: Added WorkGroup {0} ({1})", workGroup.Id, workGroup.Name);
-
-			// Works配列を処理
-			if (workGroupData.Works is not null && workGroupData.Works.Length > 0)
-			{
-				if (!_WorkListCache.ContainsKey(workGroup.Id))
-					_WorkListCache[workGroup.Id] = [];
-
-				foreach (var workData in workGroupData.Works)
-				{
-					CacheConvertedWork(workData, workGroup.Id);
-				}
-			}
+			CacheWorkGroupSubtree(workGroup.Id, workGroupData);
 		}
 		catch (Exception ex)
 		{
@@ -462,50 +610,110 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		}
 	}
 
-	private void CacheConvertedWork(JsonModels.WorkData workData, string workGroupId)
+	/// <summary>
+	/// WorkGroup スコープ更新を受信したときに、当該 WorkGroup 配下の
+	/// Works / Trains キャッシュをペイロードに合わせて完全に再構築する。
+	/// 他の WorkGroup の分は触らない。
+	/// </summary>
+	private void CacheWorkGroupSubtree(string workGroupId, JsonModels.WorkGroupData workGroupData)
 	{
-		try
+		var workGroup = JsonModelsConverter.ConvertWorkGroup(workGroupData);
+		_WorkGroupCache[workGroupId] = workGroup;
+		logger.Debug("CacheWorkGroupSubtree: Updated WorkGroup {0} ({1})", workGroupId, workGroup.Name);
+
+		// 当該 WorkGroup 配下の Works / Trains キャッシュをまるごと作り直す
+		// (他の WorkGroup の分は残す)
+		if (_WorkListCache.TryGetValue(workGroupId, out var existingWorks))
 		{
-			// JsonModelsConverterを使用してWorkを変換
-			var works = JsonModelsConverter.ConvertWorks(new[] { workData }, workGroupId);
-			if (works.Length > 0)
+			foreach (var w in existingWorks)
+				PurgeWorkSubtree(w.Id);
+		}
+		_WorkListCache[workGroupId] = [];
+
+		if (workGroupData.Works is not null && workGroupData.Works.Length > 0)
+		{
+			foreach (var workData in workGroupData.Works)
 			{
-				var work = works[0];
-				_WorkListCache[workGroupId].Add(work);
-				logger.Debug("CacheConvertedWork: Added Work {0} ({1})", work.Id, work.Name);
-
-				// Trains配列を処理
-				if (workData.Trains is not null && workData.Trains.Length > 0)
+				try
 				{
-					if (!_TrainListByWorkIdCache.ContainsKey(work.Id))
-						_TrainListByWorkIdCache[work.Id] = [];
-
-					foreach (var trainData in workData.Trains)
-					{
-						CacheConvertedTrain(trainData, work.Id);
-					}
+					var work = JsonModelsConverter.ConvertWork(workData, workGroupId);
+					_WorkListCache[workGroupId].Add(work);
+					RebuildTrainCacheForWork(work.Id, workData.Trains);
+				}
+				catch (Exception ex)
+				{
+					logger.Error(ex, "CacheWorkGroupSubtree: Failed to process Work");
 				}
 			}
 		}
-		catch (Exception ex)
+	}
+
+	/// <summary>
+	/// Work スコープ更新を受信したときに、当該 Work と配下の Trains キャッシュを
+	/// ペイロードに合わせて完全に再構築する。他の Work の分は触らない。
+	/// </summary>
+	private void CacheWorkSubtree(string workGroupId, string workId, JsonModels.WorkData workData)
+	{
+		var work = JsonModelsConverter.ConvertWork(workData, workGroupId);
+
+		if (!_WorkListCache.ContainsKey(workGroupId))
+			_WorkListCache[workGroupId] = [];
+
+		_WorkListCache[workGroupId].RemoveAll(w => w.Id == workId);
+		_WorkListCache[workGroupId].Add(work);
+		logger.Debug("CacheWorkSubtree: Updated Work {0} ({1}) under WorkGroup {2}", work.Id, work.Name, workGroupId);
+
+		RebuildTrainCacheForWork(work.Id, workData.Trains);
+	}
+
+	/// <summary>
+	/// 指定の Work 配下の Train キャッシュ (TrainListByWorkIdCache / TrainDataCache) を、
+	/// 渡された Trains 配列で完全に置き換える。
+	/// </summary>
+	/// <remarks>
+	/// 前提: TrainId はちょうど一つの Work に属する (LoaderJson の WorkIdByTrainId と同じ不変条件)。
+	/// この前提が崩れると、他の Work から参照されている TrainId を誤って _TrainDataCache から削除しうる。
+	/// </remarks>
+	private void RebuildTrainCacheForWork(string workId, JsonModels.TrainData[]? trains)
+	{
+		// 古い Train を _TrainDataCache から取り除く (上記不変条件により他 Work からは参照されない)
+		if (_TrainListByWorkIdCache.TryGetValue(workId, out var oldTrains))
 		{
-			logger.Error(ex, "CacheConvertedWork: Failed to process Work");
+			foreach (var oldTrain in oldTrains)
+				_TrainDataCache.Remove(oldTrain.Id);
+		}
+		_TrainListByWorkIdCache[workId] = [];
+
+		if (trains is null || trains.Length == 0)
+			return;
+
+		foreach (var trainJson in trains)
+		{
+			try
+			{
+				var trainData = JsonModelsConverter.ConvertTrain(trainJson);
+				_TrainDataCache[trainData.Id] = trainData;
+				_TrainListByWorkIdCache[workId].Add(trainData);
+				logger.Debug("RebuildTrainCacheForWork: Added Train {0} ({1})", trainData.Id, trainData.TrainNumber);
+			}
+			catch (Exception ex)
+			{
+				logger.Error(ex, "RebuildTrainCacheForWork: Failed to process Train");
+			}
 		}
 	}
 
-	private void CacheConvertedTrain(JsonModels.TrainData trainDataJson, string workId)
+	/// <summary>
+	/// 指定の Work 配下の Train キャッシュエントリを完全に削除する。
+	/// WorkGroup 配下の構造が変化したときの掃除に使う。
+	/// </summary>
+	private void PurgeWorkSubtree(string workId)
 	{
-		try
+		if (_TrainListByWorkIdCache.TryGetValue(workId, out var oldTrains))
 		{
-			// JsonModelsConverterを使用してTrainDataを変換
-			var trainData = JsonModelsConverter.ConvertTrain(trainDataJson);
-			_TrainDataCache[trainData.Id] = trainData;
-			_TrainListByWorkIdCache[workId].Add(trainData);
-			logger.Debug("CacheConvertedTrain: Added Train {0} ({1})", trainData.Id, trainData.TrainNumber);
-		}
-		catch (Exception ex)
-		{
-			logger.Error(ex, "CacheConvertedTrain: Failed to process Train");
+			foreach (var oldTrain in oldTrains)
+				_TrainDataCache.Remove(oldTrain.Id);
+			_TrainListByWorkIdCache.Remove(workId);
 		}
 	}
 
@@ -525,6 +733,52 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	{
 		logger.Debug("OnTrainIdChanged: {0}", value);
 		_ = SendIdUpdateAsync();
+	}
+
+	public override Task RequestServerInfoAsync(CancellationToken cancellationToken = default)
+		=> SendRequestMessageAsync(MESSAGE_TYPE_REQUEST_SERVER_INFO, additional: null, cancellationToken);
+
+	public override Task RequestDiagramInfoAsync(string? diagramId = null, CancellationToken cancellationToken = default)
+	{
+		Dictionary<string, string?>? additional = null;
+		if (diagramId is not null)
+			additional = new Dictionary<string, string?> { [DIAGRAM_ID_JSON_KEY] = diagramId };
+		return SendRequestMessageAsync(MESSAGE_TYPE_REQUEST_DIAGRAM_INFO, additional, cancellationToken);
+	}
+
+	private async Task SendRequestMessageAsync(
+		string messageType,
+		Dictionary<string, string?>? additional,
+		CancellationToken cancellationToken)
+	{
+		if (_WebSocket.State != WebSocketState.Open)
+		{
+			logger.Warn("SendRequestMessageAsync ({0}): WebSocket is not open", messageType);
+			return;
+		}
+
+		try
+		{
+			var payload = new Dictionary<string, string?> { [MESSAGE_TYPE_JSON_KEY] = messageType };
+			if (additional is not null)
+			{
+				foreach (var kv in additional)
+					payload[kv.Key] = kv.Value;
+			}
+			string json = JsonSerializer.Serialize(payload);
+			logger.Debug("SendRequestMessageAsync: Sending request: {0}", json);
+			byte[] bytes = Encoding.UTF8.GetBytes(json);
+			await _WebSocket.SendAsync(
+				new ArraySegment<byte>(bytes),
+				WebSocketMessageType.Text,
+				endOfMessage: true,
+				cancellationToken
+			);
+		}
+		catch (WebSocketException ex)
+		{
+			logger.Error(ex, "SendRequestMessageAsync ({0}): WebSocket exception", messageType);
+		}
 	}
 
 	private async Task SendIdUpdateAsync()

--- a/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
+++ b/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
@@ -28,6 +28,21 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 	// --- WebSocket クライアント管理 ---
 	private readonly ConcurrentDictionary<string, ClientState> _wsClients = new();
 
+	// --- サーバー情報・ダイヤ情報 ---
+	private readonly object _infoLock = new();
+	private ServerInfoState _serverInfo = new(
+		Name: "TRViS Reference Server",
+		Admin: null,
+		Version: "0.0.0",
+		ProtocolVersion: "1.0"
+	);
+	// DiagramId -> DiagramInfoState のマップ。null キーで「カレント」を表現。
+	private readonly Dictionary<string, DiagramInfoState> _diagrams = new();
+	private string? _currentDiagramId;
+
+	// --- 受信した RequestServerInfo / RequestDiagramInfo のログ (テスト用) ---
+	private readonly ConcurrentQueue<ReceivedRequestDto> _receivedRequests = new();
+
 	private static readonly JsonSerializerOptions JsonOptions = new()
 	{
 		PropertyNameCaseInsensitive = true,
@@ -107,6 +122,22 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			("GET", "ws-clients") => GetWsClients(),
 			("POST", "disconnect-all") => await DisconnectAllAsync(),
 			("POST", "reset") => Reset(),
+			// サーバー情報・ダイヤ情報
+			("GET", "server-info") => GetServerInfo(),
+			("POST", "server-info") => SetServerInfo(request),
+			("POST", "broadcast-server-info") => await BroadcastServerInfoAsync(),
+			("GET", "diagrams") => GetDiagrams(),
+			("POST", "diagrams") => SetDiagram(request),
+			("POST", "broadcast-diagram") => await BroadcastDiagramAsync(request),
+			// 受信要求ログ (テスト用)
+			("GET", "received-requests") => GetReceivedRequests(),
+			("DELETE", "received-requests") => ClearReceivedRequests(),
+			// リモートコマンド配信
+			("POST", "broadcast-select-train") => await BroadcastSelectTrainAsync(request),
+			("POST", "broadcast-operation-command") => await BroadcastOperationCommandAsync(request),
+			("POST", "broadcast-header-color") => await BroadcastHeaderColorAsync(request),
+			("POST", "broadcast-notification") => await BroadcastNotificationAsync(request),
+			("POST", "broadcast-time-format") => await BroadcastTimeFormatAsync(request),
 			_ => Error(HttpStatusCode.NotFound, $"Unknown control endpoint: {method} /control/{sub}"),
 		};
 	}
@@ -253,7 +284,326 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 	{
 		_state = new ServerState(0, double.NaN, false);
 		while (_httpQueryLog.TryDequeue(out _)) { }
+		while (_receivedRequests.TryDequeue(out _)) { }
+		lock (_infoLock)
+		{
+			_serverInfo = new ServerInfoState(
+				Name: "TRViS Reference Server",
+				Admin: null,
+				Version: "0.0.0",
+				ProtocolVersion: "1.0"
+			);
+			_diagrams.Clear();
+			_currentDiagramId = null;
+		}
 		return OkJson("{\"ok\":true}");
+	}
+
+	// ================================================================
+	// サーバー情報
+	// ================================================================
+
+	private HttpResponse GetServerInfo()
+	{
+		ServerInfoState info;
+		lock (_infoLock) { info = _serverInfo; }
+		return OkJson(JsonSerializer.Serialize(new
+		{
+			Name = info.Name,
+			Admin = info.Admin,
+			Version = info.Version,
+			ProtocolVersion = info.ProtocolVersion,
+		}, JsonOptions));
+	}
+
+	private HttpResponse SetServerInfo(HttpRequest request)
+	{
+		try
+		{
+			string body = Encoding.UTF8.GetString(request.Body);
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+			lock (_infoLock)
+			{
+				_serverInfo = new ServerInfoState(
+					Name: TryGetString(root, "Name") ?? _serverInfo.Name,
+					Admin: TryGetString(root, "Admin") ?? _serverInfo.Admin,
+					Version: TryGetString(root, "Version") ?? _serverInfo.Version,
+					ProtocolVersion: TryGetString(root, "ProtocolVersion") ?? _serverInfo.ProtocolVersion
+				);
+			}
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex)
+		{
+			return Error(HttpStatusCode.BadRequest, ex.Message);
+		}
+	}
+
+	private async Task<HttpResponse> BroadcastServerInfoAsync()
+	{
+		string message = BuildServerInfoMessage();
+		await BroadcastTextAsync(message);
+		return OkJson("{\"ok\":true}");
+	}
+
+	private string BuildServerInfoMessage()
+	{
+		ServerInfoState info;
+		lock (_infoLock) { info = _serverInfo; }
+		return JsonSerializer.Serialize(new
+		{
+			MessageType = "ServerInfo",
+			Name = info.Name,
+			Admin = info.Admin,
+			Version = info.Version,
+			ProtocolVersion = info.ProtocolVersion,
+		});
+	}
+
+	// ================================================================
+	// ダイヤ情報
+	// ================================================================
+
+	private HttpResponse GetDiagrams()
+	{
+		DiagramInfoState[] arr;
+		string? current;
+		lock (_infoLock)
+		{
+			arr = _diagrams.Values.ToArray();
+			current = _currentDiagramId;
+		}
+		return OkJson(JsonSerializer.Serialize(new
+		{
+			CurrentDiagramId = current,
+			Diagrams = arr.Select(d => new
+			{
+				Id = d.Id,
+				Name = d.Name,
+				Description = d.Description,
+				WorkGroupIds = d.WorkGroupIds,
+			}).ToArray(),
+		}, JsonOptions));
+	}
+
+	/// <summary>
+	/// ダイヤ情報を登録/更新する。
+	/// リクエストボディ: { Id, Name?, Description?, WorkGroupIds?: string[], MakeCurrent?: bool }
+	/// </summary>
+	private HttpResponse SetDiagram(HttpRequest request)
+	{
+		try
+		{
+			string body = Encoding.UTF8.GetString(request.Body);
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+
+			string? id = TryGetString(root, "Id");
+			if (string.IsNullOrEmpty(id))
+				return Error(HttpStatusCode.BadRequest, "Missing 'Id' field");
+
+			string? name = TryGetString(root, "Name");
+			string? description = TryGetString(root, "Description");
+			string[]? wgIds = null;
+			if (root.TryGetProperty("WorkGroupIds", out var wgIdsProp) && wgIdsProp.ValueKind == JsonValueKind.Array)
+			{
+				wgIds = wgIdsProp.EnumerateArray()
+					.Where(e => e.ValueKind == JsonValueKind.String)
+					.Select(e => e.GetString()!)
+					.ToArray();
+			}
+			bool makeCurrent = root.TryGetProperty("MakeCurrent", out var mc)
+				&& mc.ValueKind == JsonValueKind.True;
+
+			lock (_infoLock)
+			{
+				_diagrams[id] = new DiagramInfoState(id, name, description, wgIds);
+				if (makeCurrent || _currentDiagramId is null)
+					_currentDiagramId = id;
+			}
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex)
+		{
+			return Error(HttpStatusCode.BadRequest, ex.Message);
+		}
+	}
+
+	/// <summary>
+	/// ダイヤ情報を全 WebSocket クライアントへブロードキャストする。
+	/// クエリパラメータ "id" でダイヤを指定可能 (省略時はカレントダイヤ)。
+	/// </summary>
+	private async Task<HttpResponse> BroadcastDiagramAsync(HttpRequest request)
+	{
+		string? id = request.QueryString["id"];
+		var msg = BuildDiagramInfoMessage(id);
+		if (msg is null)
+			return Error(HttpStatusCode.NotFound, $"No diagram for id={id ?? "(current)"}");
+		await BroadcastTextAsync(msg);
+		return OkJson("{\"ok\":true}");
+	}
+
+	private string? BuildDiagramInfoMessage(string? id)
+	{
+		DiagramInfoState? info;
+		lock (_infoLock)
+		{
+			string? targetId = id ?? _currentDiagramId;
+			if (targetId is null || !_diagrams.TryGetValue(targetId, out info))
+				return null;
+		}
+		return JsonSerializer.Serialize(new
+		{
+			MessageType = "DiagramInfo",
+			DiagramId = info.Id,
+			Name = info.Name,
+			Description = info.Description,
+			WorkGroupIds = info.WorkGroupIds,
+		});
+	}
+
+	private HttpResponse GetReceivedRequests()
+		=> OkJson(JsonSerializer.Serialize(_receivedRequests.ToArray(), JsonOptions));
+
+	private HttpResponse ClearReceivedRequests()
+	{
+		while (_receivedRequests.TryDequeue(out _)) { }
+		return OkJson("{\"ok\":true}");
+	}
+
+	// ================================================================
+	// リモートコマンド配信
+	// ================================================================
+
+	/// <summary>
+	/// SelectTrain: { WorkGroupId?, WorkId?, TrainId? }
+	/// </summary>
+	private async Task<HttpResponse> BroadcastSelectTrainAsync(HttpRequest request)
+	{
+		try
+		{
+			using var doc = JsonDocument.Parse(request.Body.Length > 0
+				? Encoding.UTF8.GetString(request.Body)
+				: "{}");
+			var root = doc.RootElement;
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "SelectTrain",
+				WorkGroupId = TryGetString(root, "WorkGroupId"),
+				WorkId = TryGetString(root, "WorkId"),
+				TrainId = TryGetString(root, "TrainId"),
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
+	}
+
+	/// <summary>
+	/// OperationCommand: { Action: "StartOperation" | "EndOperation" | "EnableLocationService" | "DisableLocationService" }
+	/// </summary>
+	private async Task<HttpResponse> BroadcastOperationCommandAsync(HttpRequest request)
+	{
+		try
+		{
+			string body = Encoding.UTF8.GetString(request.Body);
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+			string? action = TryGetString(root, "Action");
+			if (string.IsNullOrEmpty(action))
+				return Error(HttpStatusCode.BadRequest, "Missing 'Action' field");
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "OperationCommand",
+				Action = action,
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
+	}
+
+	/// <summary>
+	/// HeaderColor: { ResetToDefault?: bool, Color_RGB?: int (0xRRGGBB) }
+	/// </summary>
+	private async Task<HttpResponse> BroadcastHeaderColorAsync(HttpRequest request)
+	{
+		try
+		{
+			string body = Encoding.UTF8.GetString(request.Body);
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+			bool reset = root.TryGetProperty("ResetToDefault", out var r)
+				&& r.ValueKind == JsonValueKind.True;
+			int? color = null;
+			if (!reset && root.TryGetProperty("Color_RGB", out var c)
+				&& c.ValueKind == JsonValueKind.Number
+				&& c.TryGetInt32(out int rgb))
+				color = rgb;
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "HeaderColor",
+				ResetToDefault = reset,
+				Color_RGB = color,
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
+	}
+
+	/// <summary>
+	/// Notification: { Id?, Title?, Body?, Priority?, IssuedAt? (ISO8601) }
+	/// </summary>
+	private async Task<HttpResponse> BroadcastNotificationAsync(HttpRequest request)
+	{
+		try
+		{
+			string body = Encoding.UTF8.GetString(request.Body);
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+			int priority = 0;
+			if (root.TryGetProperty("Priority", out var p) && p.ValueKind == JsonValueKind.Number
+				&& p.TryGetInt32(out int prio))
+				priority = prio;
+			string? issuedAt = TryGetString(root, "IssuedAt");
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "Notification",
+				Id = TryGetString(root, "Id"),
+				Title = TryGetString(root, "Title"),
+				Body = TryGetString(root, "Body"),
+				Priority = priority,
+				IssuedAt = issuedAt,
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
+	}
+
+	/// <summary>
+	/// TimeFormat: { Format?: string (例 "HH:mm" / "HH:mm:ss") }
+	/// Format が省略 / null の場合は「端末の既定にリセット」を意味する。
+	/// </summary>
+	private async Task<HttpResponse> BroadcastTimeFormatAsync(HttpRequest request)
+	{
+		try
+		{
+			string body = request.Body.Length > 0 ? Encoding.UTF8.GetString(request.Body) : "{}";
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+			string? format = TryGetString(root, "Format");
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "TimeFormat",
+				Format = format,
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
 	}
 
 	// ================================================================
@@ -281,7 +631,7 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 					break;
 				}
 				if (msg.Type == WebSocketMessageType.Text)
-					ProcessClientIdUpdate(state, msg.GetText());
+					await ProcessClientMessageAsync(state, msg.GetText());
 			}
 		}
 		catch (Exception)
@@ -295,12 +645,49 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 		}
 	}
 
-	private static void ProcessClientIdUpdate(ClientState client, string message)
+	/// <summary>
+	/// クライアントから受信した WS メッセージを処理する。
+	/// MessageType フィールドが指定されていれば該当の要求として扱い、
+	/// なければ ID 更新メッセージとして扱う (後方互換)。
+	/// </summary>
+	private async Task ProcessClientMessageAsync(ClientState client, string message)
 	{
 		try
 		{
 			using var doc = JsonDocument.Parse(message);
 			var root = doc.RootElement;
+
+			// MessageType による要求ハンドリング
+			if (root.TryGetProperty("MessageType", out var mt) && mt.ValueKind == JsonValueKind.String)
+			{
+				string? messageType = mt.GetString();
+				switch (messageType)
+				{
+					case "RequestServerInfo":
+						_receivedRequests.Enqueue(new ReceivedRequestDto(
+							ConnectionId: client.ConnectionId,
+							MessageType: messageType,
+							DiagramId: null,
+							ReceivedAt: DateTime.UtcNow));
+						await TrySendAsync(client.Connection, BuildServerInfoMessage());
+						return;
+					case "RequestDiagramInfo":
+						{
+							string? diagramId = TryGetString(root, "DiagramId");
+							_receivedRequests.Enqueue(new ReceivedRequestDto(
+								ConnectionId: client.ConnectionId,
+								MessageType: messageType,
+								DiagramId: diagramId,
+								ReceivedAt: DateTime.UtcNow));
+							var resp = BuildDiagramInfoMessage(diagramId);
+							if (resp is not null)
+								await TrySendAsync(client.Connection, resp);
+							return;
+						}
+				}
+			}
+
+			// 後方互換: MessageType が無い場合は ID 更新メッセージとして扱う
 			if (root.TryGetProperty("WorkGroupId", out var wg)) client.WorkGroupId = wg.GetString();
 			if (root.TryGetProperty("WorkId", out var w)) client.WorkId = w.GetString();
 			if (root.TryGetProperty("TrainId", out var t)) client.TrainId = t.GetString();
@@ -364,6 +751,9 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			Connection = connection;
 		}
 	}
+
+	private sealed record ServerInfoState(string? Name, string? Admin, string? Version, string? ProtocolVersion);
+	private sealed record DiagramInfoState(string Id, string? Name, string? Description, string[]? WorkGroupIds);
 }
 
 // DTO: テストプロジェクトから共有するため public に定義
@@ -379,4 +769,11 @@ public sealed record WsClientDto(
 	string? WorkGroupId,
 	string? WorkId,
 	string? TrainId
+);
+
+public sealed record ReceivedRequestDto(
+	string ConnectionId,
+	string? MessageType,
+	string? DiagramId,
+	DateTime ReceivedAt
 );

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -57,6 +57,17 @@ public partial class AppShell : Shell
 		FlyoutIconImage.BindingContext = easterEggPageViewModel;
 		FlyoutIconImage.SetBinding(FontImageSource.ColorProperty, static (EasterEggPageViewModel vm) => vm.ShellTitleTextColor);
 
+		// サーバーから HeaderColor コマンドを受信したときに、タイトルバー色を上書きする。
+		// null (= ResetToDefault) の場合は EasterEgg の設定にフォールバックする。
+		var appVm = InstanceManager.AppViewModel;
+		appVm.PropertyChanged += (_, e) =>
+		{
+			if (e.PropertyName == nameof(AppViewModel.HeaderColorOverride_RGB))
+				ApplyHeaderColorOverride(appVm.HeaderColorOverride_RGB, easterEggPageViewModel);
+		};
+		// 起動時の値も反映する (通常は null)
+		ApplyHeaderColorOverride(appVm.HeaderColorOverride_RGB, easterEggPageViewModel);
+
 		InstanceManager.AppViewModel.WindowWidth = DeviceDisplay.Current.MainDisplayInfo.Width;
 		InstanceManager.AppViewModel.WindowHeight = DeviceDisplay.Current.MainDisplayInfo.Height;
 		logger.Trace("Display Width/Height: {0}x{1}", InstanceManager.AppViewModel.WindowWidth, InstanceManager.AppViewModel.WindowHeight);
@@ -76,6 +87,31 @@ public partial class AppShell : Shell
 #endif
 
 		logger.Trace("AppShell Created");
+	}
+
+	/// <summary>
+	/// サーバー指示の色 (0xRRGGBB) でタイトルバーを上書きする。null の場合は
+	/// EasterEgg ベースのバインディングを再有効化して端末設定に戻す。
+	/// WebSocket 受信スレッドから呼ばれうるため、UI 操作は必ず MainThread に dispatch する。
+	/// </summary>
+	void ApplyHeaderColorOverride(int? rgbOrNull, EasterEggPageViewModel easterEggPageViewModel)
+	{
+		MainThread.BeginInvokeOnMainThread(() =>
+		{
+			if (rgbOrNull is int rgb)
+			{
+				byte r = (byte)((rgb >> 16) & 0xff);
+				byte g = (byte)((rgb >> 8) & 0xff);
+				byte b = (byte)(rgb & 0xff);
+				this.RemoveBinding(BackgroundColorProperty);
+				BackgroundColor = Color.FromRgb(r, g, b);
+			}
+			else
+			{
+				// バインディングを再設定して既定挙動に戻す
+				this.SetBinding(BackgroundColorProperty, static (EasterEggPageViewModel vm) => vm.ShellBackgroundColor);
+			}
+		});
 	}
 
 	void ApplyFlyoutBehavior(object? sender, bool oldValue, bool newValue)

--- a/TRViS/DTAC/Adapters/AppViewModelAdapter.cs
+++ b/TRViS/DTAC/Adapters/AppViewModelAdapter.cs
@@ -26,6 +26,7 @@ internal class AppViewModelAdapter : IAppViewModelProvider
     public TRViS.IO.Models.WorkGroup? SelectedWorkGroup => _viewModel.SelectedWorkGroup;
     public TRViS.IO.Models.Work? SelectedWork => _viewModel.SelectedWork;
     public TRViS.IO.Models.TrainData? SelectedTrainData => _viewModel.SelectedTrainData;
+    public string? HeaderTimeFormat => _viewModel.HeaderTimeFormat;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -118,6 +118,13 @@ public partial class AppViewModel : ObservableObject
 	internal void SubscribeToLocationService(TRViS.Services.LocationService locationService)
 	{
 		locationService.TimetableUpdated += OnTimetableUpdated;
+		locationService.TrainSelectionRequested += OnTrainSelectionRequested;
+		locationService.HeaderColorChangeRequested += OnHeaderColorChangeRequested;
+		locationService.TimeFormatChangeRequested += OnTimeFormatChangeRequested;
+		// NotificationReceived / OperationCommandReceived / ServerInfo / DiagramInfo は
+		// LocationService 側で受信される。OperationCommand の動作 (位置情報 ON/OFF) は
+		// LocationService が直接適用する。Notification / ServerInfo / DiagramInfo の UI 表示は
+		// 個別画面側で必要に応じて購読する。
 	}
 
 	partial void OnLoaderChanged(ILoader? value)
@@ -130,18 +137,12 @@ public partial class AppViewModel : ObservableObject
 		logger.Debug("TimetableUpdated: WorkGroupId={0}, WorkId={1}, TrainId={2}, Scope={3}",
 			timetableData.WorkGroupId, timetableData.WorkId, timetableData.TrainId, timetableData.Scope);
 
-		// 時刻表の変更スコープに応じて、表示継続可能か判定する
-		bool canContinue = CanContinueCurrentTimetable(timetableData);
-
-		if (!canContinue)
-		{
-			// 表示継続不可の場合は初期状態に戻す
-			logger.Info("Timetable changed and cannot continue -> reset to initial state");
-			SelectionManager.ResetToFirst();
-		}
-
-		// Loader のキャッシュが更新された可能性があるため、UI を再読み込み
-		// 特に WebSocket の場合は Loader のデータが動的に更新されるため、毎回再読み込みする必要がある
+		// リアルタイム編集対応: 自スコープと一致する更新では選択を維持し、
+		// 異なるスコープの更新では現在の表示は無関係なのでそのまま継続する。
+		// SelectionManager.Refresh() が各階層で選択 Id を保持しつつ最新データを反映する。
+		// - 既存選択が新ペイロードに存在する → 同じ Id の最新インスタンスに差し替え
+		// - 既存選択が消えた階層から先 → 先頭にフォールバック
+		// この挙動は Scope.All / WorkGroup / Work / Train すべてのケースをカバーする。
 		if (Loader is not null)
 		{
 			logger.Debug("Refreshing selection from Loader cache");
@@ -149,25 +150,59 @@ public partial class AppViewModel : ObservableObject
 		}
 	}
 
-	bool CanContinueCurrentTimetable(TimetableData timetableData)
+	/// <summary>
+	/// サーバーから送られた SelectTrain コマンドを反映する。
+	/// WorkGroupId / WorkId / TrainId に対応する階層を選択する。
+	/// </summary>
+	void OnTrainSelectionRequested(object? sender, SelectTrainCommand cmd)
 	{
-		// 変更スコープに基づいて判定する
-		return timetableData.Scope switch
+		logger.Info("OnTrainSelectionRequested: WorkGroupId={0}, WorkId={1}, TrainId={2}",
+			cmd.WorkGroupId, cmd.WorkId, cmd.TrainId);
+
+		if (cmd.WorkGroupId is not null)
 		{
-			// All：全体の情報が更新された場合は表示継続不可
-			TimetableScopeType.All => false,
+			var wg = SelectionManager.WorkGroupList?.FirstOrDefault(w => w.Id == cmd.WorkGroupId);
+			if (wg is not null && SelectionManager.SelectedWorkGroup?.Id != wg.Id)
+				SelectionManager.SelectedWorkGroup = wg;
+		}
 
-			// WorkGroup単位の変更：現在の選択がこのWorkGroupと異なる場合のみ継続可能
-			TimetableScopeType.WorkGroup => SelectionManager.SelectedWorkGroup?.Id != timetableData.WorkGroupId,
+		if (cmd.WorkId is not null)
+		{
+			var work = SelectionManager.WorkList?.FirstOrDefault(w => w.Id == cmd.WorkId);
+			if (work is not null && SelectionManager.SelectedWork?.Id != work.Id)
+				SelectionManager.SelectedWork = work;
+		}
 
-			// Work単位の変更：現在の選択がこのWorkと異なる場合のみ継続可能
-			TimetableScopeType.Work => SelectionManager.SelectedWork?.Id != timetableData.WorkId,
+		if (cmd.TrainId is not null)
+		{
+			var train = SelectionManager.OrderedTrainDataList?.FirstOrDefault(t => t.Id == cmd.TrainId);
+			if (train is not null && SelectionManager.SelectedTrainData?.Id != train.Id)
+				SelectionManager.SelectedTrainData = train;
+		}
+	}
 
-			// Train単位の変更：現在の選択がこのTrainと異なる場合のみ継続可能
-			TimetableScopeType.Train => SelectionManager.SelectedTrainData?.Id != timetableData.TrainId,
+	/// <summary>
+	/// サーバーから指示されたヘッダの色 (RGB)。null は端末既定。
+	/// View 側はこの値を購読してタイトルバー色を変更する。
+	/// </summary>
+	[ObservableProperty]
+	int? _HeaderColorOverride_RGB;
 
-			_ => true
-		};
+	void OnHeaderColorChangeRequested(object? sender, HeaderColorCommand cmd)
+	{
+		HeaderColorOverride_RGB = cmd.ResetToDefault ? null : cmd.Color_RGB;
+	}
+
+	/// <summary>
+	/// サーバーから指示されたタイトルバー時刻表示フォーマット ("HH:mm:ss" 等)。
+	/// null は端末既定 ("HH:mm:ss" を内部既定とする)。
+	/// </summary>
+	[ObservableProperty]
+	string? _HeaderTimeFormat;
+
+	void OnTimeFormatChangeRequested(object? sender, TimeFormatCommand cmd)
+	{
+		HeaderTimeFormat = cmd.Format;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Issueへのリンク

closes #214

## 実装した機能の説明

### 1. リアルタイム編集サポート (#214)

エディタ (TRViS_Realtime_Editor) からの「自スコープ更新」を、TRViS 側で表示を初期化せず即時反映できるようにした。これまでは編集中の Train を `Scope.Train` で再配信すると、TRViS 側が WorkGroup/Work/Train を先頭にリセットしてしまい、リアルタイム編集が成立しなかった。

- 自スコープと一致する Train/Work/WorkGroup 更新では、位置情報・各階層の選択を維持する。
- `TimetableSelectionManager.Refresh` が各階層で選択 Id をキープしつつ、最新インスタンスに差し替える。消えた階層からは先頭にフォールバック。
- `WorkGroup` / `Work` スコープ更新時は配下 (Work/Train) のキャッシュも再構築する。
- 空の `WorkGroupList` を受信したら、配下 `Work/Train` も明示的に空に揃える (Issue コメント対応)。

### 2. サーバー情報・ダイヤ情報

将来の機能拡張を見越して、`ServerInfo` (サーバー名・管理者・バージョン) と `DiagramInfo` (WorkGroup より上位の「ダイヤ」概念) をクライアントから要求・受信できるプロトコルを追加。

### 3. サーバー駆動コマンド (Server → Client)

WebSocket 経由でサーバーからクライアントを操作できるコマンドを追加:

- **SelectTrain**: 列車の選択をサーバーから指定 (WorkGroup/Work/Train Id)。
- **OperationCommand**: 運行開始 / 終了 / 位置情報サービス ON/OFF。
- **HeaderColor**: タイトルバー色の上書き / 端末既定への復元。
- **TimeFormat**: タイトルバー時刻表示フォーマット指定 (`HH:mm:ss` だけでなく `HH:mm` 等にも対応)。
- **Notification (通告)**: プロトコルのみ実装。受信イベントまでは経路があり、画面実装は今後別途。

### 4. 施行日テキスト

`Work.AffectDateText` を追加。JSON/SQL/JsonModelsConverter のいずれの経路でも、`AffectDate` が日付として解釈できなかった文字列はそのまま `AffectDateText` に格納し、Hako / VerticalStylePage の施行日ラベルで優先表示する。

## 仕様の説明

### Scope.Train/Work/WorkGroup 更新の挙動

| 操作 | 旧挙動 | 新挙動 |
| --- | --- | --- |
| 表示中の Train に対する `Scope.Train` 更新 | 先頭にリセット | 選択維持・新データで再描画 |
| 表示中の Work 配下の `Scope.Work` 更新 | 先頭にリセット | Work/Train 選択を保持・配下キャッシュ再構築 |
| 表示中の WorkGroup 配下の `Scope.WorkGroup` 更新 | 先頭にリセット | WG/Work/Train 選択を保持・配下構造を再構築 |
| `Scope.All` 更新 | 常に先頭にリセット | 既存 Id が新ペイロードに残っていれば各階層で保持、消えた階層から先頭にフォールバック |
| 別の Train/Work/WorkGroup の更新 (非自スコープ) | 影響なし | 影響なし (現状維持) |

### Server → Client コマンドのメッセージ形式 (WebSocket)

すべて `MessageType` でディスパッチ。

```jsonc
// SelectTrain
{ "MessageType": "SelectTrain", "WorkGroupId": "...", "WorkId": "...", "TrainId": "..." }

// OperationCommand
{ "MessageType": "OperationCommand",
  "Action": "StartOperation" | "EndOperation" | "EnableLocationService" | "DisableLocationService" }

// HeaderColor (ResetToDefault=true なら端末既定に戻す)
{ "MessageType": "HeaderColor", "ResetToDefault": false, "Color_RGB": 3368601 /* 0x336699 */ }

// TimeFormat (Format=null は端末既定にリセット)
{ "MessageType": "TimeFormat", "Format": "HH:mm" }

// Notification
{ "MessageType": "Notification", "Id": "...", "Title": "...", "Body": "...",
  "Priority": 0, "IssuedAt": "2026-05-09T12:34:56+09:00" }
```

### ServerInfo / DiagramInfo

クライアントから要求 (`RequestServerInfo` / `RequestDiagramInfo`) を投げると、サーバーが対応する `ServerInfo` / `DiagramInfo` メッセージで応答する。サーバーから能動的に push することも可能 (リファレンスサーバーの control endpoint で実装)。

### 施行日テキスト

`AffectDate` が日付として解釈できる場合は従来通り `yyyy年M月d日` で表示。日付として解釈できない任意文字列 (例: `"ダイヤA"`) はそのまま施行日ラベルに表示する。`AffectDateFormatter.FormatAffectDateOrText` が判定する。

## 将来的にやりたいこと

- Notification (通告) の画面実装 (本 PR ではプロトコル受信のみ)。
- `Scope.TimetableRow` 単位の細粒度更新 (#158 と統合)。
- Delete 操作・ACK / 競合検知・編集モード明示 (Issue 本文 D 項)。

## スクリーンショット

(プロトコル / バックエンド変更が中心のため、スクリーンショットなし。)

---

## テスト

すべて green:

- TRViS.Core.Tests (xUnit): 20 件 — `TimetableSelectionManager` の選択保持・空カスケード等を追加。
- TRViS.IO.Tests (xUnit): 31 件
- TRViS.LocationService.Tests (xUnit): 17 件
- TRViS.DTAC.Logic.Tests (xUnit): 180 件 — `AffectDateText` 優先表示と `TimeFormat` 切り替えを追加。
- TRViS.TimetableService.Tests (xUnit): 10 件
- TRViS.NetworkSyncService.IntegrationTests (NUnit): 65 件 — AC-1..AC-7 / ServerInfo / DiagramInfo / 各リモートコマンド / `AffectDateText` / 空ダイヤカスケードを追加。

合計 323 件 green。MAUI 本体 (maccatalyst) のビルドも 0 警告 0 エラー。

## レビューア向け補足

- `AppShell.ApplyHeaderColorOverride` は WebSocket 受信スレッドから呼ばれる可能性があるため `MainThread.BeginInvokeOnMainThread` で UI 操作を dispatch している。
- `TimetableSelectionManager.Refresh` の選択保持パスでは、setter のカスケードを避けるためフィールドに直接代入し `RaisePropertyChanged` のみを発火させている (cascade を起こすと配下が先頭にリセットされてしまうため)。
- `RebuildTrainCacheForWork` は「TrainId はちょうど一つの Work に属する」という `LoaderJson.WorkIdByTrainId` と同じ不変条件に依存している。コードコメントに明記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)