### PR TITLE
feat(network-sync): Skip GPS while WebSocket active + accept lat/lon over WebSocket

### DIFF
--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -62,6 +62,8 @@ internal class FakeNetworkSyncService : NetworkSyncServiceBase
 	public new void RaiseConnectionClosed() => base.RaiseConnectionClosed();
 	public new void RaiseConnectionFailed() => base.RaiseConnectionFailed();
 
+	public void SimulateProcessSyncedData(SyncedData syncedData) => ProcessSyncedData(syncedData);
+
 	protected override Task<SyncedData> GetSyncedDataAsync(CancellationToken token)
 	{
 		OnGetSyncedData?.Invoke();
@@ -355,5 +357,58 @@ public class LocationServiceIntegrationTests
 		Assert.That(received!.Value.lon, Is.EqualTo(135.0));
 		Assert.That(received!.Value.lat, Is.EqualTo(35.0));
 		Assert.That(received!.Value.acc, Is.EqualTo(5.0));
+	}
+
+	// -------------------------------------------------------
+	// 14. NetworkSyncService 経由の緯度経度配信は OnGpsLocationUpdated に転送される
+	// -------------------------------------------------------
+	[Test]
+	public void NetworkSyncService_LonLatReceived_ForwardedAsOnGpsLocationUpdated()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		(double lon, double lat, double? acc)? received = null;
+		_locationService.OnGpsLocationUpdated += (_, e) => received = e;
+
+		fakeNs.SimulateProcessSyncedData(new SyncedData(
+			Location_m: double.NaN,
+			Time_ms: 0,
+			CanStart: false,
+			Latitude_deg: 35.681236,
+			Longitude_deg: 139.767125,
+			Accuracy_m: 8.0
+		));
+
+		Assert.That(received, Is.Not.Null);
+		Assert.That(received!.Value.lon, Is.EqualTo(139.767125).Within(1e-9));
+		Assert.That(received!.Value.lat, Is.EqualTo(35.681236).Within(1e-9));
+		Assert.That(received!.Value.acc, Is.EqualTo(8.0).Within(1e-9));
+	}
+
+	// -------------------------------------------------------
+	// 15. NetworkSyncService に切替後 LonLatLocationService に戻したときに
+	//     購読が解除されている (二重発火しない)
+	// -------------------------------------------------------
+	[Test]
+	public void NetworkSyncService_Unsubscribed_AfterSwitchToLonLat()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		_locationService.SetLonLatLocationService();
+
+		int callCount = 0;
+		_locationService.OnGpsLocationUpdated += (_, _) => callCount++;
+
+		fakeNs.SimulateProcessSyncedData(new SyncedData(
+			Location_m: double.NaN,
+			Time_ms: 0,
+			CanStart: false,
+			Latitude_deg: 35.0,
+			Longitude_deg: 139.0,
+			Accuracy_m: null
+		));
+
+		Assert.That(callCount, Is.EqualTo(0));
 	}
 }

--- a/TRViS.LocationService.Tests/LonLatStationDetectorTests.cs
+++ b/TRViS.LocationService.Tests/LonLatStationDetectorTests.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+
+using TRViS.LocationService.Abstractions;
+using TRViS.NetworkSyncService.Internals;
+
+namespace TRViS.LocationService.Tests;
+
+/// <summary>
+/// <see cref="LonLatStationDetector"/> の単体テスト。
+/// NetworkSyncService が <see cref="TRViS.NetworkSyncService.SyncedData.Location_m"/> = NaN かつ
+/// 緯度経度ありの SyncedData を受信したときの駅判定アルゴリズムを検証する。
+/// </summary>
+[TestFixture]
+public class LonLatStationDetectorTests
+{
+	private static StaLocationInfo[] ThreeStationsClose() =>
+	[
+		// (location_m, lon, lat, nearby_radius_m)
+		new(0.0,    135.0,   35.0,   200.0),
+		new(1000.0, 135.01, 35.01, 200.0),
+		new(2000.0, 135.02, 35.02, 200.0),
+	];
+
+	[Test]
+	public void InitialFix_AtFirstStation_PicksFirstStation()
+	{
+		var detector = new LonLatStationDetector();
+		detector.SetStationLocations(ThreeStationsClose());
+
+		detector.UpdateWithLonLat(135.0, 35.0);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(detector.CurrentStationIndex, Is.EqualTo(0));
+			Assert.That(detector.IsRunningToNextStation, Is.False);
+			Assert.That(detector.IsFirstFix, Is.False);
+		});
+	}
+
+	[Test]
+	public void InitialFix_NearMiddleStation_PicksMiddleStation_ReportsChanged()
+	{
+		var detector = new LonLatStationDetector();
+		detector.SetStationLocations(ThreeStationsClose());
+
+		// 初期状態は index=0 (Reset 後の最初の有効駅)。駅2 (index=1) 付近を測位
+		bool changed = detector.UpdateWithLonLat(135.01, 35.01);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(detector.CurrentStationIndex, Is.EqualTo(1));
+			Assert.That(detector.IsRunningToNextStation, Is.False);
+			Assert.That(changed, Is.True, "0 → 1 に動いたので変化フラグは true");
+		});
+	}
+
+	[Test]
+	public void Reset_RestoresInitialState()
+	{
+		var detector = new LonLatStationDetector();
+		detector.SetStationLocations(ThreeStationsClose());
+		detector.UpdateWithLonLat(135.0, 35.0);
+
+		detector.Reset();
+
+		Assert.That(detector.IsFirstFix, Is.True);
+	}
+
+	[Test]
+	public void SetStationLocations_Null_DoesNotCrashOnUpdate()
+	{
+		var detector = new LonLatStationDetector();
+		detector.SetStationLocations(null);
+
+		Assert.DoesNotThrow(() => detector.UpdateWithLonLat(135.0, 35.0));
+		Assert.That(detector.CurrentStationIndex, Is.LessThan(0));
+	}
+
+	[Test]
+	public void Sync_ClearsHistoryButKeepsIndex()
+	{
+		var detector = new LonLatStationDetector();
+		detector.SetStationLocations(ThreeStationsClose());
+		detector.UpdateWithLonLat(135.0, 35.0);
+
+		detector.Sync(currentStationIndex: 2, isRunningToNextStation: true);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(detector.CurrentStationIndex, Is.EqualTo(2));
+			Assert.That(detector.IsRunningToNextStation, Is.True);
+			Assert.That(detector.IsFirstFix, Is.False);
+		});
+	}
+}

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -189,6 +189,21 @@ void OnIsEnabledChanged(bool value)
 	void OnNotificationReceived(object? sender, NotificationData n) => NotificationReceived?.Invoke(sender, n);
 	void OnTimeFormatChangeRequested(object? sender, TimeFormatCommand cmd) => TimeFormatChangeRequested?.Invoke(sender, cmd);
 
