### PR TITLE
fix(ws-sync): Honor RecordType when converting JSON timetable rows (#226)

### DIFF
--- a/TRViS.IO.ILoader/JsonModelsConverter.cs
+++ b/TRViS.IO.ILoader/JsonModelsConverter.cs
@@ -104,7 +104,9 @@ public static partial class JsonModelsConverter
 				RunInLimit: v.RunInLimit,
 				RunOutLimit: v.RunOutLimit,
 				Remarks: v.Remarks,
-				IsInfoRow: false,  // JSONModelsにはRecordTypeが含まれない
+				IsInfoRow: v.RecordType
+					is (int)StationRecordType.InfoRow_ForAlmostTrain
+					or (int)StationRecordType.InfoRow_ForSomeTrain,
 				DefaultMarkerColor_RGB: HexStringToRgbInt(v.MarkerColor),
 				DefaultMarkerText: v.MarkerText
 			))];

--- a/TRViS.IO.Tests/JsonModelsConverter.Tests.cs
+++ b/TRViS.IO.Tests/JsonModelsConverter.Tests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+
+using TRViS.IO.Models;
+
+using JsonModels = TRViS.JsonModels;
+
+namespace TRViS.IO.Tests;
+
+public class JsonModelsConverterTests
+{
+	static readonly JsonSerializerOptions opts = new()
+	{
+		AllowTrailingCommas = true,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	[TestCase(0, false)]
+	[TestCase(1, false)]
+	[TestCase(2, true)]
+	[TestCase(3, true)]
+	public void ConvertTrain_MapsRecordTypeToIsInfoRow(int recordType, bool expected)
+	{
+		string json = $$"""
+			{
+			  "Id": "t1",
+			  "TrainNumber": "T-001",
+			  "Direction": 1,
+			  "TimetableRows": [
+			    {
+			      "Id": "r1",
+			      "StationName": "Row",
+			      "Location_m": 0.0,
+			      "RecordType": {{recordType}}
+			    }
+			  ]
+			}
+			""";
+
+		var trainJson = JsonSerializer.Deserialize<JsonModels.TrainData>(json, opts);
+		Assert.That(trainJson, Is.Not.Null);
+
+		TrainData converted = JsonModelsConverter.ConvertTrain(trainJson!);
+
+		Assert.That(converted.Rows, Is.Not.Null);
+		Assert.That(converted.Rows!, Has.Length.EqualTo(1));
+		Assert.That(converted.Rows![0].IsInfoRow, Is.EqualTo(expected));
+	}
+
+	[Test]
+	public void ConvertTrain_MissingRecordType_DefaultsToNotInfoRow()
+	{
+		string json = """
+			{
+			  "Id": "t1",
+			  "TrainNumber": "T-001",
+			  "Direction": 1,
+			  "TimetableRows": [
+			    {
+			      "Id": "r1",
+			      "StationName": "Row",
+			      "Location_m": 0.0
+			    }
+			  ]
+			}
+			""";
+
+		var trainJson = JsonSerializer.Deserialize<JsonModels.TrainData>(json, opts);
+		Assert.That(trainJson, Is.Not.Null);
+
+		TrainData converted = JsonModelsConverter.ConvertTrain(trainJson!);
+
+		Assert.That(converted.Rows, Is.Not.Null);
+		Assert.That(converted.Rows!, Has.Length.EqualTo(1));
+		Assert.That(converted.Rows![0].IsInfoRow, Is.False);
+	}
+}


### PR DESCRIPTION
## Issueへのリンク

Fixes #226

## 実装した機能の説明

WebSocket 経由で受信した Timetable の `RecordType` を尊重し、情報行 (例: 交直切換) を正しく情報行として描画するよう修正する。

## 仕様の説明

### 背景・原因

`JsonModelsConverter.ConvertTrain` (`TRViS.IO.ILoader/JsonModelsConverter.cs:107`) では `IsInfoRow` が常に `false` にハードコードされており、コメントには「JSONModelsにはRecordTypeが含まれない」と記載されていた。実際には `TRViS.JsonModels.TimetableRowData.RecordType` (`int?`) は存在し、ファイル直読みの `LoaderJson` (`TRViS.IO/Loaders/LoaderJson.cs:154-156`) ではこの値を用いて `IsInfoRow` を判定している。

`ConvertTrain` は `TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs:576,694` から呼ばれているため、**WS 経由の Timetable 配信全般 (Train / Work / All スコープ)** で RecordType が無視されていた。

### 修正内容

- `IsInfoRow` の判定ロジックを `LoaderJson` と同じ
  ```csharp
  IsInfoRow: v.RecordType
      is (int)StationRecordType.InfoRow_ForAlmostTrain
      or (int)StationRecordType.InfoRow_ForSomeTrain,
  ```
  に置き換える。
- `TRViS.IO.ILoader` から `TRViS.IO` を参照すると循環参照になるため、既に `TRViS.IO.ILoader/Models/StationRecordType.cs` にある `TRViS.IO.Models.StationRecordType` enum を利用する (値は `TRViS.IO.Models.DB.StationRecordType` と一致)。
- 仕様: `RecordType` が `2` (`InfoRow_ForAlmostTrain`) または `3` (`InfoRow_ForSomeTrain`) のとき `IsInfoRow = true`、それ以外 (`0`, `1`, または未指定 / `null`) は `false`。

### テスト

`TRViS.IO.Tests/JsonModelsConverter.Tests.cs` に回帰テストを追加。

- `RecordType` = 0/1/2/3 の各ケース
- `RecordType` フィールド未指定のケース (`IsInfoRow = false`)

`dotnet test TRViS.IO.Tests` で 36/36 通過。

## 将来的にやりたいこと

- なし

## スクリーンショット

(コードの修正のみのため省略)