### PR TITLE
[#240] AppBarのWorkName/時刻が更新されない不具合を修正

### DIFF
--- a/TRViS.UITests/AutomationIds.cs
+++ b/TRViS.UITests/AutomationIds.cs
@@ -165,6 +165,18 @@ public static class AutomationIds
 		// shell navigation triggers ViewHost.OnDisappearing which also unlocks
 		// the orientation.
 		public const string TestNavigateHomeButton = "DTAC.TestNavigateHomeButton";
+
+		// UI_TEST-only state mirrors. The real AppBar TitleLabel / TimeLabel
+		// don't reliably surface on iOS (iOS only exposes a Label in the
+		// accessibility tree when its text is non-empty, and TimeLabel
+		// additionally hides on narrow phones via a width threshold). These
+		// invisible mirror labels are kept always non-empty by sentinel
+		// prefixes (TestSeamTitlePrefix / TestSeamTimePrefix) so they are
+		// always findable. Tests strip the prefix before asserting.
+		public const string TestTitleSeam = "DTAC.TestTitleSeam";
+		public const string TestTimeSeam = "DTAC.TestTimeSeam";
+		public const string TestSeamTitlePrefix = "T:";
+		public const string TestSeamTimePrefix = "C:";
 	}
 
 	/// <summary>

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -19,6 +19,34 @@ public class DTACViewHostPageObject : PageObject
 	public AppiumElement MenuButton => WaitForElement(AutomationIds.DTAC.MenuButton);
 	public AppiumElement TimeLabel => FindByAutomationId(AutomationIds.DTAC.TimeLabel);
 	public AppiumElement TitleLabel => FindByAutomationId(AutomationIds.DTAC.TitleLabel);
+
+	// UI_TEST seams mirroring AppBar Title / TimeLabelText. Always non-empty
+	// (sentinel-prefixed) so they appear in iOS's accessibility tree even
+	// before the first state update, and not affected by TimeLabel's
+	// narrow-screen visibility threshold. Reads return the *stripped* value.
+	public AppiumElement TestTitleSeam => WaitForElement(AutomationIds.DTAC.TestTitleSeam);
+	public AppiumElement TestTimeSeam => WaitForElement(AutomationIds.DTAC.TestTimeSeam);
+
+	/// <summary>
+	/// Current AppBar title as seen by the presenter. Reads the UI_TEST-only
+	/// TestTitleSeam Label and strips its sentinel prefix. Returns "" when
+	/// the presenter has set TitleText to empty (no Work selected).
+	/// </summary>
+	public string ReadTitleViaSeam() => StripSeamPrefix(
+		TestTitleSeam.Text ?? string.Empty,
+		AutomationIds.DTAC.TestSeamTitlePrefix);
+
+	/// <summary>
+	/// Current AppBar clock text as seen by the presenter. Reads the
+	/// UI_TEST-only TestTimeSeam Label and strips its sentinel prefix.
+	/// Updates once per second when the presenter is alive.
+	/// </summary>
+	public string ReadTimeViaSeam() => StripSeamPrefix(
+		TestTimeSeam.Text ?? string.Empty,
+		AutomationIds.DTAC.TestSeamTimePrefix);
+
+	private static string StripSeamPrefix(string raw, string prefix)
+		=> raw.StartsWith(prefix) ? raw.Substring(prefix.Length) : raw;
 	public AppiumElement TabHako => FindCustomControl(AutomationIds.DTAC.TabHako, "ハ　コ");
 	public AppiumElement TabTimetable => FindCustomControl(AutomationIds.DTAC.TabTimetable, "時刻表");
 	public AppiumElement TabWorkAffix => FindCustomControl(AutomationIds.DTAC.TabWorkAffix, "行路添付");

--- a/TRViS.UITests/Tests/NavigationTests.cs
+++ b/TRViS.UITests/Tests/NavigationTests.cs
@@ -67,4 +67,84 @@ public class NavigationTests : BaseUITest
 		Assert.That(page.IsDisplayed(), Is.True,
 			"DTACViewHost page should be displayed after navigation.");
 	}
