### PR TITLE
fix(connect-server): in-flight キャンセル + ws/wss 履歴保存 (#223)

### DIFF
--- a/TRViS/RootPages/ConnectServerDialog.xaml
+++ b/TRViS/RootPages/ConnectServerDialog.xaml
@@ -45,6 +45,7 @@
 				TextColor="{x:Static local:RootStyles.TableTextColor}"
 				Text="サーバーから読み込み"/>
 			<Button
+				x:Name="CloseButton"
 				AutomationId="ConnectServer.CloseButton"
 				Grid.Column="1"
 				Text="&#xe5cd;"

--- a/TRViS/RootPages/ConnectServerDialog.xaml.cs
+++ b/TRViS/RootPages/ConnectServerDialog.xaml.cs
@@ -29,6 +29,13 @@ public partial class ConnectServerDialog : ContentPage
 	// after the page is already disposed.
 	private bool _isBusy;
 
+	// Cancels any in-flight HandleAppLinkUriAsync when the page disappears
+	// (modal swipe-dismiss on iOS, hardware back on Android, OS-level
+	// dismissal). Without this, a connect started mid-flight would still
+	// resolve and call SetLoader on a dismissed page, surprising the user
+	// with an AppViewModel change after they intended to bail out.
+	private CancellationTokenSource _cts = new();
+
 	public ConnectServerDialog()
 	{
 		logger.Trace("Creating");
@@ -55,6 +62,25 @@ public partial class ConnectServerDialog : ContentPage
 		// Re-populate on each appearance so a re-show after preferences changed
 		// (e.g., user added a URL elsewhere) reflects the latest history.
 		PopulateHistory();
+
+		// If the dialog was previously dismissed and is now being shown again
+		// (rare but supported by Navigation), the CTS from the prior session
+		// is already cancelled — replace it so new loads aren't immediately
+		// cancelled.
+		if (_cts.IsCancellationRequested)
+		{
+			_cts.Dispose();
+			_cts = new();
+		}
+	}
+
+	protected override void OnDisappearing()
+	{
+		base.OnDisappearing();
+		// Cancel any in-flight load. The token is wired into HandleAppLinkUriAsync,
+		// which checks ThrowIfCancellationRequested at several await points and
+		// catches OperationCanceledException internally to return false cleanly.
+		_cts.Cancel();
 	}
 
 	void PopulateHistory()
@@ -201,6 +227,10 @@ public partial class ConnectServerDialog : ContentPage
 		SaveConnectionSwitch.IsEnabled = isEnabled;
 		NewConnectionButton.IsEnabled = isEnabled;
 		BackToHistoryButton.IsEnabled = isEnabled;
+		// Disable the X button during a load so the user can't tap it mid-flight.
+		// OS-level dismiss paths (iOS swipe-down on FormSheet, Android hardware
+		// back) still fire OnDisappearing → CTS.Cancel, so users aren't trapped.
+		CloseButton.IsEnabled = isEnabled;
 		LoadingIndicator.IsRunning = !isEnabled;
 		LoadingIndicator.IsVisible = !isEnabled;
 	}