+	/// <summary>
+	/// NetworkSyncService 経由で配信された緯度経度を受け取り、
+	/// GPS 由来と同じ <see cref="OnGpsLocationUpdated"/> イベントとして外部に通知する。
+	/// 端末 GPS の代わりにサーバー配信を使う構成のために、station 検出は <see cref="SyncedData.Location_m"/>
+	/// 側に任せ、ここでは Map / UI 表示用のイベント発火だけ行う。
+	/// </summary>
+	void OnNetworkSyncServiceLonLatLocationReceived(object? sender, (double Longitude, double Latitude, double? Accuracy) location)
+	{
+		locationServiceLogger.Info(
+			"NetworkSyncService LonLatLocation Received (lon: {0}, lat: {1}, accuracy: {2})",
+			location.Longitude, location.Latitude, location.Accuracy
+		);
+		OnGpsLocationUpdated?.Invoke(this, location);
+	}
+
 	void OnNetworkSyncServiceCanStartChanged(object? sender, bool canStart)
 	{
 		logger.Debug("NetworkSyncServiceCanStartChanged: {0}", canStart);
@@ -269,6 +284,7 @@ void OnIsEnabledChanged(bool value)
 			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
 			networkSyncService.NotificationReceived -= OnNotificationReceived;
 			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
+			networkSyncService.LonLatLocationReceived -= OnNetworkSyncServiceLonLatLocationReceived;
 		}
 		if (currentService is IDisposable disposable)
 			disposable.Dispose();
@@ -389,6 +405,7 @@ void OnIsEnabledChanged(bool value)
 		nextService.ConnectionClosed += OnNetworkSyncServiceConnectionClosed;
 		nextService.ConnectionFailed += OnNetworkSyncServiceConnectionFailed;
 		nextService.CanStartChanged += OnNetworkSyncServiceCanStartChanged;
+		nextService.LonLatLocationReceived += OnNetworkSyncServiceLonLatLocationReceived;
 		nextService.StaLocationInfo = currentService?.StaLocationInfo;
 		// キャッシュされた ID を設定
 		nextService.WorkGroupId = _lastWorkGroupId;
@@ -421,6 +438,7 @@ void OnIsEnabledChanged(bool value)
 			networkSyncService.ConnectionClosed -= OnNetworkSyncServiceConnectionClosed;
 			networkSyncService.ConnectionFailed -= OnNetworkSyncServiceConnectionFailed;
 			networkSyncService.CanStartChanged -= OnNetworkSyncServiceCanStartChanged;
+			networkSyncService.LonLatLocationReceived -= OnNetworkSyncServiceLonLatLocationReceived;
 		}
 		if (currentService is IDisposable disposable)
 			disposable.Dispose();

--- a/TRViS.LocationService/LonLatLocationService.cs
+++ b/TRViS.LocationService/LonLatLocationService.cs
@@ -1,6 +1,6 @@
 
-using TRViS.LocationService.Internals;
-using static TRViS.LocationService.Internals.LocationCalcUtils;
+using TRViS.NetworkSyncService.Internals;
+using static TRViS.NetworkSyncService.Internals.LocationCalcUtils;
 using TRViS.LocationService.Abstractions;
 
 namespace TRViS.Services;

--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
@@ -43,9 +43,20 @@ public sealed class ReferenceServerClient : IDisposable
 		long? time_ms = null,
 		double? location_m = null,
 		bool? canStart = null,
