### PR TITLE
fix(select-file): Filter OS picker by extension; hide storage button on Android

### DIFF
--- a/TRViS.UITests/Pages/SelectFileDialogPageObject.cs
+++ b/TRViS.UITests/Pages/SelectFileDialogPageObject.cs
@@ -26,7 +26,9 @@ public class SelectFileDialogPageObject : PageObject
 	// Empty state
 	public AppiumElement EmptyMessage => FindByAutomationId(AutomationIds.SelectFile.EmptyMessage);
 
-	// Always-visible footer actions
+	// Footer actions. BrowseButton is always present; OpenStorageLocationButton is
+	// hidden on Android (internal-storage limitation) — guard accesses with !IsAndroid
+	// or FindByAutomationId will throw NoSuchElementException.
 	public AppiumElement BrowseButton => FindByAutomationId(AutomationIds.SelectFile.BrowseButton);
 	public AppiumElement OpenStorageLocationButton => FindByAutomationId(AutomationIds.SelectFile.OpenStorageLocationButton);
 

--- a/TRViS.UITests/Tests/SelectFileDialogTests.cs
+++ b/TRViS.UITests/Tests/SelectFileDialogTests.cs
@@ -39,8 +39,14 @@ public class SelectFileDialogTests : BaseUITest
 			"With no files, the dialog should default to the empty state.");
 		Assert.That(dialog.BrowseButton.Displayed, Is.True,
 			"The browse button should remain visible in the empty state.");
-		Assert.That(dialog.OpenStorageLocationButton.Displayed, Is.True,
-			"The 'open storage location' button should be reachable so the user can drop files in.");
+		// "保存場所を開く" is hidden on Android by design — TimetableFileDirectory lives in
+		// internal storage that no Files-app can browse, and `file://` URIs throw
+		// FileUriExposedException on API 24+. See SelectFileDialog ctor for rationale.
+		if (!IsAndroid)
+		{
+			Assert.That(dialog.OpenStorageLocationButton.Displayed, Is.True,
+				"The 'open storage location' button should be reachable so the user can drop files in.");
+		}
 	}
 
 	[Test]

--- a/TRViS/RootPages/SelectFileDialog.xaml.cs
+++ b/TRViS/RootPages/SelectFileDialog.xaml.cs
@@ -30,6 +30,28 @@ public partial class SelectFileDialog : ContentPage
 	// the OnSelectFileClicked dispatch in StartHomePage.xaml.cs (.sqlite/.db/.sqlite3).
 	private static readonly string[] s_listedExtensions = { ".json", ".sqlite", ".db", ".sqlite3" };
 
+	// OS file picker filter. Strings are interpreted per-platform:
+	//   - iOS / MacCatalyst: UTI identifiers passed to UIDocumentPickerViewController.
+	//     `public.json` is system-defined; `public.database` covers files tagged as
+	//     databases. Note: `.sqlite/.db/.sqlite3` files are not natively tagged as
+	//     `public.database` on iOS — they appear as `public.data`. Until UTI conformance
+	//     is declared in Info.plist (UTExportedTypeDeclarations), iOS users who need to
+	//     pick a sqlite/db file should tap "..." → "Show all files" in the picker. The
+	//     post-pick extension check in TryLoadFileAsync remains the safety net.
+	//   - Android: MIME types. `application/octet-stream` is intentionally included
+	//     because Android often misidentifies user-supplied sqlite files with that MIME.
+	//   - Windows: file extensions including the leading dot.
+	private static readonly PickOptions s_pickOptions = new()
+	{
+		FileTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+		{
+			{ DevicePlatform.iOS, new[] { "public.json", "public.database" } },
+			{ DevicePlatform.MacCatalyst, new[] { "public.json", "public.database" } },
+			{ DevicePlatform.Android, new[] { "application/json", "application/x-sqlite3", "application/vnd.sqlite3", "application/octet-stream" } },
+			{ DevicePlatform.WinUI, new[] { ".json", ".sqlite", ".db", ".sqlite3" } },
+		}),
+	};
+
 	// Drill-down state. _rootDirectory is the user-visible "top" — going above it
 	// is not allowed (we don't want users wandering into the rest of the sandbox).
 	private DirectoryInfo _rootDirectory = DirectoryPathProvider.TimetableFileDirectory;
@@ -67,6 +89,15 @@ public partial class SelectFileDialog : ContentPage
 		// on the actual directory contents.
 		BreadcrumbBorder.IsVisible = false;
 		EmptyStateView.IsVisible = false;
+
+		// "保存場所を開く" is hidden on Android: TimetableFileDirectory lives under
+		// AppDataDirectory (/data/data/<pkg>/files/...), which is internal storage no
+		// Files-app can browse — and a `file://` URI would throw FileUriExposedException
+		// on API 24+. Until/unless the timetable directory is relocated to a shared
+		// location (e.g. via SAF / scoped storage), opening it from Android is a no-op
+		// at best. The button stays for iOS / Mac Catalyst / Windows where it works.
+		if (DeviceInfo.Current.Platform == DevicePlatform.Android)
+			OpenStorageLocationButton.IsVisible = false;
 	}
 
 	protected override void OnAppearing()