+
+	/// <summary>
+	/// Regression for #240: ViewHost is a cached ShellContent (DataTemplate),
+	/// so the same instance is reused on every flyout navigation. Earlier code
+	/// disposed the presenter on Unloaded, permanently severing its
+	/// LocationService.TimeChanged subscription — the second visit then showed
+	/// a frozen clock. Asserts the clock actually changes on the second visit.
+	///
+	/// Reads the time via DTAC.TestTimeSeam (a UI_TEST-only Label that mirrors
+	/// the presenter's TimeLabelText with a sentinel prefix). Cannot use the
+	/// real DTAC.TimeLabel: iOS doesn't surface MAUI Labels in the
+	/// accessibility tree when their text is empty, and the AppBar's TimeLabel
+	/// is hidden on narrow phones in portrait by an internal width threshold.
+	/// </summary>
+	[Test]
+	public void DTAC_ReopenAfterNavigateAway_ClockKeepsTicking()
+	{
+		var dtac = _shell.NavigateToDTAC();
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC should be visible on the first visit.");
+
+		_shell.NavigateToHome();
+
+		dtac = _shell.NavigateToDTAC();
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC should be visible on the second visit.");
+
+		// LocationService raises TimeChanged once per second (Task.Delay(100)
+		// polling that fires only when GetCurrentTimeSeconds() advances).
+		// Sleep > 1 s between reads so a live clock must have ticked at least
+		// once even if the first read landed right after a tick.
+		string firstReading = dtac.ReadTimeViaSeam();
+		Thread.Sleep(1500);
+		string secondReading = dtac.ReadTimeViaSeam();
+
+		Assert.That(secondReading, Is.Not.EqualTo(firstReading),
+			$"Clock must keep updating on the second DTAC visit (#240). " +
+			$"First='{firstReading}', Second='{secondReading}'.");
+	}
+
+	/// <summary>
+	/// Regression for #240 (title half): the same disposed-presenter chain
+	/// also unhooked AppViewModel.PropertyChanged, so a SelectedWork change
+	/// that happened *while DTAC was hidden* never updated the AppBar title.
+	/// Repro: open DTAC empty (no Work) → home → load sample + commit Work →
+	/// DTAC. With the bug, AppBar Title stays empty on the second visit.
+	///
+	/// Reads via DTAC.TestTitleSeam (UI_TEST-only mirror Label) for the same
+	/// iOS-accessibility reason as the clock test above.
+	/// </summary>
+	[Test]
+	public void DTAC_ReopenAfterWorkSelected_TitleUpdated()
+	{
+		// First DTAC visit with no Work selected — primes the broken
+		// codepath by triggering Unloaded → Dispose on the way back.
+		var dtac = _shell.NavigateToDTAC();
+		Assert.That(dtac.IsDisplayed(), Is.True);
+
+		var startHome = _shell.NavigateToHome();
+		// Demo data load + auto-open commits SelectedWork AND navigates to
+		// DTAC in one shot. Both side-effects happen *after* the dead
+		// presenter from the first visit would have missed them.
+		startHome.LoadSample();
+		startHome.WaitForElement(AutomationIds.StartHome.WorkGroupList);
+		dtac = startHome.AutoOpenForTesting();
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC should be visible after AutoOpenForTesting.");
+
+		// Title set goes through MainThread.BeginInvokeOnMainThread; give
+		// the dispatcher a beat to flush before reading.
+		Thread.Sleep(500);
+		string title = dtac.ReadTitleViaSeam();
+		Assert.That(title, Is.Not.Empty,
+			$"AppBar Title must reflect the committed Work on the second " +
+			$"DTAC visit (#240). Got='{title}'.");
+
+		// Restore Start mode for any subsequent test in this fixture's
+		// shared session. Mirrors DTACTimetableTests.SetUp's assumption.
+		_shell.NavigateToHome().ClearLoaderForTesting();
+	}
 }

