### PR TITLE
fix(android): Copy picked file to sandbox before loading

### DIFF
--- a/TRViS/RootPages/SelectFileDialog.xaml.cs
+++ b/TRViS/RootPages/SelectFileDialog.xaml.cs
@@ -477,7 +477,20 @@ public partial class SelectFileDialog : ContentPage
 			}
 
 			logger.Info("File selected via picker: {0}", result.FullPath);
-			bool ok = await TryLoadFileAsync(result.FullPath);
+
+			// FileResult.FullPath on Android may be a content:// URI rather than
+			// a filesystem path (per .NET MAUI FilePicker docs). The downstream
+			// loaders use File.OpenRead / SqliteConnection, which require a real
+			// path and would throw FileNotFoundException on a content:// URI.
+			// Stream the picked file via FileResult.OpenReadAsync (works on every
+			// platform) into the sandbox before handing the local path to the
+			// loader. Landing under TimetableFileDirectory/imported/ also makes
+			// the file appear in the card list on subsequent opens — the user
+			// suggested UserContentsDirectory but only the timetables tree is
+			// surfaced by the card list.
+			string localPath = await ImportPickedFileAsync(result);
+
+			bool ok = await TryLoadFileAsync(localPath);
 			if (ok)
 				await Navigation.PopModalAsync();
 		}
@@ -490,6 +503,53 @@ public partial class SelectFileDialog : ContentPage
 		finally
 		{
 			SetInputEnabled(true);
+		}
+	}
+
+	static async Task<string> ImportPickedFileAsync(FileResult result)
+	{
+		DirectoryInfo importedDir = new(System.IO.Path.Combine(DirectoryPathProvider.TimetableFileDirectory.FullName, "imported"));
+		if (!importedDir.Exists)
+			importedDir.Create();
+
+		string fileName = SanitizeFileName(result.FileName);
+		string destPath = ResolveUniqueFilePath(importedDir.FullName, fileName);
+
+		using Stream src = await result.OpenReadAsync();
+		using FileStream dst = File.Create(destPath);
+		await src.CopyToAsync(dst);
+
+		return destPath;
+	}
+
+	static string SanitizeFileName(string name)
+	{
+		string fileName = System.IO.Path.GetFileName(name ?? string.Empty);
+		if (string.IsNullOrWhiteSpace(fileName))
+			return "imported_file";
+
+		char[] invalid = System.IO.Path.GetInvalidFileNameChars();
+		var sb = new System.Text.StringBuilder(fileName.Length);
+		foreach (char ch in fileName)
+			sb.Append(Array.IndexOf(invalid, ch) >= 0 ? '_' : ch);
+
+		string sanitized = sb.ToString().Trim();
+		return string.IsNullOrEmpty(sanitized) ? "imported_file" : sanitized;
+	}
+
+	static string ResolveUniqueFilePath(string directory, string fileName)
+	{
+		string candidate = System.IO.Path.Combine(directory, fileName);
+		if (!File.Exists(candidate))
+			return candidate;
+
+		string baseName = System.IO.Path.GetFileNameWithoutExtension(fileName);
+		string ext = System.IO.Path.GetExtension(fileName);
+		for (int i = 1; ; i++)
+		{
+			candidate = System.IO.Path.Combine(directory, $"{baseName} ({i}){ext}");
+			if (!File.Exists(candidate))
+				return candidate;
 		}
 	}
 


### PR DESCRIPTION
## Issueへのリンク

#222 のレビュー追従。

## 実装した機能の説明

Android で FilePicker から選んだファイルを開けるように修正。

`FileResult.FullPath` は Android では `content://` URI を返すことがあり、これを
そのままローダー (`LoaderJson` → `File.OpenRead`, `LoaderSQL` → `SqliteConnection`)
に渡すと `FileNotFoundException` が出てしまうため、`FileResult.OpenReadAsync` で
ストリームとして読み出してアプリのサンドボックス内 (`TimetableFileDirectory/imported/`)
に一旦コピーし、そのローカルパスを既存のローダーに渡す形に変更しました。

ローダー側の API を Stream 受け取りに改修するより影響範囲が小さく、コピーされたファイルは
そのまま残るため、次回起動時にカード一覧の `imported/` フォルダから再度開けるという副次的な
UX 改善も得られます。

## 仕様の説明

- `SelectFileDialog` の「他の場所からファイルを開く」ボタンで OS のファイルピッカーを
  開いてファイルを選択した場合、
  - 選択したファイルを `<TimetableFileDirectory>/imported/` 配下にコピーする
    (フォルダが無ければ作成)。
  - ファイル名は `result.FileName` を使い、無効文字は `_` に置換、同名ファイルが既に
    存在する場合は ` (1)`, ` (2)`, … のサフィックスを付けて衝突を回避する。
  - コピー先のローカルパスを既存の `TryLoadFileAsync` に渡してロードする。
- iOS / Mac Catalyst / Windows では従来から `FullPath` が実ファイルパスを返すため、
  上記コピーは事実上ダウンロード後のキャッシュとしてのみ働きます (副作用は無害なため
  プラットフォーム分岐はせず常時コピー)。

## 将来的にやりたいこと

- カード一覧側で `imported/` フォルダの古いファイルを整理する仕組み。
- 同名ファイルを再度ピックしたときに「上書きする / 別名で保存する」を選べる UI。

## スクリーンショット

(挙動的な変更のみ・UI 変更なし)

## 検証

- ✅ `dotnet build TRViS/TRViS.csproj -f net10.0-android -c Debug` がローカルで成功
  (placeholder Google-services.json 利用、`.github/workflows/ui-test.yml` の手順に準拠)。
- ⚠️ Android エミュレータ実機での「ファイルを選んで実際にロードできるか」の手動確認は
  未実施 (本PRはコード変更のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)