+		double? latitude_deg = null,
+		double? longitude_deg = null,
+		double? accuracy_m = null,
 		CancellationToken ct = default)
 	{
-		var payload = new { Time_ms = time_ms, Location_m = location_m, CanStart = canStart };
+		var payload = new
+		{
+			Time_ms = time_ms,
+			Location_m = location_m,
+			CanStart = canStart,
+			Latitude_deg = latitude_deg,
+			Longitude_deg = longitude_deg,
+			Accuracy_m = accuracy_m,
+		};
 		var content = new StringContent(
 			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
 		var resp = await _http.PostAsync("/control/state", content, ct);
@@ -333,7 +344,10 @@ public sealed class ReferenceServerClient : IDisposable
 public sealed record ServerStateDto(
 	[property: JsonPropertyName("Time_ms")] long Time_ms,
 	[property: JsonPropertyName("Location_m")] double? Location_m,
-	[property: JsonPropertyName("CanStart")] bool CanStart
+	[property: JsonPropertyName("CanStart")] bool CanStart,
+	[property: JsonPropertyName("Latitude_deg")] double? Latitude_deg = null,
+	[property: JsonPropertyName("Longitude_deg")] double? Longitude_deg = null,
+	[property: JsonPropertyName("Accuracy_m")] double? Accuracy_m = null
 );
 
 public sealed record ServerInfoDto(

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -312,6 +312,64 @@ public class WebSocketIntegrationTests
 	}
 
 	[Test]
+	public async Task SyncedData_LonLat_FiresLonLatLocationReceived()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var locTask = WaitForEventAsync<(double Longitude, double Latitude, double? Accuracy)>(
+				h => service.LonLatLocationReceived += h,
+				h => service.LonLatLocationReceived -= h
+			);
+
+			await _control.SetStateAsync(
+				canStart: true,
+				latitude_deg: 35.681236,
+				longitude_deg: 139.767125,
+				accuracy_m: 12.5
+			);
+			await _control.BroadcastSyncedDataAsync();
+
+			var received = await locTask;
+			Assert.Multiple(() =>
+			{
+				Assert.That(received.Latitude, Is.EqualTo(35.681236).Within(1e-9));
+				Assert.That(received.Longitude, Is.EqualTo(139.767125).Within(1e-9));
+				Assert.That(received.Accuracy, Is.EqualTo(12.5).Within(1e-9));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task SyncedData_NoLonLat_DoesNotFireLonLatLocationReceived()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			bool received = false;
+			service.LonLatLocationReceived += (_, _) => received = true;
+
+			await _control.SetStateAsync(canStart: true);
+			await _control.BroadcastSyncedDataAsync();
+			await Task.Delay(200);
+
+			Assert.That(received, Is.False, "LonLatLocationReceived should not fire when no lat/lon is provided");
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
 	public async Task SyncedData_Location_StationIndexUpdated()
 	{
 		var service = await ConnectServiceAsync();
@@ -335,6 +393,46 @@ public class WebSocketIntegrationTests
 
 			// 駅2 (index=1) 付近の位置を送信
 			await _control.SetStateAsync(location_m: 1000.0, canStart: true);
+			await _control.BroadcastSyncedDataAsync();
+
+			var state = await stateTask;
+			Assert.That(state.NewStationIndex, Is.EqualTo(1));
+			Assert.That(state.IsRunningToNextStation, Is.False);
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task SyncedData_LonLat_StationIndexUpdatedWhenLocationMIsNaN()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			var stations = new StaLocationInfo[]
+			{
+				new(0.0,    135.0,   35.0,   200.0),
+				new(1000.0, 135.01, 35.01, 200.0),
+				new(2000.0, 135.02, 35.02, 200.0),
+			};
+			service.StaLocationInfo = stations;
+			service.IsEnabled = true;
+
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var stateTask = WaitForEventAsync<LocationStateChangedEventArgs>(
+				h => service.LocationStateChanged += h,
+				h => service.LocationStateChanged -= h
+			);
+
+			// Location_m は送らず、駅2 (index=1) のすぐそばの緯度経度を送信
+			await _control.SetStateAsync(
+				canStart: true,
+				latitude_deg: 35.01,
+				longitude_deg: 135.01
+			);
 			await _control.BroadcastSyncedDataAsync();
 
 			var state = await stateTask;

--- a/TRViS.NetworkSyncService/Internals/CalculateDistance.cs
+++ b/TRViS.NetworkSyncService/Internals/CalculateDistance.cs
@@ -1,6 +1,8 @@
+using System;
+
 using TRViS.LocationService.Abstractions;
 
-namespace TRViS.LocationService.Internals;
+namespace TRViS.NetworkSyncService.Internals;
 
 internal static partial class LocationCalcUtils
 {

--- a/TRViS.NetworkSyncService/Internals/IsNearBy.cs
+++ b/TRViS.NetworkSyncService/Internals/IsNearBy.cs
@@ -1,6 +1,6 @@
 using TRViS.LocationService.Abstractions;
 
-namespace TRViS.LocationService.Internals;
+namespace TRViS.NetworkSyncService.Internals;
 
 internal static partial class LocationCalcUtils
 {

--- a/TRViS.NetworkSyncService/Internals/LonLatStationDetector.cs
+++ b/TRViS.NetworkSyncService/Internals/LonLatStationDetector.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using TRViS.LocationService.Abstractions;
+
+using static TRViS.NetworkSyncService.Internals.LocationCalcUtils;
+
+namespace TRViS.NetworkSyncService.Internals;
+
+/// <summary>
+/// 緯度経度からの駅判定アルゴリズム。
+/// <see cref="NetworkSyncServiceBase"/> がサーバーから受信した <c>Location_m</c> が NaN
+/// で、緯度経度が代わりに配信されているときに使う。
+/// 既存の <c>LonLatLocationService</c> と同じ平均距離ベースのヒューリスティックを実装する。
+/// </summary>
+internal sealed class LonLatStationDetector
+{
+	const int CURRENT_STATION_INDEX_NOT_SET = -1;
+	const int DISTANCE_HISTORY_QUEUE_SIZE = 3;
+
+	private readonly Queue<double> _distanceHistory = new(DISTANCE_HISTORY_QUEUE_SIZE);
+
+	private StaLocationInfo[]? _staLocationInfo;
+
+	public int CurrentStationIndex { get; private set; } = CURRENT_STATION_INDEX_NOT_SET;
+	public bool IsRunningToNextStation { get; private set; }
+	public bool IsFirstFix { get; private set; } = true;
+
+	/// <summary>
+	/// 駅情報を更新する。状態 (CurrentStationIndex / IsRunningToNextStation / 履歴) はリセットされる。
+	/// </summary>
+	public void SetStationLocations(StaLocationInfo[]? staLocationInfo)
+	{
+		_staLocationInfo = staLocationInfo;
+		Reset();
+	}
+
+	public void Reset()
+	{
+		CurrentStationIndex = GetNextStationIndex(_staLocationInfo, CURRENT_STATION_INDEX_NOT_SET);
+		IsRunningToNextStation = false;
+		IsFirstFix = true;
+		_distanceHistory.Clear();
+	}
+
+	/// <summary>
+	/// 既存の駅 index と running フラグを外部状態から強制セットする。
+	/// 平均距離履歴と「初回」フラグもクリアする。
+	/// </summary>
+	public void Sync(int currentStationIndex, bool isRunningToNextStation)
+	{
+		CurrentStationIndex = currentStationIndex;
+		IsRunningToNextStation = isRunningToNextStation;
+		IsFirstFix = false;
+		_distanceHistory.Clear();
+	}
+
+	/// <summary>
+	/// 緯度経度を一回分供給して状態を更新する。
+	/// 戻り値は (CurrentStationIndex, IsRunningToNextStation) が変化したかどうか。
+	/// </summary>
+	public bool UpdateWithLonLat(double lon_deg, double lat_deg)
+	{
+		if (_staLocationInfo is null || _staLocationInfo.Length == 0)
+			return false;
+
+		int prevIndex = CurrentStationIndex;
+		bool prevRunning = IsRunningToNextStation;
+
+		if (IsFirstFix)
+		{
+			ApplyInitialFix(lon_deg, lat_deg);
+			IsFirstFix = false;
+		}
+		else
+		{
+			ApplySubsequentFix(lon_deg, lat_deg);
+		}
+
+		return prevIndex != CurrentStationIndex || prevRunning != IsRunningToNextStation;
+	}
+
+	// ============================================================
+	// 初回測位 (LonLatLocationService.ForceSetLocationInfo 相当)
+	// ============================================================
+	private void ApplyInitialFix(double lon_deg, double lat_deg)
+	{
+		StaLocationInfo[] stations = _staLocationInfo!;
+
+		// 緯度経度を持たない駅は対象外
+		double[] distanceArray = stations.Select(
+			v => v.HasLonLatLocation
+				? CalculateDistance_m(lon_deg, lat_deg, v.Location_lon_deg, v.Location_lat_deg)
+				: double.NaN
+		).ToArray();
+
+		int nearestIndex = CURRENT_STATION_INDEX_NOT_SET;
+		int firstIndex = CURRENT_STATION_INDEX_NOT_SET;
+		int lastIndex = CURRENT_STATION_INDEX_NOT_SET;
+		double nearestDistance = double.MaxValue;
+		for (int i = 0; i < distanceArray.Length; i++)
+		{
+			if (double.IsNaN(distanceArray[i]))
+				continue;
+			if (firstIndex < 0)
+				firstIndex = i;
+			lastIndex = i;
+			if (distanceArray[i] < nearestDistance)
+			{
+				nearestIndex = i;
+				nearestDistance = distanceArray[i];
+			}
+		}
+
+		if (nearestIndex < 0)
+		{
+			// 全ての駅で緯度経度が無い: なにもしない
+			CurrentStationIndex = CURRENT_STATION_INDEX_NOT_SET;
+			IsRunningToNextStation = false;
+			return;
+		}
+
+		// 有効な駅が1つしかない場合
+		if (firstIndex == lastIndex)
+		{
+			CurrentStationIndex = firstIndex;
+			IsRunningToNextStation = false;
+			return;
+		}
+
+		if (nearestIndex == firstIndex)
+		{
+			CurrentStationIndex = firstIndex;
+			IsRunningToNextStation = IsLeaved(stations[nearestIndex], distanceArray[nearestIndex]);
+		}
+		else if (nearestIndex == lastIndex)
+		{
+			if (IsNearBy(stations[nearestIndex], distanceArray[nearestIndex]))
+			{
+				CurrentStationIndex = nearestIndex;
+				IsRunningToNextStation = false;
+			}
+			else
+			{
+				CurrentStationIndex = GetPastStationIndex(stations, nearestIndex);
+				IsRunningToNextStation = true;
+			}
+		}
+		else
+		{
+			if (IsNearBy(stations[nearestIndex], distanceArray[nearestIndex]))
+			{
+				CurrentStationIndex = nearestIndex;
+				IsRunningToNextStation = false;
+			}
+			else
+			{
+				IsRunningToNextStation = true;
+				CurrentStationIndex = nearestIndex;
+				int pastIndex = GetPastStationIndex(stations, nearestIndex);
+				int nextIndex = GetNextStationIndex(stations, nearestIndex);
+				if (pastIndex >= 0 && nextIndex >= 0
+					&& distanceArray[pastIndex] < distanceArray[nextIndex])
+				{
+					CurrentStationIndex = pastIndex;
+				}
+			}
+		}
+	}
+
+	// ============================================================
+	// 連続測位 (LonLatLocationService.SetCurrentLocation 相当)
+	// ============================================================
+	private void ApplySubsequentFix(double lon_deg, double lat_deg)
+	{
+		StaLocationInfo[] stations = _staLocationInfo!;
+		if (CurrentStationIndex < 0 || stations.Length <= CurrentStationIndex)
+			return;
+
+		if (IsRunningToNextStation)
+		{
+			int nextIndex = GetNextStationIndex(stations, CurrentStationIndex);
+			if (nextIndex < 0)
+				return;
+			StaLocationInfo nextStation = stations[nextIndex];
+			double distance = CalculateDistance_m(
+				lon_deg, lat_deg, nextStation.Location_lon_deg, nextStation.Location_lat_deg);
+			double avg = PushDistanceAndAverage(distance);
+			if (!double.IsNaN(avg) && IsNearBy(nextStation, avg))
+			{
+				_distanceHistory.Clear();
+				CurrentStationIndex = nextIndex;
+				IsRunningToNextStation = false;
+			}
+		}
+		else if (GetNextStationIndex(stations, CurrentStationIndex) >= 0)
+		{
+			StaLocationInfo currentStation = stations[CurrentStationIndex];
+			double distance = CalculateDistance_m(
+				lon_deg, lat_deg, currentStation.Location_lon_deg, currentStation.Location_lat_deg);
+			double avg = PushDistanceAndAverage(distance);
+			if (!double.IsNaN(avg) && IsLeaved(currentStation, avg))
+			{
+				_distanceHistory.Clear();
+				IsRunningToNextStation = true;
+			}
+		}
+	}
+
+	private double PushDistanceAndAverage(double distance)
+	{
+		if (_distanceHistory.Count == DISTANCE_HISTORY_QUEUE_SIZE)
+			_distanceHistory.Dequeue();
+		_distanceHistory.Enqueue(distance);
+		if (_distanceHistory.Count < DISTANCE_HISTORY_QUEUE_SIZE)
+			return double.NaN;
+		return _distanceHistory.Average();
+	}
+
+	private static int GetPastStationIndex(StaLocationInfo[] stations, int currentIndex)
+	{
+		if (currentIndex <= 0)
+			return CURRENT_STATION_INDEX_NOT_SET;
+		for (int i = currentIndex - 1; i >= 0; i--)
+		{
+			if (stations[i].HasLonLatLocation)
+				return i;
+		}
+		return CURRENT_STATION_INDEX_NOT_SET;
+	}
+
+	private static int GetNextStationIndex(StaLocationInfo[]? stations, int currentIndex)
+	{
+		if (stations is null)
+			return CURRENT_STATION_INDEX_NOT_SET;
+		for (int i = currentIndex + 1; i < stations.Length; i++)
+		{
+			if (stations[i].HasLonLatLocation)
+				return i;
+		}
+		return CURRENT_STATION_INDEX_NOT_SET;
+	}
+}

--- a/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NLog;
 
 using TRViS.LocationService.Abstractions;
+using TRViS.NetworkSyncService.Internals;
 
 namespace TRViS.NetworkSyncService;
 
@@ -55,9 +56,14 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 				return;
 
 			_staLocationInfo = value;
+			_lonLatStationDetector.SetStationLocations(value);
 			ResetLocationInfo();
 		}
 	}
+
+	// Location_m が NaN かつ緯度経度が配信されたときの駅判定エンジン。
+	// SyncedData が <see cref="SyncedData.Location_m"/> を持たない接続向けのフォールバック。
+	private readonly LonLatStationDetector _lonLatStationDetector = new();
 
 	private string? _WorkGroupId;
 	public string? WorkGroupId
@@ -120,6 +126,12 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	public event EventHandler? ConnectionFailed;
 	public event EventHandler<bool>? CanStartChanged;
 
+	/// <summary>
+	/// サーバーから緯度経度が配信されたときに発火する。
+	/// 引数は (Longitude, Latitude, Accuracy?) の tuple。
+	/// </summary>
+	public event EventHandler<(double Longitude, double Latitude, double? Accuracy)>? LonLatLocationReceived;
+
 	protected bool _IsDisposed;
 
 	/// <summary>
@@ -174,8 +186,27 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	/// </summary>
 	protected void ProcessSyncedData(SyncedData syncedData)
 	{
-		Logger.Debug("ProcessSyncedData: Location_m={0}, Time_ms={1}, CanStart={2}", syncedData.Location_m, syncedData.Time_ms, syncedData.CanStart);
-		UpdateCurrentStationWithLocation(syncedData.Location_m);
+		Logger.Debug("ProcessSyncedData: Location_m={0}, Time_ms={1}, CanStart={2}, Latitude_deg={3}, Longitude_deg={4}, Accuracy_m={5}",
+			syncedData.Location_m, syncedData.Time_ms, syncedData.CanStart,
+			syncedData.Latitude_deg, syncedData.Longitude_deg, syncedData.Accuracy_m);
+
+		// 有効な緯度経度であるかを先に判定 (NaN は除外)
+		bool hasLonLat =
+			syncedData.Latitude_deg is double lat && !double.IsNaN(lat)
+			&& syncedData.Longitude_deg is double lon && !double.IsNaN(lon);
+
+		if (!double.IsNaN(syncedData.Location_m))
+		{
+			// Location_m が来ていれば従来通りそれで駅判定する。
+			// lat/lon ベースの履歴は次回フォールバック時に新規初期化する。
+			UpdateCurrentStationWithLocation(syncedData.Location_m);
+			_lonLatStationDetector.Reset();
+		}
+		else if (hasLonLat)
+		{
+			// Location_m が NaN かつ緯度経度がある場合は緯度経度ベースで駅判定する。
+			UpdateCurrentStationWithLonLat(syncedData.Longitude_deg!.Value, syncedData.Latitude_deg!.Value);
+		}
 
 		int currentTime_s = (int)(syncedData.Time_ms / 1000);
 		if (CurrentTime_s != currentTime_s)
@@ -187,6 +218,30 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 
 		CanStart = syncedData.CanStart;
 		CanUseService = syncedData.CanStart;
+
+		// 緯度経度が両方含まれていれば LonLatLocationReceived を発火する。
+		// 値がない場合 (HTTP プロトコルや lat/lon 非対応サーバー) や NaN は無視する。
+		if (hasLonLat)
+		{
+			LonLatLocationReceived?.Invoke(this, (syncedData.Longitude_deg!.Value, syncedData.Latitude_deg!.Value, syncedData.Accuracy_m));
+		}
+	}
+
+	/// <summary>
+	/// <see cref="SyncedData.Location_m"/> が NaN のときに緯度経度ベースで駅判定する。
+	/// 距離履歴の平均を取るために、検出器の状態は ProcessSyncedData の連続呼び出し間で
+	/// 保持する (毎回 Sync は呼ばない)。
+	/// </summary>
+	private void UpdateCurrentStationWithLonLat(double longitude_deg, double latitude_deg)
+	{
+		if (StaLocationInfo is null || !IsEnabled)
+			return;
+
+		bool changed = _lonLatStationDetector.UpdateWithLonLat(longitude_deg, latitude_deg);
+		if (changed)
+		{
+			ForceSetLocationInfo(_lonLatStationDetector.CurrentStationIndex, _lonLatStationDetector.IsRunningToNextStation);
+		}
 	}
 
 	void UpdateCurrentStationWithLocation(double location_m)
@@ -336,6 +391,9 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	{
 		CurrentStationIndex = stationIndex;
 		IsRunningToNextStation = isRunningToNextStation;
+		// 緯度経度ベースの駅判定エンジンも外部の強制セットに合わせて状態同期する。
+		// (距離履歴は外部介入の時点で意味を失うのでクリアする)
+		_lonLatStationDetector.Sync(stationIndex, isRunningToNextStation);
 		LocationStateChanged?.Invoke(this, new LocationStateChangedEventArgs(CurrentStationIndex, IsRunningToNextStation));
 	}
 
@@ -343,6 +401,7 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	{
 		CurrentStationIndex = 0;
 		IsRunningToNextStation = false;
+		_lonLatStationDetector.Reset();
 		LocationStateChanged?.Invoke(this, new LocationStateChangedEventArgs(CurrentStationIndex, IsRunningToNextStation));
 	}
 

--- a/TRViS.NetworkSyncService/SyncedData.cs
+++ b/TRViS.NetworkSyncService/SyncedData.cs
@@ -3,10 +3,28 @@ namespace TRViS.NetworkSyncService;
 public class SyncedData(
 	double Location_m,
 	long Time_ms,
-	bool CanStart
+	bool CanStart,
+	double? Latitude_deg = null,
+	double? Longitude_deg = null,
+	double? Accuracy_m = null
 )
 {
 	public double Location_m { get; } = Location_m;
 	public long Time_ms { get; } = Time_ms;
 	public bool CanStart { get; } = CanStart;
+
+	/// <summary>
+	/// サーバーから配信された緯度。null の場合は緯度経度の配信なし。
+	/// </summary>
+	public double? Latitude_deg { get; } = Latitude_deg;
+
+	/// <summary>
+	/// サーバーから配信された経度。null の場合は緯度経度の配信なし。
+	/// </summary>
+	public double? Longitude_deg { get; } = Longitude_deg;
+
+	/// <summary>
+	/// サーバーから配信された緯度経度の精度 [m]。緯度経度が無い場合や精度情報が無い場合は null。
+	/// </summary>
+	public double? Accuracy_m { get; } = Accuracy_m;
 }

--- a/TRViS.NetworkSyncService/TRViS.NetworkSyncService.csproj
+++ b/TRViS.NetworkSyncService/TRViS.NetworkSyncService.csproj
@@ -15,4 +15,16 @@
 		<PackageReference Include="NLog" Version="5.3.2" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>TRViS.LocationService</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>TRViS.LocationService.Tests</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>TRViS.NetworkSyncService.IntegrationTests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
 </Project>

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -27,6 +27,9 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	private const string LOCATION_M_JSON_KEY = "Location_m";
 	private const string TIME_MS_JSON_KEY = "Time_ms";
 	private const string CAN_START_JSON_KEY = "CanStart";
+	private const string LATITUDE_DEG_JSON_KEY = "Latitude_deg";
+	private const string LONGITUDE_DEG_JSON_KEY = "Longitude_deg";
+	private const string ACCURACY_M_JSON_KEY = "Accuracy_m";
 
 	// ID更新メッセージのJSONキー
 	private const string WORK_GROUP_ID_JSON_KEY = "WorkGroupId";
@@ -317,7 +320,16 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		catch (KeyNotFoundException) { }
 		catch (FormatException) { }
 
-		SyncedData syncedData = new SyncedData(location_m, time_ms, canStart);
+		double? latitude_deg = TryReadOptionalDouble(root, LATITUDE_DEG_JSON_KEY);
+		double? longitude_deg = TryReadOptionalDouble(root, LONGITUDE_DEG_JSON_KEY);
+		double? accuracy_m = TryReadOptionalDouble(root, ACCURACY_M_JSON_KEY);
+
+		SyncedData syncedData = new SyncedData(
+			location_m, time_ms, canStart,
+			Latitude_deg: latitude_deg,
+			Longitude_deg: longitude_deg,
+			Accuracy_m: accuracy_m
+		);
 		_LatestData = syncedData;
 
 		// WebSocket uses event-driven approach: process data immediately upon receipt
@@ -501,6 +513,22 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		if (root.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
 			return prop.GetString();
 		return null;
+	}
+
+	private static double? TryReadOptionalDouble(JsonElement root, string name)
+	{
+		if (!root.TryGetProperty(name, out var prop) || prop.ValueKind == JsonValueKind.Null)
+			return null;
+		if (prop.ValueKind != JsonValueKind.Number)
+			return null;
+		try
+		{
+			return prop.GetDouble();
+		}
+		catch (FormatException)
+		{
+			return null;
+		}
 	}
 
 	private void CacheTimetableData(TimetableData timetableData)

--- a/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
+++ b/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
@@ -18,9 +18,16 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 	private readonly HttpServer _httpServer;
 
 	// --- サーバー状態 (immutable record + lock で一貫性を保証) ---
-	private sealed record ServerState(long Time_ms, double Location_m, bool CanStart);
+	private sealed record ServerState(
+		long Time_ms,
+		double Location_m,
+		bool CanStart,
+		double? Latitude_deg,
+		double? Longitude_deg,
+		double? Accuracy_m
+	);
 	private readonly object _stateLock = new();
-	private ServerState _state = new(0, double.NaN, false);
+	private ServerState _state = new(0, double.NaN, false, null, null, null);
 
 	// --- HTTP クエリログ ---
 	private readonly ConcurrentQueue<ReceivedHttpQueryDto> _httpQueryLog = new();
@@ -96,6 +103,9 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			Location_m = locationForJson,
 			Time_ms = state.Time_ms,
 			CanStart = state.CanStart,
+			Latitude_deg = state.Latitude_deg,
+			Longitude_deg = state.Longitude_deg,
+			Accuracy_m = state.Accuracy_m,
 		});
 		return OkJson(json);
 	}
@@ -151,6 +161,9 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			Time_ms = state.Time_ms,
 			Location_m = locationForJson,
 			CanStart = state.CanStart,
+			Latitude_deg = state.Latitude_deg,
+			Longitude_deg = state.Longitude_deg,
+			Accuracy_m = state.Accuracy_m,
 		}));
 	}
 