@@ -229,6 +259,7 @@ public partial class ConnectServerDialog : ContentPage
 
 	async Task<bool> TryLoadAsync(string urlText, bool addToHistory)
 	{
+		CancellationToken token = _cts.Token;
 		try
 		{
 			if (string.IsNullOrWhiteSpace(urlText))
@@ -239,7 +270,7 @@ public partial class ConnectServerDialog : ContentPage
 
 			if (urlText.StartsWith("trvis://"))
 			{
-				return await InstanceManager.AppViewModel.HandleAppLinkUriAsync(urlText, addToHistory, CancellationToken.None);
+				return await InstanceManager.AppViewModel.HandleAppLinkUriAsync(urlText, addToHistory, token);
 			}
 
 			AppLinkInfo appLinkInfo = new(
@@ -247,7 +278,18 @@ public partial class ConnectServerDialog : ContentPage
 				Version: new(1, 0),
 				ResourceUri: new(urlText)
 			);
-			return await InstanceManager.AppViewModel.HandleAppLinkUriAsync(appLinkInfo, addToHistory, CancellationToken.None);
+			// Pass urlText as originalAppLink so the WebSocket branch (ws:// / wss://)
+			// can persist it to history — without it, HandleWebSocketAppLinkAsync skips
+			// the history write because the constructed AppLinkInfo doesn't retain
+			// the originating URL form.
+			return await InstanceManager.AppViewModel.HandleAppLinkUriAsync(appLinkInfo, urlText, addToHistory, token);
+		}
+		catch (OperationCanceledException) when (token.IsCancellationRequested)
+		{
+			// User dismissed the dialog while the connect was in flight. Don't
+			// show an alert on a page that's being torn down.
+			logger.Debug("TryLoadAsync cancelled by dialog dismissal");
+			return false;
 		}
 		catch (UriFormatException ex)
 		{

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -101,7 +101,16 @@ public partial class AppViewModel
 	public Task<bool> HandleAppLinkUriAsync(AppLinkInfo appLinkInfo, bool addToHistory, CancellationToken token)
 		=> HandleAppLinkUriAsync(appLinkInfo, null, addToHistory, token);
 
-	private async Task<bool> HandleAppLinkUriAsync(AppLinkInfo appLinkInfo, string? originalAppLink, bool addToHistory, CancellationToken token)
+	/// <summary>
+	/// <paramref name="originalAppLink"/> is the raw URL string the user/system supplied
+	/// before it was parsed into <see cref="AppLinkInfo"/>. The WebSocket branch only adds
+	/// to <see cref="ExternalResourceUrlHistory"/> when this is non-null, because the
+	/// constructed <see cref="AppLinkInfo"/> does not retain the originating URL form.
+	/// Callers that build an <see cref="AppLinkInfo"/> directly (e.g. ConnectServerDialog
+	/// for raw <c>ws://</c> / <c>wss://</c> entries) must pass the original text here so
+	/// history persistence works for the WebSocket path.
+	/// </summary>
+	public async Task<bool> HandleAppLinkUriAsync(AppLinkInfo appLinkInfo, string? originalAppLink, bool addToHistory, CancellationToken token)
 	{
 		string? decodedUrl = null;
 		string? appLinkString = originalAppLink;


### PR DESCRIPTION
## Issueへのリンク

#223

## 実装した機能の説明

`ConnectServerDialog` の独立した 2 つの不具合に対応:

1. ロード中に dialog を dismiss しても `HandleAppLinkUriAsync` がキャンセルされず、ページ破棄後に `SetLoader` が走り `AppViewModel` が突然変わる
2. `ws://` / `wss://` を直接入力した場合、トグル ON でも履歴 (`ExternalResourceUrlHistory`) に保存されない

## 仕様の説明

### ① in-flight キャンセル

- ダイアログに `CancellationTokenSource _cts` を持たせる。`OnDisappearing` で `Cancel()`、`OnAppearing` で再表示時にキャンセル済みなら作り直し。
- `TryLoadAsync` から `HandleAppLinkUriAsync` を呼ぶときに `_cts.Token` を渡す。
- `SetInputEnabled(false)` で `CloseButton.IsEnabled = false` も連動 (XAML 側で `x:Name="CloseButton"` を追加)。
  - X ボタン経由の途中タップは無効化。OS レベルの dismiss (iOS の swipe-down on FormSheet, Android のハードウェア戻る) は引き続き有効で、それらも `OnDisappearing` → `_cts.Cancel()` 経路で in-flight ロードを止める。
- `TryLoadAsync` に `catch (OperationCanceledException) when (token.IsCancellationRequested)` を追加。dismiss 起因のキャンセル時に「接続できませんでした」アラートが torn-down ページに出ないよう、汎用 `Exception` catch より先に拾う。

### ② ws/wss の履歴保存

- 原因: `HandleWebSocketAppLinkAsync` は `addToHistory && originalAppLink is not null` でしか履歴に書かない。ダイアログは `AppLinkInfo` を直接組み立てて `HandleAppLinkUriAsync(AppLinkInfo, bool, CT)` を呼んでおり、これは `originalAppLink: null` で private 4-arg を呼ぶ sugar だった。
- 修正: private 4-arg `HandleAppLinkUriAsync(AppLinkInfo, string?, bool, CT)` を public に昇格 (XML doc 付き)。既存 3-arg overload は `originalAppLink: null` の sugar として残し、`App.xaml.cs` 等の他経路の挙動は変えない。ダイアログから `urlText` を `originalAppLink` として渡すよう変更。
- これにより `wss://example.com/...` をフォームに入力 → 「URLを履歴に残す」ON → 接続成功 → 次回ダイアログ表示時に履歴カードに出る。

## 動作確認

- maccatalyst Debug ビルド成功 (warning/error 0 件)
- 既存 UI テスト (`ConnectServerDialogTests.cs`) は `CloseButton` の `AutomationId` ベースのまま回るので互換あり
- `App.xaml.cs` 側 deeplink 経路は string overload のみ呼ぶので無影響

## レビュー時に見てほしい点

- **Mac Catalyst の FormSheet では OS swipe-dismiss が無い**ため、ロードがハング状態のまま `CloseButton` が無効だとユーザに脱出手段が無い。Issue 著者の希望通り `CloseButton` を disable しているが、将来的に明示的「キャンセル」ボタンを足すかは別途検討。
- ws/wss 履歴については Issue 提案 A (オプション引数で渡す) のうち、private 昇格 + 既存 sugar 残し、という形にした。option B (`AppendToUrlHistory`) を新設するより API surface が小さい。
- Issue 起票者は「手元では history が動いている」とのことだが、`http(s)://` は別経路 (`decodedUrl` を使う HTTP ブランチ) で元から動作する。バグは ws/wss 経路のみなので、確認には `wss://...` を直接入力するシナリオが必要。

## 将来的にやりたいこと

- ロード中の明示的「キャンセル」ボタン (Mac Catalyst 救済)
- ws/wss 経路にも timeout / IP-prefix 等のサニティチェック

## スクリーンショット

(コードのみの修正のため割愛)

🤖 Generated with [Claude Code](https://claude.com/claude-code)