### PR TITLE
fix(network-sync): Tolerate disposed/aborted WebSocket in DisconnectAsync

### DIFF
--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -929,6 +929,9 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		_isDisconnecting = true;
 		_ReceiveLoopCts?.Cancel();
 
+		// 受信ループのキャンセルにより ClientWebSocket が内部で Abort/Dispose 済みの場合、
+		// CloseAsync は ObjectDisposedException や InvalidOperationException を投げ得る。
+		// シャットダウンパスではいずれも握りつぶして良い。
 		if (_WebSocket.State == WebSocketState.Open)
 		{
 			try
@@ -939,10 +942,9 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 					cancellationToken
 				);
 			}
-			catch (WebSocketException ex)
+			catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or InvalidOperationException)
 			{
-				logger.Warn(ex, "DisconnectAsync: WebSocket exception");
-				// Already closed or error
+				logger.Warn(ex, "DisconnectAsync: WebSocket already closed or disposed");
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Widens `DisconnectAsync`'s `CloseAsync` catch in [TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs](TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs) to also swallow `ObjectDisposedException` and `InvalidOperationException`, fixing an intermittent flake in `WebSocketIntegrationTests`.

## Why
`_ReceiveLoopCts.Cancel()` in `DisconnectAsync` triggers `ClientWebSocket.ReceiveAsync` cancellation, which (per `ClientWebSocket` semantics) aborts and disposes the underlying socket internally. The subsequent `if (_WebSocket.State == WebSocketState.Open)` check is therefore TOCTOU — the state can flip between the check and the `CloseAsync` call, causing `ObjectDisposedException: Cannot access a disposed object. Object name: 'System.Net.WebSockets.WebSocket'`.

Most recently observed flaking on `OperationCommand_AllActions_AreReceivedCorrectly` ([CI run](https://github.com/TetsuOtter/TRViS/actions/runs/25624453824/job/75216916457)); the same job passed on simple rerun, confirming a race rather than a deterministic bug.

## Scope
Other WebSocket call sites were inspected and need no change:
- `ReceiveMessagesAsync`'s `ReceiveAsync`/`CloseAsync` are inside `ReceiveLoopAsync`'s broad `catch (Exception)`, which already short-circuits on `_isDisconnecting`.
- `Dispose()` calls `_WebSocket.Dispose()` (idempotent).
- `SendAsync`/`ConnectAsync` are not on the teardown path.

`OperationCanceledException` is intentionally **not** swallowed so caller-token cancellation still propagates.

## Test plan
- [x] Built `TRViS.NetworkSyncService.csproj` cleanly with .NET 10 SDK
- [x] Ran the integration-tests Docker Compose stack 30 consecutive times — 30/30 passed (65 tests each, ~16s/run)
- [ ] CI integration-tests workflow green on this PR

Note: the original race is rare and not deterministically reproducible locally, so the 30-run loop is "no regression" evidence; the defensive catch is justified by inspection of `ClientWebSocket`'s cancellation→abort path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)