@@ -165,6 +178,9 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			lock (_stateLock)
 			{
 				var (time, location, canStart) = (_state.Time_ms, _state.Location_m, _state.CanStart);
+				double? latitude = _state.Latitude_deg;
+				double? longitude = _state.Longitude_deg;
+				double? accuracy = _state.Accuracy_m;
 
 				if (root.TryGetProperty("Time_ms", out var t) && t.ValueKind != JsonValueKind.Null)
 					time = t.GetInt64();
@@ -172,8 +188,14 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 					location = l.ValueKind == JsonValueKind.Null ? double.NaN : l.GetDouble();
 				if (root.TryGetProperty("CanStart", out var cs) && cs.ValueKind != JsonValueKind.Null)
 					canStart = cs.GetBoolean();
+				if (root.TryGetProperty("Latitude_deg", out var lat))
+					latitude = lat.ValueKind == JsonValueKind.Null ? null : lat.GetDouble();
+				if (root.TryGetProperty("Longitude_deg", out var lon))
+					longitude = lon.ValueKind == JsonValueKind.Null ? null : lon.GetDouble();
+				if (root.TryGetProperty("Accuracy_m", out var acc))
+					accuracy = acc.ValueKind == JsonValueKind.Null ? null : acc.GetDouble();
 
-				_state = new ServerState(time, location, canStart);
+				_state = new ServerState(time, location, canStart, latitude, longitude, accuracy);
 			}
 
 			return OkJson("{\"ok\":true}");
