### PR TITLE
fix(network-sync): Inherit WorkName/AffectDate from parent Work when caching Trains

### DIFF
--- a/TRViS.IO.ILoader/JsonModelsConverter.cs
+++ b/TRViS.IO.ILoader/JsonModelsConverter.cs
@@ -76,9 +76,33 @@ public static partial class JsonModelsConverter
 	}
 
 	/// <summary>
-	/// JsonModels.TrainData を TRViS.IO.Models.TrainData に変換します
+	/// JsonModels.TrainData を TRViS.IO.Models.TrainData に変換します。
+	/// 親 WorkData が存在しない場合の既定オーバーロード。
+	/// WorkName / AffectDate は <c>null</c> になるので、可能な限り親情報を渡せるオーバーロードを使うこと。
 	/// </summary>
 	public static TrainData ConvertTrain(JsonModels.TrainData trainJson)
+		=> ConvertTrain(trainJson, workName: null, affectDate: null);
+
+	/// <summary>
+	/// JsonModels.TrainData を TRViS.IO.Models.TrainData に変換します。
+	/// 親 WorkData が手元にあるときは、その <see cref="JsonModels.WorkData.Name"/> /
+	/// <see cref="JsonModels.WorkData.AffectDate"/> を引き継いで埋めます。
+	/// JsonModels.TrainData 自体は WorkName / AffectDate を持たないため、
+	/// 呼び出し側で親文脈を渡さない限り IO.Models.TrainData 側のこれらは null になる。
+	/// LoaderJson の単一ファイルロードと挙動を揃えるためのフックです。
+	/// </summary>
+	public static TrainData ConvertTrain(JsonModels.TrainData trainJson, JsonModels.WorkData? parentWork)
+		=> ConvertTrain(
+			trainJson,
+			workName: parentWork?.Name,
+			affectDate: StringToDateOnlyUtil.StringToDateOnlyOrNull(parentWork?.AffectDate));
+
+	/// <summary>
+	/// JsonModels.TrainData を TRViS.IO.Models.TrainData に変換します。
+	/// WorkName / AffectDate を呼び出し側で解決済みの値として渡したい場合に使います
+	/// (例: Train スコープ単独更新で、既にキャッシュ済みの Work から値を引き継ぐ)。
+	/// </summary>
+	public static TrainData ConvertTrain(JsonModels.TrainData trainJson, string? workName, DateOnly? affectDate)
 	{
 		string trainId = string.IsNullOrEmpty(trainJson.Id)
 			? Guid.NewGuid().ToString()
@@ -113,6 +137,8 @@ public static partial class JsonModelsConverter
 		return new TrainData(
 			Id: trainId,
 			Direction: trainJson.Direction < 0 ? Direction.Inbound : Direction.Outbound,
+			WorkName: workName,
+			AffectDate: affectDate,
 			TrainNumber: trainJson.TrainNumber,
 			MaxSpeed: trainJson.MaxSpeed,
 			SpeedType: trainJson.SpeedType,

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -1855,6 +1855,138 @@ public class WebSocketIntegrationTests
 	}
 
 	// ================================================================
+	// 親 Work からの WorkName / AffectDate 引き継ぎ
+	//
+	// JsonModels.TrainData は WorkName / AffectDate を持たないため、IO.Models.TrainData の
+	// これらフィールドは親 WorkData (Name / AffectDate) から引き継いで埋める必要がある。
+	// LoaderJson はこれを行っているが、WebSocket 経由のキャッシュ生成でも同様に動くこと、
+	// および Train スコープ単独更新では既にキャッシュ済みの Work から引き継がれることを検証する。
+	// ================================================================
+
+	[Test]
+	public async Task TrainData_AllScope_InheritsWorkNameFromParentWork()
+	{
+		// All スコープロード後、各 Train の WorkName が親 Work.Name と一致すること。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await ttTask;
+
+			var loader = (ILoader)service;
+			var work = loader.GetWorkList(TestData.WorkGroupId).First();
+
+			var train1 = loader.GetTrainData(TestData.TrainId);
+			var train2 = loader.GetTrainData(TestData.TrainId2);
+			Assert.Multiple(() =>
+			{
+				Assert.That(train1, Is.Not.Null);
+				Assert.That(train1!.WorkName, Is.EqualTo(work.Name));
+				Assert.That(train2, Is.Not.Null);
+				Assert.That(train2!.WorkName, Is.EqualTo(work.Name));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task TrainData_AllScope_InheritsAffectDateFromParentWork()
+	{
+		// All スコープロード後、各 Train の AffectDate が親 Work.AffectDate (パース済み DateOnly) と一致すること。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await ttTask;
+
+			var loader = (ILoader)service;
+			var work = loader.GetWorkList(TestData.WorkGroupId).First();
+			Assert.That(work.AffectDate, Is.Not.Null, "Work.AffectDate のパース前提");
+
+			var train1 = loader.GetTrainData(TestData.TrainId);
+			var train2 = loader.GetTrainData(TestData.TrainId2);
+			Assert.Multiple(() =>
+			{
+				Assert.That(train1, Is.Not.Null);
+				Assert.That(train1!.AffectDate, Is.EqualTo(work.AffectDate));
+				Assert.That(train2, Is.Not.Null);
+				Assert.That(train2!.AffectDate, Is.EqualTo(work.AffectDate));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task TrainData_TrainScopeAfterAllScope_PreservesWorkNameAndAffectDateFromCachedWork()
+	{
+		// Train スコープ単独更新の JSON には親 Work 情報が含まれない。
+		// 既にキャッシュ済みの Work から WorkName / AffectDate を引き継いで埋め直すこと。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			// 1. まず All スコープでキャッシュを作成
+			var firstTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await firstTask;
+
+			var loader = (ILoader)service;
+			var work = loader.GetWorkList(TestData.WorkGroupId).First();
+			string expectedWorkName = work.Name;
+			DateOnly? expectedAffectDate = work.AffectDate;
+
+			// 2. Train スコープ単独更新
+			var ttTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(
+				TestData.TrainScopeJson,
+				workId: TestData.WorkId,
+				trainId: TestData.TrainId
+			);
+			await ttTask;
+
+			// 3. 更新後の Train が新しい TrainNumber を持ちつつ、
+			//    親 Work から引き継いだ WorkName / AffectDate も保持していること
+			var updated = loader.GetTrainData(TestData.TrainId);
+			Assert.Multiple(() =>
+			{
+				Assert.That(updated, Is.Not.Null);
+				Assert.That(updated!.TrainNumber, Is.EqualTo("T-001-Updated"), "Train スコープの新ペイロード値");
+				Assert.That(updated.WorkName, Is.EqualTo(expectedWorkName), "親 Work.Name を引き継いでいること");
+				Assert.That(updated.AffectDate, Is.EqualTo(expectedAffectDate), "親 Work.AffectDate を引き継いでいること");
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
 	// 空ダイヤのカスケード (#214 コメント対応)
 	// ================================================================
 

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -573,7 +573,21 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 							timetableData.JsonData,
 							JsonDeserializeOptions
 						);
-						var trainData = JsonModelsConverter.ConvertTrain(jsonModels!);
+						// Train スコープ単独更新の JSON には親 Work の情報 (Name / AffectDate) が含まれない。
+						// IO.Models.TrainData.WorkName / AffectDate は親から引き継ぐべき値なので、
+						// 既にキャッシュ済みの Work を WorkId で引いて、その Name / AffectDate を流用する。
+						// (Work がまだキャッシュされていない場合は null のまま; AffectDateFormatter は
+						//  「今日−DayCount」にフォールバックする既存挙動になる)
+						string? inheritedWorkName = null;
+						DateOnly? inheritedAffectDate = null;
+						if (timetableData.WorkId is not null)
+						{
+							var cachedWork = FindCachedWork(timetableData.WorkId);
+							inheritedWorkName = cachedWork?.Name;
+							inheritedAffectDate = cachedWork?.AffectDate;
+						}
+
+						var trainData = JsonModelsConverter.ConvertTrain(jsonModels!, inheritedWorkName, inheritedAffectDate);
 						_TrainDataCache[timetableData.TrainId] = trainData;
 
 						// WorkIdに紐づくTrainのリストにも追加
@@ -638,7 +652,7 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 				{
 					var work = JsonModelsConverter.ConvertWork(workData, workGroupId);
 					_WorkListCache[workGroupId].Add(work);
-					RebuildTrainCacheForWork(work.Id, workData.Trains);
+					RebuildTrainCacheForWork(work.Id, workData.Trains, workData);
 				}
 				catch (Exception ex)
 				{
@@ -663,7 +677,7 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		_WorkListCache[workGroupId].Add(work);
 		logger.Debug("CacheWorkSubtree: Updated Work {0} ({1}) under WorkGroup {2}", work.Id, work.Name, workGroupId);
 
-		RebuildTrainCacheForWork(work.Id, workData.Trains);
+		RebuildTrainCacheForWork(work.Id, workData.Trains, workData);
 	}
 
 	/// <summary>
@@ -673,8 +687,13 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	/// <remarks>
 	/// 前提: TrainId はちょうど一つの Work に属する (LoaderJson の WorkIdByTrainId と同じ不変条件)。
 	/// この前提が崩れると、他の Work から参照されている TrainId を誤って _TrainDataCache から削除しうる。
+	/// <para>
+	/// <paramref name="parentWork"/> は親 WorkData。各 Train の WorkName / AffectDate は
+	/// JsonModels.TrainData が持たないため、ここで親から引き継いで埋める
+	/// (LoaderJson と同じ挙動。AffectDateFormatter のフォールバックを抑止する)。
+	/// </para>
 	/// </remarks>
-	private void RebuildTrainCacheForWork(string workId, JsonModels.TrainData[]? trains)
+	private void RebuildTrainCacheForWork(string workId, JsonModels.TrainData[]? trains, JsonModels.WorkData? parentWork)
 	{
 		// 古い Train を _TrainDataCache から取り除く (上記不変条件により他 Work からは参照されない)
 		if (_TrainListByWorkIdCache.TryGetValue(workId, out var oldTrains))
@@ -691,7 +710,7 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		{
 			try
 			{
-				var trainData = JsonModelsConverter.ConvertTrain(trainJson);
+				var trainData = JsonModelsConverter.ConvertTrain(trainJson, parentWork);
 				_TrainDataCache[trainData.Id] = trainData;
 				_TrainListByWorkIdCache[workId].Add(trainData);
 				logger.Debug("RebuildTrainCacheForWork: Added Train {0} ({1})", trainData.Id, trainData.TrainNumber);
@@ -701,6 +720,23 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 				logger.Error(ex, "RebuildTrainCacheForWork: Failed to process Train");
 			}
 		}
+	}
+
+	/// <summary>
+	/// _WorkListCache を WorkId で線形検索する (どの WorkGroup 配下にあるかを意識せずに引きたい場合)。
+	/// Train スコープ単独更新で、親 Work の Name / AffectDate を引き継ぐために使う。
+	/// </summary>
+	private Work? FindCachedWork(string workId)
+	{
+		foreach (var workList in _WorkListCache.Values)
+		{
+			foreach (var work in workList)
+			{
+				if (work.Id == workId)
+					return work;
+			}
+		}
+		return null;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Issueへのリンク

(audit follow-up — `JsonModelsConverter` の親文脈引き継ぎ漏れ)

## 実装した機能の説明

`WebSocketNetworkSyncService` 経由でロードされた `IO.Models.TrainData` の `WorkName` / `AffectDate` が常に `null` になっていた問題の修正です。

`JsonModels.TrainData` (NuGet) には `WorkName` も `AffectDate` も無く、これらの値は親 `JsonModels.WorkData.Name` / `WorkData.AffectDate` から引き継ぐ設計になっています。`LoaderJson` (ファイルロード経路) はこの引き継ぎを行っていますが ([TRViS.IO/Loaders/LoaderJson.cs:180-181](https://github.com/TetsuOtter/TRViS/blob/main/TRViS.IO/Loaders/LoaderJson.cs#L180-L181))、`JsonModelsConverter.ConvertTrain` には親文脈が渡されておらず、WebSocket 経路では `loader.GetTrainData(...).WorkName` / `AffectDate` が常に `null` になっていました。

実害として `AffectDateFormatter.FormatAffectDateOnly` が `AffectDate is null` のとき「今日 − DayCount」にフォールバックするため、DTAC ヘッダーの施行日表示が壊れます。

## 仕様の説明

- `JsonModelsConverter.ConvertTrain` に 2 つのオーバーロードを追加
  - `ConvertTrain(JsonModels.TrainData, JsonModels.WorkData? parentWork)`: 親 WorkData を渡す通常経路 (LoaderJson と同じ挙動)
  - `ConvertTrain(JsonModels.TrainData, string? workName, DateOnly? affectDate)`: 解決済みの値を直接渡す経路 (Train スコープ単独更新でキャッシュ済みの `Work` から引き継ぐ用)
  - 既存の 1 引数版は内部的に新オーバーロードへ委譲 (後方互換)
- `WebSocketNetworkSyncService.RebuildTrainCacheForWork` に `JsonModels.WorkData? parentWork` 引数を追加し、`CacheWorkSubtree` / `CacheWorkGroupSubtree` から呼び出すときに親を渡す
- `CacheTimetableData` の `Train` スコープでは、ペイロードに親情報が含まれないため `_WorkListCache` を `WorkId` で線形検索するヘルパー `FindCachedWork` を追加し、その `Name` / `AffectDate` を Train へ引き継ぐ (= 既存キャッシュからのリードスルー)
- ファイル `TimetableSelectionManager.RefreshTrainDataForWork` が `_loader.GetTrainData(td.Id)` で Train を再取得するため、書き込みパスで埋めることで `Refresh()` 後も値が保たれます

### テスト

[TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs](TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs) に統合テスト 3 本追加:

- `TrainData_AllScope_InheritsWorkNameFromParentWork` — All スコープ受信後、`loader.GetTrainData(...).WorkName` が親 Work.Name と一致
- `TrainData_AllScope_InheritsAffectDateFromParentWork` — 同じく `AffectDate` がパース済み `DateOnly` と一致
- `TrainData_TrainScopeAfterAllScope_PreservesWorkNameAndAffectDateFromCachedWork` — All スコープ後の Train スコープ単独更新でも、新しい TrainNumber を取り込みつつ親 Work から引き継いだ `WorkName` / `AffectDate` が保持される

`dotnet test TRViS.NetworkSyncService.IntegrationTests/...` 全 68 件 (新規 3 件含む) パス。`TRViS.IO.Tests` も全 31 件パス (回帰なし)。

## 将来的にやりたいこと

- Train スコープ単独更新で対応する `Work` がまだキャッシュされていない (= 順序が逆) ケース。現状は `WorkName` / `AffectDate` が `null` になり、`AffectDateFormatter` の既存フォールバックに任せる。実用上はサーバが先に Work / All を配信する前提だが、必要なら警告ログを出すなどの拡張余地あり。

## スクリーンショット

UI 上の差分は施行日表示が「今日 − DayCount」から本来の日付に戻ること。サーバ運用時にしか再現しないため、本 PR はテストコードでのみ検証しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)