@@ -469,7 +500,7 @@ public partial class SelectFileDialog : ContentPage
 		try
 		{
 			SetInputEnabled(false);
-			var result = await FilePicker.Default.PickAsync();
+			var result = await FilePicker.Default.PickAsync(s_pickOptions);
 			if (result is null)
 			{
 				logger.Info("File picker cancelled");


### PR DESCRIPTION
## Issueへのリンク

Closes #222

## 実装した機能の説明

`SelectFileDialog` の UX 上問題のあった 2 経路を修正しました。

### 1. OS FilePicker に拡張子フィルタを追加

`OnBrowseClicked` で `FilePicker.Default.PickAsync()` をオプション無しで呼んでいたため、ユーザは任意ファイルを選べてしまい、`.txt` 等の対応外形式を選んだあとに「対応していないファイル形式です」と告げられる UX でした。プラットフォーム別の `PickOptions` (json / sqlite / db / sqlite3) を渡すようにしました。

| プラットフォーム | フィルタ値 |
| --- | --- |
| iOS / MacCatalyst | `public.json`, `public.database` (UTI) |
| Android | `application/json`, `application/x-sqlite3`, `application/vnd.sqlite3`, `application/octet-stream` |
| Windows | `.json`, `.sqlite`, `.db`, `.sqlite3` |

**iOS の制約**: `.sqlite/.db/.sqlite3` 拡張子は iOS 上でネイティブに `public.database` UTI として登録されておらず `public.data` 扱いになります。Info.plist に `UTExportedTypeDeclarations` を宣言するまでは、SQLite ファイルを iOS で開く場合はピッカー右上「…」→「すべてのファイルを表示」が必要です。`TryLoadFileAsync` 内の post-pick 拡張子チェックがセーフティネットとして機能します。

**Android のトレードオフ**: `application/octet-stream` を含めているため、SQLite 以外のバイナリファイルも選択可能になります。元の苦情だった `.txt` (= `text/plain`) は除外できているので OK と判断しました。

### 2. OpenStorageLocation ボタンを Android で非表示

`OpenInOsFileManagerAsync` の `#else` 分岐 (`new Uri(fullPath)` → `file://`) は Android API 24+ で `FileUriExposedException` を投げます。さらに `TimetableFileDirectory` は `AppDataDirectory` (`/data/data/<pkg>/files/...`) 配下の内部ストレージで、Files アプリから到達できる場所ではありません。FileProvider 経由でも個別ファイル URI しか発行できず「フォルダを開く」UX には合わないため、Android では button そのものを `IsVisible = false` にしました。

iOS / Mac Catalyst / Windows は従来どおり (`shareddocuments://` / Finder / Explorer)。

## 仕様の説明

### コード変更

- `TRViS/RootPages/SelectFileDialog.xaml.cs`
  - 静的フィールド `s_pickOptions` を追加し、`OnBrowseClicked` から `PickAsync(s_pickOptions)` を呼ぶよう変更
  - コンストラクタで `DeviceInfo.Current.Platform == DevicePlatform.Android` 判定により `OpenStorageLocationButton.IsVisible = false`
- `TRViS.UITests/Tests/SelectFileDialogTests.cs`
  - `OpenStorageLocationButton.Displayed` のアサートを `if (!IsAndroid)` でガード
- `TRViS.UITests/Pages/SelectFileDialogPageObject.cs`
  - フッターアクションのコメントを更新 (Android 上は OpenStorageLocationButton が無いことを明記)

### 検証

- `dotnet build` ✅ Mac Catalyst / Android / iOS すべて成功
- `TRViS.UITests` ビルド ✅ 成功
- ローカル UI テスト実機検証は未実施 (CI に委ねます)

## 将来的にやりたいこと

- iOS の sqlite UTI 問題: Info.plist に `UTExportedTypeDeclarations` を宣言して `.sqlite/.db/.sqlite3` を `public.database` 準拠にする (フォローアップ対応推奨)
- **別途検出した out-of-scope バグ**: Android で OS ピッカーが返す `FileResult.FullPath` は `content://` URI のことがあり、現在の `LoaderJson.InitFromFileAsync` / `new LoaderSQL(...)` に直接渡すと `FileNotFoundException` で失敗します。`OpenReadAsync` でストリーム経由に変更するか、サンドボックス内にコピーしてからローダに渡す必要があります。本 PR とは別に対応します。

## スクリーンショット

UI レイアウト自体に変化はなく (Android で「保存場所を開く」が消えるのみ)、ファイル選択ダイアログの挙動変更のため割愛します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)