@@ -194,6 +216,9 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			Location_m = locationForJson,
 			Time_ms = state.Time_ms,
 			CanStart = state.CanStart,
+			Latitude_deg = state.Latitude_deg,
+			Longitude_deg = state.Longitude_deg,
+			Accuracy_m = state.Accuracy_m,
 		});
 		await BroadcastTextAsync(json);
 		return OkJson("{\"ok\":true}");
@@ -282,7 +307,7 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 
 	private HttpResponse Reset()
 	{
-		_state = new ServerState(0, double.NaN, false);
+		_state = new ServerState(0, double.NaN, false, null, null, null);
 		while (_httpQueryLog.TryDequeue(out _)) { }
 		while (_receivedRequests.TryDequeue(out _)) { }
 		lock (_infoLock)

--- a/TRViS/Services/LocationServiceGpsAdapter.cs
+++ b/TRViS/Services/LocationServiceGpsAdapter.cs
@@ -29,6 +29,13 @@ internal class LocationServiceGpsAdapter : IDisposable
 	{
 		if (e.NewValue)
 		{
+			// NetworkSyncService が現在の location source の場合は端末 GPS を起動しない。
+			// 位置情報はサーバーから配信されるため、端末 GPS は電力の無駄になる。
+			if (_locationService.CurrentService is not LonLatLocationService)
+			{
+				logger.Info("LocationService.IsEnabled changed to true but CurrentService is not LonLatLocationService -> skip GPS listening");
+				return;
+			}
 			logger.Info("LocationService.IsEnabled changed to true -> StartGpsListening");
 			_ = StartGpsListeningAsync();
 		}


### PR DESCRIPTION
## 概要

ログを見ると WebSocket 経由で SyncedData を受信しているのに端末 GPS も同時に動作していた問題と、WebSocket 経由で緯度経度を受信できるようにする要望に対応します。

## 1. WebSocket 使用中は GPS を起動しない

[LocationService.cs](TRViS.LocationService/LocationService.cs) で WebSocket の `CanStart=true` を受信すると自動で `IsEnabled = true` が走り、`LocationServiceGpsAdapter` が GPS 取得を開始 → `SetGpsLocation` がデータを破棄 という無駄なループがあったため、GPS adapter にガードを追加。

`LocationServiceGpsAdapter.OnLocationServiceIsEnabledChanged` で `CurrentService is not LonLatLocationService` のときは GPS 起動をスキップします。サービス切替時はもともと `IsEnabled = false` を経由するので、起動側にガードを置くだけで十分。

## 2. WebSocket 経由で緯度経度を受信

`SyncedData` メッセージに `Latitude_deg` / `Longitude_deg` / `Accuracy_m`(任意) を追加。`NetworkSyncServiceBase` に新規 `LonLatLocationReceived` イベントを追加し、`LocationService` がこれを既存の `OnGpsLocationUpdated` に転送するため、Map / UI 表示などの既存購読者は無修正で動作します。

## 3. `Location_m` が NaN のときは lat/lon で駅判定

`Location_m` が NaN かつ lat/lon ありのときは、`LonLatLocationService` と同じ平均距離ベースの駅判定アルゴリズムを使うフォールバックを追加。

依存関係の壁 (`TRViS.LocationService → TRViS.NetworkSyncService`) を回避するため:

- `LocationCalcUtils` (`CalculateDistance` / `IsNearBy` / `IsLeaved`) を `TRViS.NetworkSyncService.Internals` に移動 → `LonLatLocationService` は using を更新するだけ
- 新規 `LonLatStationDetector` (stateful) を `TRViS.NetworkSyncService.Internals` に追加 → `NetworkSyncServiceBase` がこれを使ってフォールバック判定
- `InternalsVisibleTo` を `TRViS.NetworkSyncService` に追加して必要なテスト/上位プロジェクトから internal を見えるように

### 想定する運用

「サーバーが `Location_m` モードか lat/lon モードのどちらかにコミットする」前提で設計しています。`Location_m` が来るたびに lat/lon 履歴を Reset するため、両モードを毎メッセージ単位で混在させると毎回初回測位扱いになり、3点平均距離は機能しません。

## テスト計画

- [x] LocationService.Tests: 24 passed (新規 LonLatStationDetectorTests 5本 + LonLat 転送 2本含む)
- [x] NetworkSyncService.IntegrationTests: 68 passed (新規 LonLat WebSocket E2E 3本含む)
- [x] DTAC.Logic.Tests: 180 passed (回帰なし)
- [x] 主アプリ (maccatalyst) ビルド成功
- [ ] 実機 / 実サーバーで GPS が起動しないことを ログで確認
- [ ] 実機 / 実サーバーで `Location_m=NaN` + lat/lon 配信時に駅判定が動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)