--- a/TRViS.UITests/Tests/NavigationTests.cs
+++ b/TRViS.UITests/Tests/NavigationTests.cs
@@ -120,12 +120,29 @@ public class NavigationTests : BaseUITest
 	[Test]
 	public void DTAC_ReopenAfterWorkSelected_TitleUpdated()
 	{
+		// Clear any loader/SelectedWork left by a prior test in this
+		// fixture's shared Appium session — base SetUp only navigates to
+		// StartHome and accepts the privacy policy. Without this, a
+		// non-empty AppBar title carried over from an earlier test would
+		// let the later `Is.Not.EqualTo(initialTitle)` assertion pass
+		// trivially even with the bug present.
+		var startHome = new StartHomePageObject(Driver);
+		startHome.ClearLoaderForTesting();
+
 		// First DTAC visit with no Work selected — primes the broken
 		// codepath by triggering Unloaded → Dispose on the way back.
 		var dtac = _shell.NavigateToDTAC();
 		Assert.That(dtac.IsDisplayed(), Is.True);
 
-		var startHome = _shell.NavigateToHome();
+		// Capture the post-clear title baseline. With no SelectedWork the
+		// presenter sets TitleText to "", so the seam reads its sentinel
+		// prefix only (stripped to "" by the page object). Asserting the
+		// later title differs from this baseline catches the bug even on
+		// platforms where an empty TitleText still surfaces non-empty
+		// fallback text in the seam.
+		string initialTitle = dtac.ReadTitleViaSeam();
+
+		startHome = _shell.NavigateToHome();
 		// Demo data load + auto-open commits SelectedWork AND navigates to
 		// DTAC in one shot. Both side-effects happen *after* the dead
 		// presenter from the first visit would have missed them.
@@ -142,6 +159,9 @@ public class NavigationTests : BaseUITest
 		Assert.That(title, Is.Not.Empty,
 			$"AppBar Title must reflect the committed Work on the second " +
 			$"DTAC visit (#240). Got='{title}'.");
+		Assert.That(title, Is.Not.EqualTo(initialTitle),
+			$"AppBar Title must change after a Work is selected (#240). " +
+			$"Initial='{initialTitle}', After='{title}'.");
 
 		// Restore Start mode for any subsequent test in this fixture's
 		// shared session. Mirrors DTACTimetableTests.SetUp's assumption.

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -35,7 +35,12 @@ public partial class ViewHost : ContentPage
 		_dtacViewModel = dtacViewModel;
 
 		_presenter.StateChanged += OnPresenterStateChanged;
-		Unloaded += (_, _) => _presenter.Dispose();
+		// ViewHost is a cached ShellContent (DataTemplate) — the same instance is
+		// reused on every navigation. Disposing the presenter on Unloaded would
+		// permanently sever its event subscriptions, so the second visit would
+		// freeze the clock and stop updating the title (#240).
+		// HorizontalTimetablePage uses the same factory but is RegisterRoute'd
+		// (a fresh page per navigation), so its Unloaded+Dispose remains correct.
 
 		Shell.SetNavBarIsVisible(this, false);
 
@@ -76,6 +81,8 @@ public partial class ViewHost : ContentPage
 
 #if UI_TEST
 		AddTestNavigateHomeSeam();
+		AddTestStateSeams();
+		ApplyTestStateSeams(_presenter.CurrentState);
 #endif
 
 		logger.Trace("Created");
@@ -119,6 +126,78 @@ public partial class ViewHost : ContentPage
 	// Mirrors AutomationIds.DTAC.TestNavigateHomeButton in the test project
 	// (which is the consumer). Inlined here to avoid a project reference.
 	private const string AutomationIdValueForTestNavigateHome = "DTAC.TestNavigateHomeButton";
+
+	// UI_TEST-only state seams. The AppBar's TitleLabel / TimeLabel are MAUI
+	// Labels; iOS only surfaces a Label in the accessibility tree when its
+	// text is non-empty, and TimeLabel additionally hides itself on narrow
+	// screens (width threshold in AppBar). Both make assertions over the
+	// presenter's state flaky on iPhone-portrait. These seam labels mirror
+	// state.TitleText and state.TimeLabelText with a sentinel prefix so they
+	// are always non-empty (always findable), and are kept invisible to the
+	// user via transparent text + zero size + InputTransparent. Tests strip
+	// the sentinel before asserting.
+	private const string AutomationIdValueForTestTitleSeam = "DTAC.TestTitleSeam";
+	private const string AutomationIdValueForTestTimeSeam = "DTAC.TestTimeSeam";
+	private const string TestTitleSeamPrefix = "T:";
+	private const string TestTimeSeamPrefix = "C:";
+	private Label _testTitleSeamLabel = null!;
+	private Label _testTimeSeamLabel = null!;
+
+	private void AddTestStateSeams()
+	{
+		// Stack above the existing TestNavigateHomeButton in the bottom-LEFT
+		// corner. The bottom-left of row 2 is already established as the
+		// reserved test-seam region (see AddTestNavigateHomeSeam) so production
+		// controls (NextTrainButton at bottom-right of the timetable, the AppBar
+		// AppIcon/Theme/Time stack on the right) are guaranteed not to compete
+		// with these labels. TestNavigateHomeButton sits at margin 0; offset
+		// these by 28/56 px so the three seams form a non-overlapping vertical
+		// strip up the left edge.
+		_testTimeSeamLabel = BuildSeamLabel(
+			AutomationIdValueForTestTimeSeam,
+			TestTimeSeamPrefix,
+			bottomMarginPx: 28);
+		_testTitleSeamLabel = BuildSeamLabel(
+			AutomationIdValueForTestTitleSeam,
+			TestTitleSeamPrefix,
+			bottomMarginPx: 56);
+		Grid.SetRow(_testTimeSeamLabel, 2);
+		Grid.SetRow(_testTitleSeamLabel, 2);
+		MainGrid.Children.Add(_testTimeSeamLabel);
+		MainGrid.Children.Add(_testTitleSeamLabel);
+	}
+
+	private static Label BuildSeamLabel(string automationId, string initialText, double bottomMarginPx)
+	{
+		// iOS XCUITest sets accessible="true" only when isAccessibilityElement
+		// is YES, which UILabel computes from frame size + text presence + alpha.
+		// 1×1 with transparent text falls below the threshold and the element is
+		// returned as accessible="false" (FindElement skips it). Match the
+		// existing TestNavigateHomeButton 24×24 footprint with a non-zero
+		// FontSize so the text drives a11y presence; TextColor=Transparent +
+		// InputTransparent keep it invisible and click-through.
+		return new Label
+		{
+			AutomationId = automationId,
+			Text = initialText,
+			TextColor = Colors.Transparent,
+			BackgroundColor = Colors.Transparent,
+			InputTransparent = true,
+			FontSize = 8,
+			HorizontalOptions = LayoutOptions.Start,
+			VerticalOptions = LayoutOptions.End,
+			WidthRequest = 24,
+			HeightRequest = 24,
+			Margin = new Thickness(0, 0, 0, bottomMarginPx),
+			Padding = 0,
+		};
+	}
+
+	private void ApplyTestStateSeams(ViewHostPageState state)
+	{
+		_testTitleSeamLabel.Text = TestTitleSeamPrefix + (state.TitleText ?? string.Empty);
+		_testTimeSeamLabel.Text = TestTimeSeamPrefix + (state.TimeLabelText ?? string.Empty);
+	}
 #endif
 
 	private void AppShell_SafeAreaMarginChanged(object? sender, Thickness oldValue, Thickness newValue)
@@ -190,6 +269,10 @@ public partial class ViewHost : ContentPage
 	private void ApplyPresenterState(ViewHostStateSection changed)
 	{
 		var state = _presenter.CurrentState;
+
+#if UI_TEST
+		ApplyTestStateSeams(state);
+#endif
 
 		if ((changed & ViewHostStateSection.TitleText) != 0)
 		{


### PR DESCRIPTION
This pull request introduces robust UI test "seams" to reliably surface AppBar title and clock state in automated tests, addressing issues where iOS test automation could not access invisible or empty labels. It also fixes regressions where the clock and title would stop updating after navigating away and back to the DTAC view, by ensuring the presenter is not disposed on navigation. Two new regression tests are added to guarantee these behaviors.

**UI Test Seams for AppBar State:**

* Added always-present, UI_TEST-only invisible labels (`TestTitleSeam`, `TestTimeSeam`) to mirror the AppBar's Title and Clock text, each prefixed with a sentinel so they're always non-empty and reliably accessible in iOS test automation. Tests read these seams and strip the prefix before asserting. (`TRViS/DTAC/ViewHost.xaml.cs`, `TRViS.UITests/AutomationIds.cs`, `TRViS.UITests/Pages/DTACViewHostPageObject.cs`) [[1]](diffhunk://#diff-46fce376e4d10b4cfb286a8079904ba947305b54b080ac76693e384282757cd2R129-R200) [[2]](diffhunk://#diff-e62429bd9f607cddcb7507d1395af45933f25fdeee59f6077ed0b427d594a8c8R168-R179) [[3]](diffhunk://#diff-62c20ce629f4d06daf6c2caef5ce00f9b52a0357fe4d619ed01ac2da78d28f12R22-R49)

* The seams are updated on every presenter state change, ensuring tests always see the current state. (`TRViS/DTAC/ViewHost.xaml.cs`)

**Navigation & State Management Fixes:**

* Stopped disposing the presenter on `Unloaded` in `ViewHost`, since the view is cached and reused by the Shell; this prevents event subscriptions from being severed and fixes issues where the clock or title would stop updating after returning to the view. (`TRViS/DTAC/ViewHost.xaml.cs`)

**Automated Regression Tests:**

* Added two regression tests:
  - One verifies that the clock continues to update after navigating away and back to DTAC, using the new seam label for assertions. (`TRViS.UITests/Tests/NavigationTests.cs`)
  - The other ensures the AppBar title updates correctly after a work selection change while DTAC is hidden, again using the seam label for reliable assertions. (`TRViS.UITests/Tests/NavigationTests.cs`)

**UI Test Page Object Enhancements:**

* The DTAC view host page object now exposes methods to read the seam values (with prefix stripping) for use in tests. (`TRViS.UITests/Pages/DTACViewHostPageObject.cs`)