### PR TITLE
fix(io): TrainData.Color を LineColor_RGB に反映 (LoaderJson / WebSocket 両系統)

### DIFF
--- a/TRViS.IO.ILoader/JsonModelsConverter.cs
+++ b/TRViS.IO.ILoader/JsonModelsConverter.cs
@@ -127,7 +127,8 @@ public static partial class JsonModelsConverter
 			Rows: rows,
 			AfterArrive: trainJson.AfterArrive,
 			DayCount: trainJson.DayCount ?? 0,
-			IsRideOnMoving: trainJson.IsRideOnMoving
+			IsRideOnMoving: trainJson.IsRideOnMoving,
+			LineColor_RGB: HexStringToRgbInt(trainJson.Color)
 		);
 	}
 

--- a/TRViS.IO.Tests/Loaders/LoaderJson.Tests.cs
+++ b/TRViS.IO.Tests/Loaders/LoaderJson.Tests.cs
@@ -85,7 +85,7 @@ public class LoaderJsonTests
 			// Assert.That(actual[0].WorkId, Is.EqualTo(workId));
 			Assert.That(actual[0].TrainNumber, Is.EqualTo("WG01-W01-Train01"));
 			Assert.That(actual[0].Direction, Is.EqualTo(Direction.Outbound));
-			Assert.That(actual[0].LineColor_RGB, Is.Null);
+			Assert.That(actual[0].LineColor_RGB, Is.EqualTo(0x2255BB));
 			Assert.That(actual[0].TrainInfo, Is.EqualTo("列車情報 (列車名など)"));
 			Assert.That(actual[0].Destination, Is.EqualTo("終着駅"));
 			Assert.That(actual[0].CarCount, Is.EqualTo(10));

--- a/TRViS.IO/Loaders/LoaderJson.cs
+++ b/TRViS.IO/Loaders/LoaderJson.cs
@@ -164,7 +164,7 @@ public class LoaderJson : ILoader
 							BeforeDeparture: trainData.BeforeDeparture,
 							BeginRemarks: trainData.BeginRemarks,
 							CarCount: trainData.CarCount,
-							LineColor_RGB: null, // Not Implemented
+							LineColor_RGB: Utils.HexStringToRgbInt(trainData.Color),
 							DayCount: trainData.DayCount ?? 0,
 							Destination: trainData.Destination,
 							Id: trainId,

--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/TestData.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/TestData.cs
@@ -228,6 +228,29 @@ public static class TestData
 		""";
 
 	/// <summary>
+	/// Train スコープ配信用 (Color 明示指定): TrainData.Color (=路線色) を含む。
+	/// JsonModelsConverter が Color を LineColor_RGB に変換することを検証する。
+	/// </summary>
+	public static readonly string TrainScopeJson_WithColor = $$"""
+		{
+		  "Id": "{{TrainId}}",
+		  "TrainNumber": "T-001",
+		  "Direction": 1,
+		  "Color": "FF0000",
+		  "TimetableRows": [
+		    {
+		      "StationName": "テスト駅A",
+		      "Location_m": 0.0,
+		      "Longitude_deg": 135.0,
+		      "Latitude_deg": 35.0,
+		      "OnStationDetectRadius_m": 300.0,
+		      "Departure": "10:00:00"
+		    }
+		  ]
+		}
+		""";
+
+	/// <summary>
 	/// WorkGroup スコープ配信用 (フル): 配下の Works/Trains 構造を含む完全な WorkGroup データ。
 	/// AC-3 / AC-5 の検証で、配下の Works/Trains キャッシュが再構築されることを確認する。
 	/// </summary>

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -495,6 +495,47 @@ public class WebSocketIntegrationTests
 		}
 	}
 
+	[Test]
+	public async Task Timetable_TrainScope_WithExplicitColor_PropagatesToCachedTrainAsLineColor()
+	{
+		// リグレッション: WebSocket 経由で Color を明示指定した Train データを配信したとき、
+		// ILoader.GetTrainData が LineColor_RGB を保持する必要がある。
+		// 以前は JsonModelsConverter.ConvertTrain が Color を渡していなかったため
+		// 常に null になり、サーバーから配信した路線色が表示されなかった。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var firstTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await firstTask;
+
+			var timetableTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.TrainScopeJson_WithColor,
+				workId: TestData.WorkId,
+				trainId: TestData.TrainId
+			);
+			await timetableTask;
+
+			var loader = (ILoader)service;
+			var updatedTrain = loader.GetTrainData(TestData.TrainId);
+			Assert.That(updatedTrain, Is.Not.Null);
+			Assert.That(updatedTrain!.LineColor_RGB, Is.EqualTo(0xFF0000));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
 	// ================================================================
 	// 運行中の時刻表更新
 	// ================================================================


### PR DESCRIPTION
## Issueへのリンク

なし (`ConvertTrain` の取りこぼし整理の続き)

## 実装した機能の説明

`JsonModels.TrainData.Color` (16進文字列の路線色) を `TRViS.IO.Models.TrainData.LineColor_RGB` に反映するよう、JSON → モデル変換の 2 箇所を修正する。

- `JsonModelsConverter.ConvertTrain` (WebSocket 経由のリアルタイム配信で使われるパス)
- `LoaderJson` (ローカル JSON ファイル読み込みパス)

## 仕様の説明

これまではいずれの経路でも `Color` フィールドを読み取らずに `LineColor_RGB = null` を渡しており、JSON 上で路線色を指定しても UI に反映されなかった。

- どちらのパスでも、既存の `HexStringToRgbInt` ヘルパー (空・null・パース失敗 → null、`#` プレフィックスは許容) を使って Color → LineColor_RGB に変換する。
- LoaderJson 側にあった `// Not Implemented` コメントは本対応で実装済みとなったため除去。
- 直前にマージされた `NextTrainId` 修正と同種の「`ConvertTrain` 漏れ」シリーズ。

### 動作

| 入力 (`Color`) | `LineColor_RGB` |
| --- | --- |
| `"FF0000"` | `0xFF0000` |
| `"#3366CC"` | `0x3366CC` |
| `""` / `null` / 不正値 | `null` |

### テスト

- 新規: `TRViS.NetworkSyncService.IntegrationTests` に WebSocket 経由のリグレッションテスト 1 件 (`Timetable_TrainScope_WithExplicitColor_PropagatesToCachedTrainAsLineColor`) と対応する TestData フィクスチャ (`TrainScopeJson_WithColor`) を追加。
- 更新: `LoaderJson.Tests.cs` の Train01 アサーションを `Is.Null` → `Is.EqualTo(0x2255BB)` に変更 (`db.sample.json` の Train01 が元々 `"Color": "2255BB"` を持っていた)。Train02 (Color 未指定) は引き続き `Is.Null`。
- `dotnet test TRViS.IO.Tests` 31/31 PASS、`dotnet test TRViS.NetworkSyncService.IntegrationTests` 66/66 PASS。

## 将来的にやりたいこと

`ConvertTrain` の他の取りこぼしフィールド (`WorkType`、`BeforeDeparture_OnStationTrackCol`、`AfterArrive_OnStationTrackCol`、`TimetableRow.RecordType` 由来の `IsInfoRow` 等) も同様にケースバイケースで詰めていきたい。

## スクリーンショット

なし (内部データ変換ロジックの修正のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)