### PR TITLE
fix(network-sync, DTAC): preserve operation/marker state across WS updates and view re-entries

### DIFF
--- a/TRViS.DTAC.Logic.Tests/LocationMarkerRowCoordinatorTests.cs
+++ b/TRViS.DTAC.Logic.Tests/LocationMarkerRowCoordinatorTests.cs
@@ -1,0 +1,169 @@
+using TRViS.DTAC.Logic;
+
+namespace TRViS.DTAC.Logic.Tests;
+
+public class LocationMarkerRowCoordinatorTests
+{
+	private sealed class StubRow : ILocationMarkerHighlightTarget
+	{
+		public bool IsLocationMarkerOnThisRow { get; set; }
+	}
+
+	private static StubRow[] MakeRows(int count)
+	{
+		var rows = new StubRow[count];
+		for (int i = 0; i < count; i++)
+			rows[i] = new StubRow();
+		return rows;
+	}
+
+	[Fact]
+	public void SetRows_AfterMarkerConfigured_HighlightsMatchingRow()
+	{
+		var c = new LocationMarkerRowCoordinator
+		{
+			MarkerRowIndex = 2,
+			IsMarkerVisible = true,
+		};
+		var rows = MakeRows(4);
+
+		c.SetRows(rows);
+
+		Assert.False(rows[0].IsLocationMarkerOnThisRow);
+		Assert.False(rows[1].IsLocationMarkerOnThisRow);
+		Assert.True(rows[2].IsLocationMarkerOnThisRow);
+		Assert.False(rows[3].IsLocationMarkerOnThisRow);
+	}
+
+	[Fact]
+	public void SetRows_MarkerInvisible_NoRowHighlighted()
+	{
+		var c = new LocationMarkerRowCoordinator
+		{
+			MarkerRowIndex = 2,
+			IsMarkerVisible = false,
+		};
+		var rows = MakeRows(4);
+
+		c.SetRows(rows);
+
+		Assert.All(rows, r => Assert.False(r.IsLocationMarkerOnThisRow));
+	}
+
+	[Fact]
+	public void MarkerRowIndexChange_RedistributesToExistingRows()
+	{
+		var c = new LocationMarkerRowCoordinator { IsMarkerVisible = true };
+		var rows = MakeRows(4);
+		c.SetRows(rows);
+		c.MarkerRowIndex = 1;
+		Assert.True(rows[1].IsLocationMarkerOnThisRow);
+
+		c.MarkerRowIndex = 3;
+
+		Assert.False(rows[1].IsLocationMarkerOnThisRow);
+		Assert.True(rows[3].IsLocationMarkerOnThisRow);
+	}
+
+	[Fact]
+	public void IsMarkerVisibleChange_RedistributesToExistingRows()
+	{
+		var c = new LocationMarkerRowCoordinator { MarkerRowIndex = 2 };
+		var rows = MakeRows(4);
+		c.SetRows(rows);
+		Assert.False(rows[2].IsLocationMarkerOnThisRow);
+
+		c.IsMarkerVisible = true;
+		Assert.True(rows[2].IsLocationMarkerOnThisRow);
+
+		c.IsMarkerVisible = false;
+		Assert.False(rows[2].IsLocationMarkerOnThisRow);
+	}
+
+	[Fact]
+	public void SetRows_ReplacingRowsWhileMarkerStaysAtSameIndex_HighlightsNewRow()
+	{
+		// 不具合再現: 横型時刻表ページから戻ったとき等、行モデルが差し替わっても
+		// マーカー行 index が同じだと、新しい行に対して IsLocationMarkerOnThisRow=true を
+		// 設定する経路が抜けて DriveTime ラベルが黒文字のまま残るケース。
+		// 旧 View 実装は StateChanged を受けて for-loop で RowViewList に適用していたが、
+		// SetRowViewsAsync が async で後から rows を入れ替えるため race していた。
+		// Coordinator 経由なら SetRows のタイミングで必ず再適用される。
+		var c = new LocationMarkerRowCoordinator
+		{
+			MarkerRowIndex = 1,
+			IsMarkerVisible = true,
+		};
+		var oldRows = MakeRows(3);
+		c.SetRows(oldRows);
+		Assert.True(oldRows[1].IsLocationMarkerOnThisRow);
+
+		// 「行モデル差し替え」のシミュレーション: 別インスタンスの行配列を渡す。
+		// このとき新しい行は初期値 false で来る (現実の SetTrainData も同様)。
+		var newRows = MakeRows(3);
+		Assert.False(newRows[1].IsLocationMarkerOnThisRow); // 前提: 新行は黒文字状態
+
+		c.SetRows(newRows);
+
+		Assert.False(newRows[0].IsLocationMarkerOnThisRow);
+		Assert.True(newRows[1].IsLocationMarkerOnThisRow);  // ← 修正後はここが白文字に
+		Assert.False(newRows[2].IsLocationMarkerOnThisRow);
+	}
+
+	[Fact]
+	public void SetRows_NullClearsRows_NoCrashOnSubsequentMarkerChange()
+	{
+		var c = new LocationMarkerRowCoordinator { IsMarkerVisible = true };
+		c.SetRows(MakeRows(3));
+		c.SetRows(null);
+
+		// 列無しの状態でマーカーが動いても何も起こらない (NRE しない)
+		c.MarkerRowIndex = 1;
+		c.IsMarkerVisible = false;
+	}
+
+	[Fact]
+	public void SetRows_MarkerIndexOutOfRange_NoCrashAndNoRowHighlighted()
+	{
+		var c = new LocationMarkerRowCoordinator
+		{
+			MarkerRowIndex = 99, // out of range
+			IsMarkerVisible = true,
+		};
+		var rows = MakeRows(3);
+
+		c.SetRows(rows);
+
+		Assert.All(rows, r => Assert.False(r.IsLocationMarkerOnThisRow));
+	}
+
+	/// <summary>
+	/// 旧 View 実装相当 (= 「StateChanged を受信したタイミングで一度だけ for-loop で適用、
+	/// 行差し替えは後から非同期で行われる」) を再現すると、新しい行に対してマーカー highlight が
+	/// 抜け落ちることを示すデモテスト。Coordinator のテストと対比させ、なぜ Coordinator が必要かを
+	/// コードで明示する。
+	/// </summary>
+	[Fact]
+	public void DemonstrateBug_LegacyApplyOnceThenReplaceRows_NewRowsNotHighlighted()
+	{
+		// 旧 View の挙動: state が変わるたびに一度だけ rows.ForEach(...) で flag を立てるが、
+		// その後で行が差し替わる場合、新行に対しては適用されない (再適用パスがない)。
+		static void LegacyApplyOnce(IReadOnlyList<ILocationMarkerHighlightTarget> rows, int markerRowIndex, bool isMarkerVisible)
+		{
+			int effective = isMarkerVisible ? markerRowIndex : -1;
+			for (int i = 0; i < rows.Count; i++)
+				rows[i].IsLocationMarkerOnThisRow = (i == effective);
+		}
+
+		// 旧 view 実装シミュレーション
+		var oldRows = MakeRows(3);
+		LegacyApplyOnce(oldRows, markerRowIndex: 1, isMarkerVisible: true);
+		Assert.True(oldRows[1].IsLocationMarkerOnThisRow);
+
+		// SetRowViewsAsync が後から rows を差し替えるシミュレーション。
+		// 旧実装ではこの後、もう一度 LegacyApplyOnce が呼ばれる保証がない (state が変わっていないため)。
+		var newRows = MakeRows(3);
+		// ↓ ここが不具合: マーカー index は同じだが、新行は黒文字のまま。
+		Assert.False(newRows[1].IsLocationMarkerOnThisRow);
+	}
+}

--- a/TRViS.DTAC.Logic.Tests/TimetableRebuildPolicyTests.cs
+++ b/TRViS.DTAC.Logic.Tests/TimetableRebuildPolicyTests.cs
@@ -5,67 +5,55 @@ namespace TRViS.DTAC.Logic.Tests;
 public class TimetableRebuildPolicyTests
 {
 	[Fact]
-	public void CanUpdateInPlace_SameIdAndSameRowCount_True()
+	public void IsSameTrainEdit_SameId_True()
 	{
 		// 通常の WS リアルタイム編集ケース: 同じ列車の field 編集が来た。
-		Assert.True(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: "t-1", currentRowCount: 18,
-			newTrainId: "t-1", newRowCount: 18));
+		Assert.True(TimetableRebuildPolicy.IsSameTrainEdit(
+			currentTrainId: "t-1",
+			newTrainId: "t-1"));
 	}
 
 	[Fact]
-	public void CanUpdateInPlace_DifferentTrainId_False()
+	public void IsSameTrainEdit_DifferentTrainId_False()
 	{
 		// 列車切替: 全面再構築すべき。
-		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: "t-1", currentRowCount: 18,
-			newTrainId: "t-2", newRowCount: 18));
+		Assert.False(TimetableRebuildPolicy.IsSameTrainEdit(
+			currentTrainId: "t-1",
+			newTrainId: "t-2"));
 	}
 
 	[Fact]
-	public void CanUpdateInPlace_SameIdDifferentRowCount_False()
+	public void IsSameTrainEdit_CurrentIdNull_False()
 	{
-		// 同じ列車だが行が増減した: 構造変化なので全面再構築。
-		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: "t-1", currentRowCount: 18,
-			newTrainId: "t-1", newRowCount: 19));
-		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: "t-1", currentRowCount: 18,
-			newTrainId: "t-1", newRowCount: 17));
+		// 初回ロード: 既存 row 列が無いので mutate 不可、全面構築扱い。
+		Assert.False(TimetableRebuildPolicy.IsSameTrainEdit(
+			currentTrainId: null,
+			newTrainId: "t-1"));
 	}
 
 	[Fact]
-	public void CanUpdateInPlace_CurrentIdNull_False()
+	public void IsSameTrainEdit_NewIdNull_False()
 	{
-		// 初回ロード: 既存 row 列が無いので in-place 不可。
-		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: null, currentRowCount: 0,
-			newTrainId: "t-1", newRowCount: 18));
+		// 列車選択解除 (TrainData=null) ケース: 全面クリア相当。
+		Assert.False(TimetableRebuildPolicy.IsSameTrainEdit(
+			currentTrainId: "t-1",
+			newTrainId: null));
 	}
 
 	[Fact]
-	public void CanUpdateInPlace_NewIdNull_False()
+	public void IsSameTrainEdit_BothIdsNull_False()
 	{
-		// 列車選択解除 (TrainData=null) ケース: 全面クリア相当なので in-place しない。
-		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: "t-1", currentRowCount: 18,
-			newTrainId: null, newRowCount: 0));
+		Assert.False(TimetableRebuildPolicy.IsSameTrainEdit(
+			currentTrainId: null,
+			newTrainId: null));
 	}
 
 	[Fact]
-	public void CanUpdateInPlace_BothIdsNull_False()
+	public void IsSameTrainEdit_SameId_RowCountIsNotConsidered()
 	{
-		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: null, currentRowCount: 0,
-			newTrainId: null, newRowCount: 0));
-	}
-
-	[Fact]
-	public void CanUpdateInPlace_SameIdZeroRows_True()
-	{
-		// 同じ Id で両方 0 行というレアケースでも安定して in-place 扱い (= no-op).
-		Assert.True(TimetableRebuildPolicy.CanUpdateInPlace(
-			currentTrainId: "t-1", currentRowCount: 0,
-			newTrainId: "t-1", newRowCount: 0));
+		// 同じ列車に対する更新であれば、行数が違っていても (= 駅追加/削除でも)
+		// soft path 対象とする。呼び出し側は overlap 部分を field 更新し、
+		// 余りを Add / 不足を Remove することで mutate ベースで対応する。
+		Assert.True(TimetableRebuildPolicy.IsSameTrainEdit("t-1", "t-1"));
 	}
 }

--- a/TRViS.DTAC.Logic.Tests/TimetableRebuildPolicyTests.cs
+++ b/TRViS.DTAC.Logic.Tests/TimetableRebuildPolicyTests.cs
@@ -1,0 +1,71 @@
+using TRViS.DTAC.Logic;
+
+namespace TRViS.DTAC.Logic.Tests;
+
+public class TimetableRebuildPolicyTests
+{
+	[Fact]
+	public void CanUpdateInPlace_SameIdAndSameRowCount_True()
+	{
+		// 通常の WS リアルタイム編集ケース: 同じ列車の field 編集が来た。
+		Assert.True(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: "t-1", currentRowCount: 18,
+			newTrainId: "t-1", newRowCount: 18));
+	}
+
+	[Fact]
+	public void CanUpdateInPlace_DifferentTrainId_False()
+	{
+		// 列車切替: 全面再構築すべき。
+		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: "t-1", currentRowCount: 18,
+			newTrainId: "t-2", newRowCount: 18));
+	}
+
+	[Fact]
+	public void CanUpdateInPlace_SameIdDifferentRowCount_False()
+	{
+		// 同じ列車だが行が増減した: 構造変化なので全面再構築。
+		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: "t-1", currentRowCount: 18,
+			newTrainId: "t-1", newRowCount: 19));
+		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: "t-1", currentRowCount: 18,
+			newTrainId: "t-1", newRowCount: 17));
+	}
+
+	[Fact]
+	public void CanUpdateInPlace_CurrentIdNull_False()
+	{
+		// 初回ロード: 既存 row 列が無いので in-place 不可。
+		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: null, currentRowCount: 0,
+			newTrainId: "t-1", newRowCount: 18));
+	}
+
+	[Fact]
+	public void CanUpdateInPlace_NewIdNull_False()
+	{
+		// 列車選択解除 (TrainData=null) ケース: 全面クリア相当なので in-place しない。
+		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: "t-1", currentRowCount: 18,
+			newTrainId: null, newRowCount: 0));
+	}
+
+	[Fact]
+	public void CanUpdateInPlace_BothIdsNull_False()
+	{
+		Assert.False(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: null, currentRowCount: 0,
+			newTrainId: null, newRowCount: 0));
+	}
+
+	[Fact]
+	public void CanUpdateInPlace_SameIdZeroRows_True()
+	{
+		// 同じ Id で両方 0 行というレアケースでも安定して in-place 扱い (= no-op).
+		Assert.True(TimetableRebuildPolicy.CanUpdateInPlace(
+			currentTrainId: "t-1", currentRowCount: 0,
+			newTrainId: "t-1", newRowCount: 0));
+	}
+}

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -290,19 +290,36 @@ public class VerticalStylePagePresenterTests
 	}
 
 	/// <summary>
-	/// 同じ Id でも行数が変わった (= 駅が追加/削除された) ら、構造変化なので「運行前」にリセットされる。
+	/// 同じ Id で行数が変わった (= 駅が追加/削除された) 場合でも、同じ列車の編集なので
+	/// 運行中状態は維持される。RowStates dict は新 row 数に揃えてリサイズされる。
 	/// </summary>
 	[Fact]
-	public void SelectedTrainDataChanged_SameIdDifferentRowCount_ResetsRunningState()
+	public void SelectedTrainDataChanged_SameIdDifferentRowCount_PreservesRunningStateAndResizesRowStates()
 	{
 		var (presenter, _, _, _, appVm) = CreatePresenter();
 		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
 		presenter.OnStartButtonClicked();
 		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
 
-		appVm.SelectedTrainData = CreateTrainData(rowCount: 4);
+		// 行数を 3 → 5 に増やす (駅 2 つ追加に相当)
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 5);
 
-		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+		Assert.Multiple(() =>
+		{
+			Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+				"同じ列車に対する更新なら、行数が増えても運行中フラグは維持される");
+			Assert.Equal(5, presenter.CurrentState.RowStates.Count);
+		});
+
+		// 今度は逆に 5 → 2 に減らす
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 2);
+
+		Assert.Multiple(() =>
+		{
+			Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+				"同じ列車の行削除でも運行中フラグは維持される");
+			Assert.Equal(2, presenter.CurrentState.RowStates.Count);
+		});
 	}
 
 	/// <summary>

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -145,7 +145,7 @@ public class VerticalStylePagePresenterTests
 		return (presenter, locationService, markerToggle, clock, appVm);
 	}
 
-	private static TrainData CreateTrainData(string destination = "Tokyo", int rowCount = 3, DateOnly? affectDate = null)
+	private static TrainData CreateTrainData(string destination = "Tokyo", int rowCount = 3, DateOnly? affectDate = null, string id = "train-001", int firstRowDriveTimeMM = 10)
 	{
 		var rows = new TimetableRow[rowCount];
 		for (int i = 0; i < rowCount; i++)
@@ -153,7 +153,7 @@ public class VerticalStylePagePresenterTests
 			rows[i] = new TimetableRow(
 				Id: $"row-{i}",
 				Location: new LocationInfo(i * 1000.0),
-				DriveTimeMM: 10,
+				DriveTimeMM: i == 0 ? firstRowDriveTimeMM : 10,
 				DriveTimeSS: 0,
 				StationName: $"Station {i}",
 				IsOperationOnlyStop: false,
@@ -170,7 +170,7 @@ public class VerticalStylePagePresenterTests
 		}
 
 		return new TrainData(
-			Id: "train-001",
+			Id: id,
 			Direction: 0,
 			WorkName: "Test Work",
 			TrainNumber: "101",
@@ -235,6 +235,95 @@ public class VerticalStylePagePresenterTests
 		Assert.Equal(trainData.Rows, locationService.LastSetRows);
 		Assert.Equal(1, markerToggle.ResetCount);
 		Assert.False(state.PageHeaderState.IsRunning);
+	}
+
+	/// <summary>
+	/// 不具合再現: 運行開始した状態で、同じ列車に対して 1 行だけ field 編集された
+	/// TrainData (= 別インスタンスだが Id と行数は同じ) が来た時、運行中状態 (IsRunning /
+	/// IsRunStarted) が維持されること。旧実装は SetSelectedTrainData が無条件に
+	/// false 代入していたため、WS 経由のリアルタイム編集ごとに「運行前」に戻されていた。
+	/// </summary>
+	[Fact]
+	public void SelectedTrainDataChanged_SameIdAndRowCount_PreservesRunningState()
+	{
+		var (presenter, _, markerToggle, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, firstRowDriveTimeMM: 5);
+
+		// 運行開始
+		presenter.OnStartButtonClicked();
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsRunStarted);
+		int markerResetsBeforeEdit = markerToggle.ResetCount;
+
+		// 同じ列車 (Id="train-001") に対するリアルタイム編集を模擬:
+		// 別インスタンス、行数は同じ、先頭行の DriveTimeMM だけ変える。
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, firstRowDriveTimeMM: 7);
+
+		Assert.Multiple(() =>
+		{
+			Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+				"運行中フラグは同一列車の field 編集で巻き戻されてはならない");
+			Assert.True(presenter.CurrentState.TimetableViewState.IsRunStarted,
+				"運行開始フラグも同様に維持される");
+			Assert.Equal(markerResetsBeforeEdit, markerToggle.ResetCount);
+		});
+	}
+
+	/// <summary>
+	/// 列車切替 (Id 変化) は従来通り「運行前」にリセットされる。
+	/// </summary>
+	[Fact]
+	public void SelectedTrainDataChanged_DifferentTrainId_ResetsRunningState()
+	{
+		var (presenter, _, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, id: "train-A");
+		presenter.OnStartButtonClicked();
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, id: "train-B");
+
+		Assert.Multiple(() =>
+		{
+			Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+			Assert.False(presenter.CurrentState.TimetableViewState.IsRunStarted);
+		});
+	}
+
+	/// <summary>
+	/// 同じ Id でも行数が変わった (= 駅が追加/削除された) ら、構造変化なので「運行前」にリセットされる。
+	/// </summary>
+	[Fact]
+	public void SelectedTrainDataChanged_SameIdDifferentRowCount_ResetsRunningState()
+	{
+		var (presenter, _, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+		presenter.OnStartButtonClicked();
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 4);
+
+		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+	}
+
+	/// <summary>
+	/// 同 Id + 同行数の soft 更新でも、表示用の field (Destination 等) は更新される。
+	/// 運行中状態維持と表示更新は両立させる。
+	/// </summary>
+	[Fact]
+	public void SelectedTrainDataChanged_SameIdAndRowCount_StillPropagatesFieldEdits()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(destination: "Tokyo", rowCount: 3);
+
+		var edited = CreateTrainData(destination: "Osaka", rowCount: 3);
+		appVm.SelectedTrainData = edited;
+
+		Assert.Multiple(() =>
+		{
+			Assert.Equal("Osaka", presenter.CurrentState.Destination.OriginalValue);
+			// SetTimetableRows は呼ばれている (StaLocationInfo の再計算に必要)
+			Assert.Equal(edited.Rows, locationService.LastSetRows);
+		});
 	}
 
 	#endregion

--- a/TRViS.DTAC.Logic/LocationMarkerRowCoordinator.cs
+++ b/TRViS.DTAC.Logic/LocationMarkerRowCoordinator.cs
@@ -1,0 +1,92 @@
+namespace TRViS.DTAC.Logic;
+
+/// <summary>
+/// 「現在位置マーカー (CurrentLocationMarker) と重なっている行は DriveTime ラベルを白文字にする」
+/// の状態を保持する対象 (= タイムテーブル行モデル)。
+/// </summary>
+public interface ILocationMarkerHighlightTarget
+{
+	/// <summary>
+	/// 現在位置マーカーがこの行に被っているかどうか。
+	/// true のときに DriveTime ラベルを白文字 (反転色) で描く。
+	/// </summary>
+	bool IsLocationMarkerOnThisRow { get; set; }
+}
+
+/// <summary>
+/// マーカー位置と「現在 View に並んでいる行モデル列」の対応関係を一元管理するヘルパー。
+/// 行モデル列が差し替わっても、保持しているマーカー位置に従って新しい行に対しても
+/// <see cref="ILocationMarkerHighlightTarget.IsLocationMarkerOnThisRow"/> を再適用する。
+///
+/// 旧実装は View 側で「StateChanged を受信したタイミングで RowViewList の各 Model に対して
+/// for-loop で適用」していたが、ObservableCollection を差し替えた直後は RowViewList が
+/// まだ古い行のままで、新しい行は async で後から追加されるため、新行に対する適用が
+/// 漏れて DriveTime ラベルが黒文字のままになる不具合 (issue: HorizontalTimetable 往復後等) があった。
+/// ここに集約することで「行を差し替えたら必ず再適用する」「マーカー位置が変わったら必ず再適用する」を
+/// View 側の async タイミングに依存せず保証する。
+/// </summary>
+public sealed class LocationMarkerRowCoordinator
+{
+	private int _markerRowIndex = -1;
+	private bool _isMarkerVisible = false;
+	private IReadOnlyList<ILocationMarkerHighlightTarget>? _rows;
+
+	/// <summary>
+	/// 現在のマーカー対象行 (0-based)。<see cref="IsMarkerVisible"/> が false のときは無視される。
+	/// 変更すると保持中の行に即時反映する。
+	/// </summary>
+	public int MarkerRowIndex
+	{
+		get => _markerRowIndex;
+		set
+		{
+			if (_markerRowIndex == value)
+				return;
+			_markerRowIndex = value;
+			ApplyToRows();
+		}
+	}
+
+	/// <summary>
+	/// マーカー (CurrentLocationMarker) を画面に出しているか。
+	/// false のときはどの行も highlight しない。
+	/// </summary>
+	public bool IsMarkerVisible
+	{
+		get => _isMarkerVisible;
+		set
+		{
+			if (_isMarkerVisible == value)
+				return;
+			_isMarkerVisible = value;
+			ApplyToRows();
+		}
+	}
+
+	/// <summary>
+	/// 行モデル列を差し替える。直後に現在のマーカー状態を各行に適用する。
+	/// 既存と同じ参照を渡されたときも、リスト内オブジェクトの状態が外部要因で
+	/// リセットされている可能性があるので再適用する。
+	/// </summary>
+	public void SetRows(IReadOnlyList<ILocationMarkerHighlightTarget>? rows)
+	{
+		_rows = rows;
+		ApplyToRows();
+	}
+
+	private void ApplyToRows()
+	{
+		if (_rows is null)
+			return;
+
+		int effectiveRow = _isMarkerVisible ? _markerRowIndex : -1;
+		for (int i = 0; i < _rows.Count; i++)
+		{
+			bool shouldHighlight = i == effectiveRow;
+			// 一致しても代入する: 新しく作られた行で flag が false のままになっているケースを
+			// 拾うため (`==` チェックでスキップすると新行が highlight されない)。
+			// 既存 ObservableObject 実装は同値代入を内部で no-op 化するので副作用はない。
+			_rows[i].IsLocationMarkerOnThisRow = shouldHighlight;
+		}
+	}
+}

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -117,8 +117,35 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 			return;
 		}
 
+		// 同じ列車 (Id 一致 + 行数一致) なら soft 更新パスへ。WS リアルタイム編集 (TRViS_Realtime_Editor)
+		// が同一 TrainId に対して都度新インスタンスを発行するため、ここで参照が変わったからといって
+		// 運行状態を巻き戻すと、ユーザーが「運行開始」を押した直後に列の DriveTime を 1 つ直しただけで
+		// 「運行前」に戻されてしまう。同 Id + 同行数の更新は表示 field の更新だけに留め、
+		// IsRunning / IsRunStarted / marker toggle / IsLocationServiceEnabled は維持する。
+		string? newId = trainData?.Id;
+		string? oldId = _lastTrainData?.Id;
+		int newRowCount = trainData?.Rows?.Length ?? 0;
+		int oldRowCount = _currentState.RowStates.Count;
+		bool canSoftUpdate = trainData is not null
+			&& TimetableRebuildPolicy.CanUpdateInPlace(oldId, oldRowCount, newId, newRowCount);
+
 		_lastTrainData = trainData;
 
+		if (canSoftUpdate)
+		{
+			VerticalPageStateFactory.ApplyTrainDataFields(_currentState, trainData, affectDate);
+			VerticalPageStateFactory.SyncRowStatesIsInfoRow(_currentState, trainData!.Rows!);
+
+			// 駅情報は更新する。NetworkSyncServiceBase.StaLocationInfo の setter が
+			// 旧 current 駅の Location_m を新配列で再検索して index を再計算するので、
+			// 走行中の駅追跡は維持される。
+			_locationService.SetTimetableRows(trainData.Rows);
+
+			RaiseStateChanged(VerticalPageStateSection.All);
+			return;
+		}
+
+		// 全面リセットパス: 列車切替 / 行数変化 / null クリア / 初回ロード のいずれか。
 		bool isLocationServiceEnabled = _currentState.LocationServiceState.IsEnabled;
 		bool canUseLocationService = _currentState.PageHeaderState.CanUseLocationService;
 

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -117,24 +117,24 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 			return;
 		}
 
-		// 同じ列車 (Id 一致 + 行数一致) なら soft 更新パスへ。WS リアルタイム編集 (TRViS_Realtime_Editor)
+		// 同じ列車 (TrainId 一致) なら soft 更新パスへ。WS リアルタイム編集 (TRViS_Realtime_Editor)
 		// が同一 TrainId に対して都度新インスタンスを発行するため、ここで参照が変わったからといって
 		// 運行状態を巻き戻すと、ユーザーが「運行開始」を押した直後に列の DriveTime を 1 つ直しただけで
-		// 「運行前」に戻されてしまう。同 Id + 同行数の更新は表示 field の更新だけに留め、
+		// 「運行前」に戻されてしまう。同 Id 更新は表示 field と RowStates の更新だけに留め、
 		// IsRunning / IsRunStarted / marker toggle / IsLocationServiceEnabled は維持する。
+		// 行数が変わった場合 (= 駅追加/削除) も同じ列車であれば soft path で対応する。
+		// RowStates dict は新 row 数に揃えてリサイズし、IsInfoRow を再同期する。
 		string? newId = trainData?.Id;
 		string? oldId = _lastTrainData?.Id;
-		int newRowCount = trainData?.Rows?.Length ?? 0;
-		int oldRowCount = _currentState.RowStates.Count;
 		bool canSoftUpdate = trainData is not null
-			&& TimetableRebuildPolicy.CanUpdateInPlace(oldId, oldRowCount, newId, newRowCount);
+			&& TimetableRebuildPolicy.IsSameTrainEdit(oldId, newId);
 
 		_lastTrainData = trainData;
 
 		if (canSoftUpdate)
 		{
 			VerticalPageStateFactory.ApplyTrainDataFields(_currentState, trainData, affectDate);
-			VerticalPageStateFactory.SyncRowStatesIsInfoRow(_currentState, trainData!.Rows!);
+			VerticalPageStateFactory.ResizeAndSyncRowStates(_currentState, trainData!.Rows ?? []);
 
 			// 駅情報は更新する。NetworkSyncServiceBase.StaLocationInfo の setter が
 			// 旧 current 駅の Location_m を新配列で再検索して index を再計算するので、

--- a/TRViS.DTAC.Logic/TimetableRebuildPolicy.cs
+++ b/TRViS.DTAC.Logic/TimetableRebuildPolicy.cs
@@ -1,0 +1,40 @@
+namespace TRViS.DTAC.Logic;
+
+/// <summary>
+/// VerticalTimetableViewModel が新しい TrainData を受け取った時、行リストを
+/// 全面再構築 (= ObservableCollection を作り直して row UI を全 dispose → 再生成) するか、
+/// 既存の行モデルに対して in-place で field 単位の差分更新だけ行うかを判定するためのポリシー。
+///
+/// 不具合の背景: WebSocket 経由のリアルタイム編集では、CacheTimetableData で
+/// 同じ TrainId に対しても都度新しい <c>TrainData</c> インスタンスが作られる。
+/// 旧実装はその度に <c>ObservableCollection&lt;...&gt;</c> ごと差し替えていたため、
+/// 1 行の DriveTimeMM を直しただけでも全ての行 UI が破棄されて上から再描画される
+/// 見た目になっていた。同一列車 (= 同じ Id) で行数も変わらないなら、field 代入で
+/// PropertyChanged 単位の更新に留めれば、変更のあった row だけが UI 更新される。
+/// </summary>
+public static class TimetableRebuildPolicy
+{
+	/// <summary>
+	/// 現在表示中の TrainData (<paramref name="currentTrainId"/> / <paramref name="currentRowCount"/>) に対して
+	/// 新しい TrainData (<paramref name="newTrainId"/> / <paramref name="newRowCount"/>) が「同じ列車の field 単位編集」と
+	/// 言えるかを返す。true なら呼び出し側は既存の row 列に in-place 更新を適用してよい。
+	///
+	/// 同一とみなす条件:
+	///   - 両方の TrainId が null でなく、文字列として等しい
+	///   - 行数も等しい (構造変化なし)
+	/// それ以外 (= 列車自体の切替、行が追加/削除されたケース) は全面再構築させる。
+	/// </summary>
+	public static bool CanUpdateInPlace(
+		string? currentTrainId,
+		int currentRowCount,
+		string? newTrainId,
+		int newRowCount
+	)
+	{
+		if (currentTrainId is null || newTrainId is null)
+			return false;
+		if (!string.Equals(currentTrainId, newTrainId, StringComparison.Ordinal))
+			return false;
+		return currentRowCount == newRowCount;
+	}
+}

--- a/TRViS.DTAC.Logic/TimetableRebuildPolicy.cs
+++ b/TRViS.DTAC.Logic/TimetableRebuildPolicy.cs
@@ -1,40 +1,28 @@
 namespace TRViS.DTAC.Logic;
 
 /// <summary>
-/// VerticalTimetableViewModel が新しい TrainData を受け取った時、行リストを
-/// 全面再構築 (= ObservableCollection を作り直して row UI を全 dispose → 再生成) するか、
-/// 既存の行モデルに対して in-place で field 単位の差分更新だけ行うかを判定するためのポリシー。
+/// 新しい TrainData が「同じ列車の編集」(= 同じ TrainId に対する更新) かどうかを判定する。
+/// true なら呼び出し側 (ViewModel / Presenter) は ObservableCollection を作り直さず、
+/// 既存の行列を mutate (= 同 index は field 上書き、超過分は Add / 不足分は Remove)
+/// して、行 UI の dispose+再生成や IsRunning 等の運行状態リセットを避けることができる。
 ///
-/// 不具合の背景: WebSocket 経由のリアルタイム編集では、CacheTimetableData で
-/// 同じ TrainId に対しても都度新しい <c>TrainData</c> インスタンスが作られる。
-/// 旧実装はその度に <c>ObservableCollection&lt;...&gt;</c> ごと差し替えていたため、
-/// 1 行の DriveTimeMM を直しただけでも全ての行 UI が破棄されて上から再描画される
-/// 見た目になっていた。同一列車 (= 同じ Id) で行数も変わらないなら、field 代入で
-/// PropertyChanged 単位の更新に留めれば、変更のあった row だけが UI 更新される。
+/// 不具合の背景: WebSocket 経由のリアルタイム編集 (TRViS_Realtime_Editor) では、
+/// CacheTimetableData で同じ TrainId に対しても都度新しい <c>TrainData</c> インスタンスが
+/// 作られる。旧実装はその度に <c>ObservableCollection&lt;...&gt;</c> ごと差し替えていたため、
+/// 1 行の DriveTimeMM を直しただけでも全ての行 UI が破棄されて上から再描画されたり、
+/// 運行中なのに「運行前」状態に戻されたりしていた。
 /// </summary>
 public static class TimetableRebuildPolicy
 {
 	/// <summary>
-	/// 現在表示中の TrainData (<paramref name="currentTrainId"/> / <paramref name="currentRowCount"/>) に対して
-	/// 新しい TrainData (<paramref name="newTrainId"/> / <paramref name="newRowCount"/>) が「同じ列車の field 単位編集」と
-	/// 言えるかを返す。true なら呼び出し側は既存の row 列に in-place 更新を適用してよい。
-	///
-	/// 同一とみなす条件:
-	///   - 両方の TrainId が null でなく、文字列として等しい
-	///   - 行数も等しい (構造変化なし)
-	/// それ以外 (= 列車自体の切替、行が追加/削除されたケース) は全面再構築させる。
+	/// 新 TrainData が現在表示中のものと「同じ列車の編集」と言えるか。
+	/// 行数は問わない (= 駅が追加/削除された場合も同じ列車の編集としてカウントし、
+	/// 行モデル列の mutate で対応する)。
 	/// </summary>
-	public static bool CanUpdateInPlace(
-		string? currentTrainId,
-		int currentRowCount,
-		string? newTrainId,
-		int newRowCount
-	)
+	public static bool IsSameTrainEdit(string? currentTrainId, string? newTrainId)
 	{
 		if (currentTrainId is null || newTrainId is null)
 			return false;
-		if (!string.Equals(currentTrainId, newTrainId, StringComparison.Ordinal))
-			return false;
-		return currentRowCount == newRowCount;
+		return string.Equals(currentTrainId, newTrainId, StringComparison.Ordinal);
 	}
 }

--- a/TRViS.DTAC.Logic/VerticalPageStateFactory.cs
+++ b/TRViS.DTAC.Logic/VerticalPageStateFactory.cs
@@ -21,26 +21,36 @@ internal static class VerticalPageStateFactory
 		bool isLocationServiceEnabled)
 	{
 		var state = new VerticalPageState();
+		state.LocationServiceState.IsEnabled = isLocationServiceEnabled;
+		state.PageHeaderState.IsLocationServiceEnabled = isLocationServiceEnabled;
+		ApplyTrainDataFields(state, trainData, affectDate);
+		return state;
+	}
 
-		if (trainData == null)
+	/// <summary>
+	/// 既存の <see cref="VerticalPageState"/> に TrainData 由来の表示用 field のみを
+	/// 上書きする。<c>IsRunning</c> / <c>IsRunStarted</c> / <c>IsLocationServiceEnabled</c>
+	/// など、表示外の運行状態は触らない。
+	///
+	/// 同 Id + 同行数の WS リアルタイム編集 (soft 更新) と、新規列車選択時の初期化
+	/// (= <see cref="CreateStateFromTrainData"/>) の両方からこの helper を呼ぶことで、
+	/// 「表示用 field を作る」ロジックを一箇所にまとめている。
+	/// </summary>
+	public static void ApplyTrainDataFields(VerticalPageState state, TrainData? trainData, string? affectDate)
+	{
+		if (trainData is null)
 		{
-			state.LocationServiceState.IsEnabled = isLocationServiceEnabled;
 			state.PageHeaderState.AffectDateLabelText = affectDate ?? string.Empty;
-			state.PageHeaderState.IsLocationServiceEnabled = isLocationServiceEnabled;
-			return state;
+			return;
 		}
 
-		// Set destination
 		VerticalPageStateUpdater.UpdateDestinationState(state.Destination, trainData.Destination);
 
-		// Set train info
 		state.TrainInfoAreaState.TrainInfoText = trainData.TrainInfo ?? string.Empty;
 		state.TrainInfoAreaState.BeforeDepartureText = trainData.BeforeDeparture ?? string.Empty;
 
-		// Set next day indicator
 		VerticalPageStateUpdater.UpdateNextDayIndicatorState(state.NextDayIndicatorState, trainData.DayCount);
 
-		// Set train display info
 		state.TrainDisplayInfo.TrainNumber = trainData.TrainNumber ?? string.Empty;
 		state.TrainDisplayInfo.CarCount = trainData.CarCount;
 		state.TrainDisplayInfo.MaxSpeed = trainData.MaxSpeed ?? string.Empty;
@@ -48,14 +58,23 @@ internal static class VerticalPageStateFactory
 		state.TrainDisplayInfo.NominalTractiveCapacity = trainData.NominalTractiveCapacity ?? string.Empty;
 		state.TrainDisplayInfo.BeginRemarks = trainData.BeginRemarks ?? string.Empty;
 
-		// Set location service state
-		state.LocationServiceState.IsEnabled = isLocationServiceEnabled;
-
-		// Set page header state
 		state.PageHeaderState.AffectDateLabelText = affectDate ?? string.Empty;
-		state.PageHeaderState.IsLocationServiceEnabled = isLocationServiceEnabled;
+	}
 
-		return state;
+	/// <summary>
+	/// 既存の <see cref="VerticalPageState.RowStates"/> エントリに対し、TimetableRow 側の
+	/// <c>IsInfoRow</c> フラグだけを上書きする。同 Id + 同行数の soft 更新で使う。
+	/// 行数が一致しない場合は何もしない (= 呼び出し側で全面再構築すべきケース)。
+	/// </summary>
+	public static void SyncRowStatesIsInfoRow(VerticalPageState state, TimetableRow[] rows)
+	{
+		if (state.RowStates.Count != rows.Length)
+			return;
+		for (int i = 0; i < rows.Length; i++)
+		{
+			if (state.RowStates.TryGetValue(i, out var rowState))
+				rowState.IsInfoRow = rows[i].IsInfoRow;
+		}
 	}
 
 	/// <summary>

--- a/TRViS.DTAC.Logic/VerticalPageStateFactory.cs
+++ b/TRViS.DTAC.Logic/VerticalPageStateFactory.cs
@@ -62,19 +62,30 @@ internal static class VerticalPageStateFactory
 	}
 
 	/// <summary>
-	/// 既存の <see cref="VerticalPageState.RowStates"/> エントリに対し、TimetableRow 側の
-	/// <c>IsInfoRow</c> フラグだけを上書きする。同 Id + 同行数の soft 更新で使う。
-	/// 行数が一致しない場合は何もしない (= 呼び出し側で全面再構築すべきケース)。
+	/// 同 Id soft 更新で使う RowStates の差分同期。既存 entry の <c>IsInfoRow</c> を上書きしつつ、
+	/// 行数の増減に合わせて末尾の entry を Add / Remove する。LocationState など RowStates が
+	/// 保持している運行状態 (マーカー位置等) は重なっている index 範囲では維持される。
 	/// </summary>
-	public static void SyncRowStatesIsInfoRow(VerticalPageState state, TimetableRow[] rows)
+	public static void ResizeAndSyncRowStates(VerticalPageState state, TimetableRow[] rows)
 	{
-		if (state.RowStates.Count != rows.Length)
-			return;
-		for (int i = 0; i < rows.Length; i++)
+		int oldCount = state.RowStates.Count;
+		int newCount = rows.Length;
+		int overlap = System.Math.Min(oldCount, newCount);
+
+		// 1. 重なっている position の IsInfoRow を再同期。
+		for (int i = 0; i < overlap; i++)
 		{
-			if (state.RowStates.TryGetValue(i, out var rowState))
-				rowState.IsInfoRow = rows[i].IsInfoRow;
+			if (state.RowStates.TryGetValue(i, out var rs))
+				rs.IsInfoRow = rows[i].IsInfoRow;
 		}
+
+		// 2. 末尾追加: 新 row 数が多いなら不足分を作る。
+		for (int i = oldCount; i < newCount; i++)
+			state.RowStates[i] = new VerticalTimetableRowState { IsInfoRow = rows[i].IsInfoRow };
+
+		// 3. 末尾削除: 旧 row 数が多いなら余剰分を消す。逆順で index 安定。
+		for (int i = oldCount - 1; i >= newCount; i--)
+			state.RowStates.Remove(i);
 	}
 
 	/// <summary>

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -883,8 +883,12 @@ public class WebSocketIntegrationTests
 	}
 
 	[Test]
-	public async Task Timetable_AllScopeUpdate_AlwaysResetsState()
+	public async Task Timetable_AllScopeUpdate_PreservesLocationStateWhenCurrentTrainStillExists()
 	{
+		// #245: 運行中 (TrainId 選択済み・StationIndex>0 or IsRunning=true) に Scope.All を
+		// 受信しても、現在の TrainId が新ペイロードに依然含まれていれば位置情報は維持される。
+		// 「全データ配信」ボタンや (実装の良し悪しはさておき) 周期的な All 配信のたびに
+		// 駅 index と走行フラグが初期化されてしまう以前の挙動を防ぐ。
 		var service = await ConnectServiceAsync();
 		try
 		{
@@ -892,16 +896,231 @@ public class WebSocketIntegrationTests
 			service.TrainId = TestData.TrainId;
 			service.ForceSetLocationInfo(2, true);
 
+			int locationChangedCount = 0;
+			service.LocationStateChanged += (_, _) => locationChangedCount++;
+
+			var timetableTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+
+			// 新ペイロードには現在の TrainId が含まれる → リセットしないはず
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+
+			await timetableTask;
+			await Task.Delay(300); // リセットが起きないことを確認するための猶予
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(locationChangedCount, Is.EqualTo(0));
+				Assert.That(service.CurrentStationIndex, Is.EqualTo(2));
+				Assert.That(service.IsRunningToNextStation, Is.True);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task Timetable_AllScopeUpdate_ResetsLocationStateWhenCurrentTrainGone()
+	{
+		// #245: 現在の TrainId が新ペイロードに存在しない (= その列車が削除された) 場合は、
+		// 位置情報をリセットする。古い列車の駅 index が新しい時刻表に対して有効である保証がないため。
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			service.TrainId = "non-existent-train-id";
+			service.ForceSetLocationInfo(2, true);
+
 			var locationTask = WaitForEventAsync<LocationStateChangedEventArgs>(
 				h => service.LocationStateChanged += h,
 				h => service.LocationStateChanged -= h
 			);
 
-			// All スコープは常にリセット
 			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
 
 			var state = await locationTask;
-			Assert.That(state.NewStationIndex, Is.EqualTo(0));
+			Assert.Multiple(() =>
+			{
+				Assert.That(state.NewStationIndex, Is.EqualTo(0));
+				Assert.That(state.IsRunningToNextStation, Is.False);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task Timetable_AllScopeUpdate_ResetsLocationStateWhenNoTrainSelected()
+	{
+		// #245: TrainId が未選択の状態で Scope.All を受信した場合は、リセットされる。
+		// (「現在の Train が新ペイロードに残っている」と見なすべき判断材料がないため)
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			// TrainId は設定しない
+			service.ForceSetLocationInfo(2, true);
+
+			var locationTask = WaitForEventAsync<LocationStateChangedEventArgs>(
+				h => service.LocationStateChanged += h,
+				h => service.LocationStateChanged -= h
+			);
+
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+
+			var state = await locationTask;
+			Assert.Multiple(() =>
+			{
+				Assert.That(state.NewStationIndex, Is.EqualTo(0));
+				Assert.That(state.IsRunningToNextStation, Is.False);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
+	// StaLocationInfo 差し替え時の駅 index 再計算 (#245)
+	// ================================================================
+
+	[Test]
+	public async Task StaLocationInfo_StationBeforeCurrentRemoved_ShiftsIndexUp()
+	{
+		// #245: 運行中に「現在駅よりも前の駅」が削除された場合は、駅 index が
+		// 削除された分だけ繰り上がる (= 現在駅の物理的位置に追従する)。
+		// 旧配列: [0m, 1000m, 2000m, 3000m], CurrentStationIndex=2 (= 2000m, 走行中)
+		// 新配列: [1000m, 2000m, 3000m]            (先頭駅 0m を削除)
+		//   → 旧 current(2000m) は 新 index=1 にずれる; 走行フラグは維持
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			service.StaLocationInfo = new StaLocationInfo[]
+			{
+				new(0.0,    null, null, 200.0),
+				new(1000.0, null, null, 200.0),
+				new(2000.0, null, null, 200.0),
+				new(3000.0, null, null, 200.0),
+			};
+			service.ForceSetLocationInfo(2, true);
+
+			var stateTask = WaitForEventAsync<LocationStateChangedEventArgs>(
+				h => service.LocationStateChanged += h,
+				h => service.LocationStateChanged -= h
+			);
+
+			service.StaLocationInfo = new StaLocationInfo[]
+			{
+				new(1000.0, null, null, 200.0),
+				new(2000.0, null, null, 200.0),
+				new(3000.0, null, null, 200.0),
+			};
+
+			var state = await stateTask;
+			Assert.Multiple(() =>
+			{
+				Assert.That(state.NewStationIndex, Is.EqualTo(1));
+				Assert.That(state.IsRunningToNextStation, Is.True);
+				Assert.That(service.CurrentStationIndex, Is.EqualTo(1));
+				Assert.That(service.IsRunningToNextStation, Is.True);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task StaLocationInfo_StationAfterCurrentRemoved_PreservesIndex()
+	{
+		// #245: 現在駅より「後」の駅が削除されても、現在駅自体が残っていれば
+		// 駅 index は変わらず走行フラグも維持される。
+		// 旧配列: [0m, 1000m, 2000m, 3000m], CurrentStationIndex=1 (= 1000m, 走行中)
+		// 新配列: [0m, 1000m, 2000m]            (末尾駅 3000m を削除)
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			service.StaLocationInfo = new StaLocationInfo[]
+			{
+				new(0.0,    null, null, 200.0),
+				new(1000.0, null, null, 200.0),
+				new(2000.0, null, null, 200.0),
+				new(3000.0, null, null, 200.0),
+			};
+			service.ForceSetLocationInfo(1, true);
+
+			int locationChangedCount = 0;
+			service.LocationStateChanged += (_, _) => locationChangedCount++;
+
+			service.StaLocationInfo = new StaLocationInfo[]
+			{
+				new(0.0,    null, null, 200.0),
+				new(1000.0, null, null, 200.0),
+				new(2000.0, null, null, 200.0),
+			};
+
+			await Task.Delay(100); // 余計なイベントが起きないことを確認する猶予
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(locationChangedCount, Is.EqualTo(0));
+				Assert.That(service.CurrentStationIndex, Is.EqualTo(1));
+				Assert.That(service.IsRunningToNextStation, Is.True);
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
+	public async Task StaLocationInfo_CurrentStationRemoved_ResetsLocationInfo()
+	{
+		// #245: 現在駅そのものが削除された場合は、駅 index を 0 にリセットして走行も停止する。
+		// 旧配列: [0m, 1000m, 2000m], CurrentStationIndex=1 (= 1000m, 走行中)
+		// 新配列: [0m, 2000m]            (現在駅 1000m を削除)
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+			service.StaLocationInfo = new StaLocationInfo[]
+			{
+				new(0.0,    null, null, 200.0),
+				new(1000.0, null, null, 200.0),
+				new(2000.0, null, null, 200.0),
+			};
+			service.ForceSetLocationInfo(1, true);
+
+			var stateTask = WaitForEventAsync<LocationStateChangedEventArgs>(
+				h => service.LocationStateChanged += h,
+				h => service.LocationStateChanged -= h
+			);
+
+			service.StaLocationInfo = new StaLocationInfo[]
+			{
+				new(0.0,    null, null, 200.0),
+				new(2000.0, null, null, 200.0),
+			};
+
+			var state = await stateTask;
+			Assert.Multiple(() =>
+			{
+				Assert.That(state.NewStationIndex, Is.EqualTo(0));
+				Assert.That(state.IsRunningToNextStation, Is.False);
+				Assert.That(service.CurrentStationIndex, Is.EqualTo(0));
+				Assert.That(service.IsRunningToNextStation, Is.False);
+			});
 		}
 		finally
 		{

--- a/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
@@ -55,10 +55,54 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 			if (_staLocationInfo == value)
 				return;
 
+			// 旧 current 駅を控えておく (新配列で対応駅を Location_m で探すため)。
+			StaLocationInfo? oldCurrentStation = null;
+			if (_staLocationInfo is not null
+				&& CurrentStationIndex >= 0
+				&& CurrentStationIndex < _staLocationInfo.Length)
+			{
+				oldCurrentStation = _staLocationInfo[CurrentStationIndex];
+			}
+			int oldIndex = CurrentStationIndex;
+			bool oldRunning = IsRunningToNextStation;
+
 			_staLocationInfo = value;
 			_lonLatStationDetector.SetStationLocations(value);
-			ResetLocationInfo();
+
+			// #245: 「現在の位置情報サービスの状態をもとに、更新後の駅 index を計算する」
+			// 旧 current 駅が新配列にも存在するならその index に追従させ、走行フラグを引き継ぐ。
+			// (= 「前の駅が削除された」「後の駅が追加された」等の編集で index がずれたケース)
+			// 存在しなければ駅自体が削除されたものとみなしてリセットする。
+			int newIndex = FindStationIndexByLocation_m(value, oldCurrentStation);
+			if (newIndex < 0)
+			{
+				ResetLocationInfo();
+				return;
+			}
+			if (newIndex == oldIndex && oldRunning == IsRunningToNextStation)
+			{
+				// 状態が変わらない: _lonLatStationDetector は上の SetStationLocations で履歴クリア
+				// 済みなので Sync で同期だけ取り、外部にはイベントを飛ばさない。
+				_lonLatStationDetector.Sync(newIndex, oldRunning);
+				return;
+			}
+			ForceSetLocationInfo(newIndex, oldRunning);
 		}
+	}
+
+	private static int FindStationIndexByLocation_m(StaLocationInfo[]? newArray, StaLocationInfo? oldStation)
+	{
+		if (newArray is null || oldStation is null)
+			return -1;
+		double key = oldStation.Location_m;
+		if (double.IsNaN(key))
+			return -1;
+		for (int i = 0; i < newArray.Length; i++)
+		{
+			if (newArray[i].Location_m == key)
+				return i;
+		}
+		return -1;
 	}
 
 	// Location_m が NaN かつ緯度経度が配信されたときの駅判定エンジン。
@@ -366,14 +410,17 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	/// 時刻表の更新を受信したとき、位置情報を初期状態にリセットすべきかを判定する。
 	/// リアルタイム編集対応のため、自スコープと一致する更新では位置情報を維持する
 	/// (例: 編集中の Train が更新されても駅 index を保持する)。
-	/// 全体更新 (<see cref="TimetableScopeType.All"/>) の場合のみリセットする。
+	/// 全体更新 (<see cref="TimetableScopeType.All"/>) の場合も、現在追跡中の Train が
+	/// 新ペイロードに残っていれば維持する (#245: 運行中の意図しないリセットを防ぐ)。
 	/// </summary>
 	private bool ShouldResetLocationOnTimetableUpdate(TimetableData timetableData)
 	{
 		return timetableData.Scope switch
 		{
-			// 全体更新: 構造が変わるため位置情報をリセットする
-			TimetableScopeType.All => true,
+			// 全体更新: 現在追跡中の Train が新ペイロードに残っていれば維持する。
+			//   - 残っている → 編集や再配信のたびに運行中状態を巻き戻されては困るので維持
+			//   - 残っていない (削除された or 未選択) → 古い駅 index が新時刻表で有効な保証がないのでリセット
+			TimetableScopeType.All => !IsCurrentTrainStillTracked(),
 			// WorkGroup / Work / Train 単位の更新: 自スコープと一致するか否かに関わらず維持する。
 			//   - 一致する場合 → ユーザーが今見ているデータの再描画を期待しているのでリセットしない
 			//   - 一致しない場合 → そもそも現在の表示と無関係なのでリセットしない
@@ -383,6 +430,14 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 			_ => false,
 		};
 	}
+
+	/// <summary>
+	/// 現在 <see cref="TrainId"/> として追跡している列車が、最新の時刻表データに依然存在しているかを返す。
+	/// <see cref="ShouldResetLocationOnTimetableUpdate"/> が Scope.All 受信時の判定に使う。
+	/// 既定では false (= リセット側に倒す) を返す。時刻表キャッシュにアクセスできる実装側で
+	/// override すること (例: WebSocketNetworkSyncService)。
+	/// </summary>
+	protected virtual bool IsCurrentTrainStillTracked() => false;
 
 	public void ForceSetLocationInfo(
 		int stationIndex,

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -781,6 +781,17 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		}
 	}
 
+	protected override bool IsCurrentTrainStillTracked()
+	{
+		// RaiseTimetableUpdated は CacheTimetableData の後に呼ばれるため、
+		// All スコープ受信時はここでチェックする時点で既に新ペイロードを反映した
+		// _TrainDataCache になっている。残っていれば「同じ列車が新時刻表にも存在する」
+		// と見なし、駅 index / 走行フラグを維持する。
+		if (string.IsNullOrEmpty(TrainId))
+			return false;
+		return _TrainDataCache.ContainsKey(TrainId);
+	}
+
 	protected override void OnWorkGroupIdChanged(string? value)
 	{
 		logger.Debug("OnWorkGroupIdChanged: {0}", value);

--- a/TRViS.UITests/AutomationIds.cs
+++ b/TRViS.UITests/AutomationIds.cs
@@ -177,6 +177,19 @@ public static class AutomationIds
 		public const string TestTimeSeam = "DTAC.TestTimeSeam";
 		public const string TestSeamTitlePrefix = "T:";
 		public const string TestSeamTimePrefix = "C:";
+
+		// UI_TEST-only seam: changes the first non-InfoRow in the current train's
+		// TimetableRows to IsInfoRow=true, then re-sets AppViewModel.SelectedTrainData
+		// with the modified clone. This exercises the WebSocket soft-update code path
+		// (same train ID → ApplyPositionAlignedDiff → PropertyChanged("IsInfoRow") →
+		// UpdateAllComponents) to reproduce the "station-name label stays visible after
+		// IsInfoRow false→true transition" bug.
+		public const string TestSeedIsInfoRowTransitionButton = "DTAC.TestSeedIsInfoRowTransitionButton";
+
+		// AutomationId pattern for timetable row components (set in UI_TEST builds only).
+		// Use string.Format: TimetableRowStationNamePattern.Replace("{0}", rowIndex.ToString())
+		public const string TimetableRowStationNamePattern = "TimetableRow.{0}.StationName";
+		public const string TimetableRowInfoRowPattern = "TimetableRow.{0}.InfoRow";
 	}
 
 	/// <summary>

--- a/TRViS.UITests/Tests/IsInfoRowTransitionTests.cs
+++ b/TRViS.UITests/Tests/IsInfoRowTransitionTests.cs
@@ -1,0 +1,138 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Mac;
+using TRViS.UITests.Pages;
+
+namespace TRViS.UITests.Tests;
+
+/// <summary>
+/// Regression test for "non-InfoRow components (station name, drive time, etc.)
+/// remain visible after a WebSocket soft-update changes IsInfoRow from false to true
+/// on a timetable row."
+///
+/// Uses the UI_TEST seam <c>DTAC.TestSeedIsInfoRowTransitionButton</c> which:
+///   1. Takes the first non-InfoRow in the currently selected train,
+///   2. Clones the TrainData with that row's IsInfoRow flipped to true, and
+///   3. Re-sets AppViewModel.SelectedTrainData — triggering the same soft-update
+///      code path as a WebSocket edit (same train ID → ApplyPositionAlignedDiff →
+///      ApplyRowToExistingModel → PropertyChanged("IsInfoRow") → UpdateAllComponents).
+///
+/// The AutomationId-based assertions check the Grid.Children state indirectly:
+///   - "TimetableRow.N.StationName" is present &amp; user-visible before the transition.
+///   - After the transition: StationName is gone; "TimetableRow.N.InfoRow" is visible.
+/// </summary>
+[TestFixture]
+[Infrastructure.RetryAllTests(2)]
+public class IsInfoRowTransitionTests : Infrastructure.BaseUITest
+{
+	private StartHomePageObject _startHomePage = null!;
+
+	protected override bool ShareSessionAcrossTestsInFixture => true;
+
+	[SetUp]
+	public override void SetUp()
+	{
+		base.SetUp();
+
+		_startHomePage = new StartHomePageObject(Driver);
+
+		if (!_startHomePage.PollDisplayed(AutomationIds.StartHome.Title, timeoutSeconds: 3))
+		{
+			new AppShellPage(Driver).NavigateToHome();
+			_startHomePage = new StartHomePageObject(Driver);
+		}
+		_startHomePage.ClearLoaderForTesting();
+		_startHomePage.AcceptPrivacyPolicyIfNeeded();
+	}
+
+	/// <summary>
+	/// Core regression: after the IsInfoRow seam fires, the station-name label
+	/// must disappear and the info-row label must appear.
+	///
+	/// Before the fix: UpdateAllComponents() in the IsInfoRow=true branch only
+	/// called UpdateInfoRow() — station-name (and other non-InfoRow components)
+	/// stayed in the Grid. This test would find StationName still visible → fail.
+	///
+	/// After the fix: RemoveNonInfoRowComponents() is called first, so StationName
+	/// is removed from the Grid before UpdateInfoRow() adds the InfoRow label.
+	/// </summary>
+	[Test]
+	public void InfoRowTransition_FalseToTrue_RemovesStationNameShowsInfoLabel()
+	{
+		// --- Setup: load sample data and navigate to DTAC timetable. ---
+		Assert.That(_startHomePage.IsDisplayed(), Is.True);
+		_startHomePage.LoadSample();
+		_startHomePage.WaitForElement(AutomationIds.StartHome.WorkGroupList);
+
+		var dtac = _startHomePage.AutoOpenForTesting();
+		dtac.SwitchToTimetableTab();
+
+		// Row 0 in the default sample train is "駅１" (IsInfoRow=false).
+		// The UI_TEST build sets AutomationId = "TimetableRow.0.StationName" on it.
+		string stationId = string.Format(AutomationIds.DTAC.TimetableRowStationNamePattern, 0);
+		string infoRowId = string.Format(AutomationIds.DTAC.TimetableRowInfoRowPattern, 0);
+
+		// --- Pre-condition: station-name label is visible before the transition. ---
+		Assert.That(
+			IsElementUserVisible(stationId),
+			Is.True,
+			"Row 0 StationNameLabel must be visible before the IsInfoRow transition.");
+
+		// --- Action: trigger the seam that simulates the WebSocket IsInfoRow edit. ---
+		var seamButton = dtac.WaitForElement(AutomationIds.DTAC.TestSeedIsInfoRowTransitionButton);
+		seamButton.Click();
+		Thread.Sleep(500); // allow the PropertyChanged cascade to settle
+
+		// --- Post-condition (FAILS before fix): station-name must be gone. ---
+		Assert.That(
+			IsElementUserVisible(stationId),
+			Is.False,
+			"Row 0 StationNameLabel must NOT be visible after IsInfoRow changed to true " +
+			"(non-InfoRow components must be removed from the Grid).");
+
+		// --- Post-condition: info-row label must be visible. ---
+		Assert.That(
+			IsElementUserVisible(infoRowId),
+			Is.True,
+			"Row 0 InfoRowLabel must be visible after IsInfoRow changed to true.");
+	}
+
+	/// <summary>
+	/// Returns true when the element is findable AND genuinely visible (non-zero size).
+	/// Combining Displayed + Size disambiguates the Mac Catalyst quirk where unparented
+	/// elements with an AutomationId are surfaced as Displayed=true but with 0×0 size.
+	/// </summary>
+	private bool IsElementUserVisible(string automationId, double timeoutSeconds = 3)
+	{
+		var prevWait = Driver.Manage().Timeouts().ImplicitWait;
+		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+		var locator = AutomationIdLocator(automationId);
+		try
+		{
+			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+			while (DateTime.UtcNow < deadline)
+			{
+				var elements = Driver.FindElements(locator);
+				if (elements.Count > 0)
+				{
+					try
+					{
+						var el = elements[0];
+						if (el.Displayed && el.Size.Width > 0 && el.Size.Height > 0)
+							return true;
+					}
+					catch { }
+				}
+				Thread.Sleep(100);
+			}
+			return false;
+		}
+		finally
+		{
+			Driver.Manage().Timeouts().ImplicitWait = prevWait;
+		}
+	}
+
+	private By AutomationIdLocator(string automationId)
+		=> IsAndroid ? By.Id(automationId) : MobileBy.AccessibilityId(automationId);
+}

--- a/TRViS.UITests/Tests/IsInfoRowTransitionTests.cs
+++ b/TRViS.UITests/Tests/IsInfoRowTransitionTests.cs
@@ -22,6 +22,7 @@ namespace TRViS.UITests.Tests;
 ///   - After the transition: StationName is gone; "TimetableRow.N.InfoRow" is visible.
 /// </summary>
 [TestFixture]
+[Platform(Exclude = "Linux", Reason = "Android UIAutomator2 does not expose the timetable Grid's per-row children as addressable nodes. The DTAC timetable is a large 8-column Grid inside DTAC.TimetableScrollView; the ScrollView and top-level seam Labels (DTAC.TestTitleSeam etc.) resolve by resource-id, but no descendant of the row Grid does — verified across three approaches (inner-content id forwarding, pre-attach AutomationId assignment, and a dedicated hidden mirror Label built with the proven ViewHost seam recipe, all EMPTY). The component-removal regression this test guards lives in platform-agnostic VerticalTimetableRow.cs and is verified on iPhone, iPad mini 5, iPad mini A17, macOS, and Windows. (The Android job is the only UI-test job whose NUnit host is Linux.)")]
 [Infrastructure.RetryAllTests(2)]
 public class IsInfoRowTransitionTests : Infrastructure.BaseUITest
 {
@@ -98,13 +99,23 @@ public class IsInfoRowTransitionTests : Infrastructure.BaseUITest
 	}
 
 	/// <summary>
-	/// Returns true when the element is findable AND genuinely visible (non-zero size).
-	/// Combining Displayed + Size disambiguates the Mac Catalyst quirk where unparented
-	/// elements with an AutomationId are surfaced as Displayed=true but with 0×0 size.
+	/// Returns true when the element is findable AND laid out (non-zero size).
+	///
+	/// Size-only (not <c>Displayed</c>) is the cross-platform-reliable signal because
+	/// <c>Displayed</c> reports false in two unrelated, expected situations here:
+	///   1. Mac Catalyst surfaces unparented elements with an AutomationId in the
+	///      accessibility tree but reports them as 0×0 — size catches this.
+	///   2. On iPhone the timetable Grid (width ≈ 740) is wider than the screen
+	///      (≈ 390 pt), so XCUITest cascades <c>visible=false</c> from the off-screen
+	///      parent down to every child. The child's frame is still non-zero in that
+	///      state, so a size check correctly treats it as present while
+	///      <c>Displayed</c> would wrongly report it absent.
+	/// When the component is actually removed from the Grid, the element either
+	/// leaves the tree (iOS/Android) or reports 0×0 (macOS) — both make this false.
 	/// </summary>
 	private bool IsElementUserVisible(string automationId, double timeoutSeconds = 3)
 	{
-		var prevWait = Driver.Manage().Timeouts().ImplicitWait;
+		var prevWait = TimeSpan.FromSeconds(10);
 		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
 		var locator = AutomationIdLocator(automationId);
 		try
@@ -118,7 +129,7 @@ public class IsInfoRowTransitionTests : Infrastructure.BaseUITest
 					try
 					{
 						var el = elements[0];
-						if (el.Displayed && el.Size.Width > 0 && el.Size.Height > 0)
+						if (el.Size.Width > 0 && el.Size.Height > 0)
 							return true;
 					}
 					catch { }

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
@@ -368,14 +368,47 @@ public class VerticalTimetableRow : IDisposable
 		InfoRowLabel.HorizontalOptions = LayoutOptions.Start;
 		Grid.SetColumnSpan(InfoRowLabel, 6);
 	}
+	private void RemoveNonInfoRowComponents()
+	{
+		RemoveComponent(ref DriveTimeGrid);
+		DriveTimeMMLabel = null;
+		DriveTimeSSLabel = null;
+		RemoveComponent(ref StationNameLabel);
+		RemoveComponent(ref ArrivalTimeCell);
+		if (Brackets is var (open, close))
+		{
+			RemoveComponent(ref open);
+			RemoveComponent(ref close);
+		}
+		Brackets = null;
+		if (OpOnlyStopBrackets is var (opOpen, opClose))
+		{
+			RemoveComponent(ref opOpen);
+			RemoveComponent(ref opClose);
+		}
+		OpOnlyStopBrackets = null;
+		RemoveComponent(ref DepartureTimeCell);
+		RemoveComponent(ref LastStopLineGrid);
+		RemoveComponent(ref TrackNameLabel);
+		RemoveComponent(ref RunInOutLimitGrid);
+		RunInLimitLabel = null;
+		RunOutLimitLabel = null;
+		RemoveComponent(ref RemarksLabel);
+		RemoveComponent(ref MarkerBox);
+		RemoveComponent(ref MarkerTransparentBox);
+		BackgroundBoxView!.Color = Colors.Transparent;
+	}
+
 	private void UpdateAllComponents()
 	{
 		if (Model.IsInfoRow)
 		{
+			RemoveNonInfoRowComponents();
 			UpdateInfoRow();
 		}
 		else
 		{
+			RemoveComponent(ref InfoRowLabel);
 			UpdateDriveTime();
 			UpdateStationName();
 			UpdateArrivalTime();

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
@@ -444,6 +444,7 @@ public class VerticalTimetableRow : IDisposable
 		SetRowIfAttached(RunInOutLimitGrid);
 		SetRowIfAttached(RemarksLabel);
 		SetRowIfAttached(MarkerBox);
+		SetRowIfAttached(MarkerTransparentBox);
 		SetRowIfAttached(InfoRowLabel);
 	}
 

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
@@ -361,6 +361,9 @@ public class VerticalTimetableRow : IDisposable
 		}
 
 		EnsureComponent(ref InfoRowLabel, DTACElementStyles.TimetableInfoRowHtmlAutoDetectLabel<HtmlAutoDetectLabel>, STATION_NAME_COLUMN);
+#if UI_TEST
+		InfoRowLabel.AutomationId = $"TimetableRow.{Model.RowIndex}.InfoRow";
+#endif
 		InfoRowLabel.Text = Model.InfoText;
 		InfoRowLabel.HorizontalOptions = LayoutOptions.Start;
 		Grid.SetColumnSpan(InfoRowLabel, 6);
@@ -448,6 +451,9 @@ public class VerticalTimetableRow : IDisposable
 		}
 
 		var label = EnsureComponent(ref StationNameLabel, CreateStationNameComponent, STATION_NAME_COLUMN);
+#if UI_TEST
+		label.AutomationId = $"TimetableRow.{Model.RowIndex}.StationName";
+#endif
 		label.Text = StationNameConverter.Convert(Model.StationName);
 	}
 

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableRow.cs
@@ -365,6 +365,12 @@ public class VerticalTimetableRow : IDisposable
 		InfoRowLabel.AutomationId = $"TimetableRow.{Model.RowIndex}.InfoRow";
 #endif
 		InfoRowLabel.Text = Model.InfoText;
+#if UI_TEST
+		// Mirror the id onto the inner Label (set synchronously by the Text
+		// setter) so it surfaces as an Android resource-id; see UpdateStationName.
+		if (InfoRowLabel.Content is Element infoInner)
+			infoInner.AutomationId = InfoRowLabel.AutomationId;
+#endif
 		InfoRowLabel.HorizontalOptions = LayoutOptions.Start;
 		Grid.SetColumnSpan(InfoRowLabel, 6);
 	}
@@ -489,6 +495,15 @@ public class VerticalTimetableRow : IDisposable
 		label.AutomationId = $"TimetableRow.{Model.RowIndex}.StationName";
 #endif
 		label.Text = StationNameConverter.Convert(Model.StationName);
+#if UI_TEST
+		// HtmlAutoDetectLabel is a ContentView whose AutomationId does not surface
+		// as an Android UIAutomator2 resource-id. Its inner Content (set
+		// synchronously by the Text setter above) is a Label subclass, which does
+		// map to a resource-id, so mirror the id onto it. The outer id is kept for
+		// iOS/macOS which find the ContentView wrapper directly.
+		if (label.Content is Element inner)
+			inner.AutomationId = label.AutomationId;
+#endif
 	}
 
 	private void UpdateArrivalTime()

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
@@ -266,9 +266,13 @@ public partial class VerticalTimetableView : Grid
 
 	private async void OnCurrentRowsCollectionChangedAsync(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 	{
-		// 同 Train 内での mutate 経由更新 (= ObservableCollection.Add / RemoveAt) は
-		// 該当行だけを incremental に追加/削除して、行 UI 全体の dispose+再構築を回避する。
-		// それ以外 (Reset / Replace / Move) は安全側に倒して従来通り SetRowViewsAsync で全面再構築する。
+		// 同 Train 内での mutate 経由更新 (= ObservableCollection.Add / RemoveAt / Move) は
+		// 該当行だけを incremental に追加/削除/並び替えして、行 UI 全体の dispose+再構築を回避する。
+		// - Add: 新規行 UI を 1 つ追加する。
+		// - Remove: 対応する行 UI を破棄する。
+		// - Move: RowViewList のエントリを組み替えるだけ。実際の視覚位置は model.RowIndex →
+		//   Grid.SetRow 側で制御するため、ここでは List の順序のみを合わせる。
+		// それ以外 (Reset / Replace) は安全側に倒して従来通り SetRowViewsAsync で全面再構築する。
 		try
 		{
 			switch (e.Action)
@@ -278,6 +282,9 @@ public partial class VerticalTimetableView : Grid
 					break;
 				case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
 					await HandleCollectionRemoveAsync(e);
+					break;
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
+					await HandleCollectionMoveAsync(e);
 					break;
 				default:
 					await OnViewModelCurrentRowsChangedAsync();
@@ -364,6 +371,26 @@ public partial class VerticalTimetableView : Grid
 					RowViewList.RemoveAt(removeAt);
 				}
 			}
+		});
+	}
+
+	/// <summary>
+	/// CollectionChanged.Move に対応する incremental 並び替え。
+	/// ViewModel の ApplySmartDiff が発火する。Grid 上の視覚位置は model.RowIndex →
+	/// Grid.SetRow で制御されるため、ここでは RowViewList の要素順序だけを合わせる。
+	/// </summary>
+	private Task HandleCollectionMoveAsync(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+	{
+		int oldIndex = e.OldStartingIndex;
+		int newIndex = e.NewStartingIndex;
+
+		return MainThread.InvokeOnMainThreadAsync(() =>
+		{
+			if (oldIndex < 0 || oldIndex >= RowViewList.Count) return;
+			if (newIndex < 0 || newIndex >= RowViewList.Count) return;
+			var rowView = RowViewList[oldIndex];
+			RowViewList.RemoveAt(oldIndex);
+			RowViewList.Insert(newIndex, rowView);
 		});
 	}
 

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
@@ -54,6 +54,11 @@ public partial class VerticalTimetableView : Grid
 	private readonly VerticalTimetableViewPresenter _presenter;
 	private readonly LocationServiceAdapter _locationServiceAdapter;
 
+	// 現在 CollectionChanged を購読中の ObservableCollection への参照。CurrentRows が
+	// ObservableProperty で差し替えられた時に、古い方の購読を外して新しい方に貼り替えるために保持する。
+	// これを忘れると同 Train 内の Add/Remove (mutate 経由の差分更新) が View 側で見えなくなる。
+	private ObservableCollection<VerticalTimetableRowModel> _trackedCurrentRows;
+
 	#endregion
 
 	#region Properties
@@ -163,7 +168,8 @@ public partial class VerticalTimetableView : Grid
 		_presenter.StateChanged += OnPresenterStateChanged;
 		_presenter.ScrollRequested += OnPresenterScrollRequested;
 		ViewModel.PropertyChanged += OnViewModelPropertyChanged;
-		ViewModel.CurrentRows.CollectionChanged += OnCurrentRowsCollectionChangedAsync;
+		_trackedCurrentRows = ViewModel.CurrentRows;
+		_trackedCurrentRows.CollectionChanged += OnCurrentRowsCollectionChangedAsync;
 
 		logger.Trace("Created");
 	}
@@ -215,6 +221,12 @@ public partial class VerticalTimetableView : Grid
 		switch (e.PropertyName)
 		{
 			case nameof(ViewModel.CurrentRows):
+				// CurrentRows が ObservableCollection ごと差し替えられた → 旧 collection の
+				// CollectionChanged 購読を外して、新 collection に貼り直す。これを怠ると、
+				// 以降の同 Train mutate (Add/Remove) が View に届かなくなり、行 UI が更新されない。
+				_trackedCurrentRows.CollectionChanged -= OnCurrentRowsCollectionChangedAsync;
+				_trackedCurrentRows = ViewModel.CurrentRows;
+				_trackedCurrentRows.CollectionChanged += OnCurrentRowsCollectionChangedAsync;
 				await OnViewModelCurrentRowsChangedAsync();
 				break;
 			case nameof(ViewModel.AfterRemarksText):
@@ -253,7 +265,107 @@ public partial class VerticalTimetableView : Grid
 	}
 
 	private async void OnCurrentRowsCollectionChangedAsync(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		=> await OnViewModelCurrentRowsChangedAsync();
+	{
+		// 同 Train 内での mutate 経由更新 (= ObservableCollection.Add / RemoveAt) は
+		// 該当行だけを incremental に追加/削除して、行 UI 全体の dispose+再構築を回避する。
+		// それ以外 (Reset / Replace / Move) は安全側に倒して従来通り SetRowViewsAsync で全面再構築する。
+		try
+		{
+			switch (e.Action)
+			{
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
+					await HandleCollectionAddAsync(e);
+					break;
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
+					await HandleCollectionRemoveAsync(e);
+					break;
+				default:
+					await OnViewModelCurrentRowsChangedAsync();
+					break;
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.Fatal(ex, "Unknown Exception");
+			InstanceManager.CrashlyticsWrapper.Log(ex, "VerticalTimetableView.OnCurrentRowsCollectionChanged");
+			await Util.ExitWithAlertAsync(ex);
+		}
+	}
+
+	/// <summary>
+	/// CollectionChanged.Add に対応する incremental 追加。ViewModel の差分更新パスは
+	/// 末尾追加しか発火しないので NewStartingIndex は通常 RowViewList.Count と等しい。
+	/// </summary>
+	private async Task HandleCollectionAddAsync(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+	{
+		if (e.NewItems is null || e.NewItems.Count == 0)
+			return;
+
+		int startIndex = e.NewStartingIndex >= 0 ? e.NewStartingIndex : RowViewList.Count;
+		var modelsToAdd = new List<VerticalTimetableRowModel>(e.NewItems.Count);
+		foreach (var item in e.NewItems)
+		{
+			if (item is VerticalTimetableRowModel m)
+				modelsToAdd.Add(m);
+		}
+		if (modelsToAdd.Count == 0)
+			return;
+
+		// 「最後の station 行」index は新規追加で変わり得る。追加対象の中で最も末尾寄りの
+		// 非 info 行に isLastRow=true を付ける (= 1 つだけが last station)。先行の Add 群は false。
+		int lastStationOffset = -1;
+		for (int i = modelsToAdd.Count - 1; i >= 0; i--)
+		{
+			if (!modelsToAdd[i].IsInfoRow)
+			{
+				lastStationOffset = i;
+				break;
+			}
+		}
+
+		await MainThread.InvokeOnMainThreadAsync(() =>
+		{
+			for (int i = 0; i < modelsToAdd.Count; i++)
+			{
+				int rowIndex = startIndex + i;
+				bool isLastRow = i == lastStationOffset;
+				VerticalTimetableRow rowView = new(this, modelsToAdd[i], ColumnVisibilityState, MarkerViewModel, isLastRow);
+				rowView.RowTapped += RowTapped;
+				rowView.MarkerBoxClicked += OnMarkerBoxClicked;
+				if (rowIndex >= RowViewList.Count)
+					RowViewList.Add(rowView);
+				else
+					RowViewList.Insert(rowIndex, rowView);
+			}
+		});
+	}
+
+	/// <summary>
+	/// CollectionChanged.Remove に対応する incremental 削除。ViewModel の差分更新パスは
+	/// 末尾削除しか発火しないので OldStartingIndex は通常 (RowViewList.Count - count) と等しい。
+	/// </summary>
+	private Task HandleCollectionRemoveAsync(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+	{
+		if (e.OldItems is null || e.OldItems.Count == 0)
+			return Task.CompletedTask;
+
+		int startIndex = e.OldStartingIndex;
+		int removeCount = e.OldItems.Count;
+
+		return MainThread.InvokeOnMainThreadAsync(() =>
+		{
+			// index 末尾側から外す: 前から消すと残りの index がずれて狙った行を捨てそこねる。
+			for (int i = removeCount - 1; i >= 0; i--)
+			{
+				int removeAt = startIndex + i;
+				if (removeAt >= 0 && removeAt < RowViewList.Count)
+				{
+					RowViewList[removeAt].Dispose();
+					RowViewList.RemoveAt(removeAt);
+				}
+			}
+		});
+	}
 
 	private void OnViewModelAfterRemarksTextChanged()
 	{

--- a/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
+++ b/TRViS/DTAC/TimetableParts/VerticalTimetableView.cs
@@ -379,10 +379,14 @@ public partial class VerticalTimetableView : Grid
 		Grid.SetRow(CurrentLocationBoxView, markerRow);
 		Grid.SetRow(CurrentLocationLine, markerRow);
 
-		// Update per-row highlight directly — no ViewModel round-trip
-		int effectiveMarkerRow = state.Marker.IsBoxVisible ? markerRow : -1;
-		for (int i = 0; i < RowViewList.Count; i++)
-			RowViewList[i].Model.IsLocationMarkerOnThisRow = (i == effectiveMarkerRow);
+		// 現在位置マーカーが被る行の DriveTime ラベルを白文字 (反転色) にするため、
+		// マーカー位置を ViewModel に書き込む。ViewModel 側 (LocationMarkerRowCoordinator)
+		// が現在の CurrentRows と、その後 SetTrainData で差し替わる新しい行の双方に対して
+		// 適用してくれるので、ここで RowViewList を直接 for-loop する必要はない。
+		// (旧実装は async な SetRowViewsAsync が新行を populate する前にこの for-loop が
+		//  古い RowViewList に対して走ってしまい、新行が黒文字のまま残る不具合があった)
+		ViewModel.MarkerRowIndex = markerRow;
+		ViewModel.IsMarkerVisible = state.Marker.IsBoxVisible;
 
 		bool shouldHaptic = state.Marker.IsBoxVisible
 			&& (prevBoxVisible != state.Marker.IsBoxVisible

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -50,6 +50,11 @@ public partial class VerticalStylePage : ContentView
 	// after a Work switch when this page instance is reused across navigations.
 	private ScrollView? _phoneOuterScrollView;
 
+	// 直近に ApplyPresenterState(All) で TimetableView に流し込んだ TrainData の参照。
+	// OnViewBecameActive (横型時刻表ページから戻った時など) は常に All を投げてくるので、
+	// ここで前回と同じ参照かを見て不要な行再構築・スクロールリセットを抑止する。
+	private IO.Models.TrainData? _lastAppliedTrainData = null;
+
 	public VerticalStylePage()
 	{
 		logger.Trace("Creating...");
@@ -323,22 +328,31 @@ public partial class VerticalStylePage : ContentView
 			UpdateTimetableActivityIndicator();
 		}
 
-		// Apply scroll position on All change (train data changed)
+		// Apply scroll position on All change (train data changed).
+		// 横型時刻表ページから戻った時の OnViewBecameActive も "All" を投げてくるが、
+		// その時 TrainData の参照は変わっていない。SetTrainData は ObservableCollection
+		// を都度作り直してしまうため、行を完全再描画し、走行フラグもリセットしてしまう
+		// (見た目がチラつく / 描画状態が失われる)。参照同一の時はスキップする。
 		if (changed == VerticalPageStateSection.All)
 		{
-			MainThread.BeginInvokeOnMainThread(() =>
+			var currentTrainData = _presenter.CurrentTrainData;
+			if (!ReferenceEquals(_lastAppliedTrainData, currentTrainData))
 			{
-				TimetableAreaScrollView.ScrollToAsync(0, 0, false);
-				// On phone the inner TimetableAreaScrollView is hidden behind
-				// _phoneOuterScrollView, which is the actual user-facing scroller.
-				// Reset its position too so a Work switch returns the PageHeader
-				// (and the 横型時刻表 button) to the top of the viewport instead
-				// of inheriting the previous Work's scroll offset on a cached
-				// page instance.
-				_phoneOuterScrollView?.ScrollToAsync(0, 0, false);
-			});
-			TimetableView.ViewModel.SetTrainData(_presenter.CurrentTrainData);
-			DebugMap?.SetTimetableRowList(_presenter.CurrentTrainData?.Rows);
+				_lastAppliedTrainData = currentTrainData;
+				MainThread.BeginInvokeOnMainThread(() =>
+				{
+					TimetableAreaScrollView.ScrollToAsync(0, 0, false);
+					// On phone the inner TimetableAreaScrollView is hidden behind
+					// _phoneOuterScrollView, which is the actual user-facing scroller.
+					// Reset its position too so a Work switch returns the PageHeader
+					// (and the 横型時刻表 button) to the top of the viewport instead
+					// of inheriting the previous Work's scroll offset on a cached
+					// page instance.
+					_phoneOuterScrollView?.ScrollToAsync(0, 0, false);
+				});
+				TimetableView.ViewModel.SetTrainData(currentTrainData);
+				DebugMap?.SetTimetableRowList(currentTrainData?.Rows);
+			}
 		}
 	}
 

--- a/TRViS/DTAC/VerticalStylePage.xaml.cs
+++ b/TRViS/DTAC/VerticalStylePage.xaml.cs
@@ -329,16 +329,26 @@ public partial class VerticalStylePage : ContentView
 		}
 
 		// Apply scroll position on All change (train data changed).
-		// 横型時刻表ページから戻った時の OnViewBecameActive も "All" を投げてくるが、
-		// その時 TrainData の参照は変わっていない。SetTrainData は ObservableCollection
-		// を都度作り直してしまうため、行を完全再描画し、走行フラグもリセットしてしまう
-		// (見た目がチラつく / 描画状態が失われる)。参照同一の時はスキップする。
+		// 「列車自体が切り替わったか」は TrainData の参照ではなく Id で判定する。
+		// WebSocket 経由のリアルタイム編集では、同一列車でも CacheTimetableData が
+		// 都度新しい TrainData インスタンスを作る (= 参照は毎回変わる) ため、参照だけで
+		// 判定するとリアルタイム編集のたびに「列車切替扱い」になってスクロール位置が
+		// 先頭に飛んでしまう。Id 一致なら同じ列車として扱い、ユーザーの閲覧位置を維持する。
+		//
+		// SetTrainData 自体は常に呼ぶ。ViewModel 内の TimetableRebuildPolicy が
+		// 「同 Id + 同行数 → field 単位の in-place 更新 (行 UI は dispose しない)」/
+		// 「列車切替 or 行数変化 → 全面再構築」を切り分けるので、ここでは
+		// 「列車自体が切り替わった時だけスクロール位置と DebugMap をリセットする」だけを担う。
 		if (changed == VerticalPageStateSection.All)
 		{
 			var currentTrainData = _presenter.CurrentTrainData;
-			if (!ReferenceEquals(_lastAppliedTrainData, currentTrainData))
+			string? newId = currentTrainData?.Id;
+			string? oldId = _lastAppliedTrainData?.Id;
+			bool isTrainSwitch = !string.Equals(newId, oldId, StringComparison.Ordinal);
+			_lastAppliedTrainData = currentTrainData;
+
+			if (isTrainSwitch)
 			{
-				_lastAppliedTrainData = currentTrainData;
 				MainThread.BeginInvokeOnMainThread(() =>
 				{
 					TimetableAreaScrollView.ScrollToAsync(0, 0, false);
@@ -350,9 +360,10 @@ public partial class VerticalStylePage : ContentView
 					// page instance.
 					_phoneOuterScrollView?.ScrollToAsync(0, 0, false);
 				});
-				TimetableView.ViewModel.SetTrainData(currentTrainData);
-				DebugMap?.SetTimetableRowList(currentTrainData?.Rows);
 			}
+
+			TimetableView.ViewModel.SetTrainData(currentTrainData);
+			DebugMap?.SetTimetableRowList(currentTrainData?.Rows);
 		}
 	}
 

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -5,6 +5,7 @@ using TR.Maui.AnchorPopover;
 using TRViS.DTAC.Adapters;
 using TRViS.DTAC.Logic.Abstractions;
 using TRViS.DTAC.Logic.Presenter;
+using TRViS.IO.Models;
 using TRViS.RootPages;
 using TRViS.Services;
 using TRViS.Utils;
@@ -23,6 +24,10 @@ public partial class ViewHost : ContentPage
 	private readonly ViewHostPresenter _presenter;
 	private readonly DTACViewHostViewModel _dtacViewModel;
 
+#if UI_TEST
+	private AppViewModel? _testAppVm;
+#endif
+
 	public ViewHost()
 	{
 		logger.Trace("Creating...");
@@ -33,6 +38,10 @@ public partial class ViewHost : ContentPage
 			out DTACViewHostViewModel dtacViewModel);
 
 		_dtacViewModel = dtacViewModel;
+
+#if UI_TEST
+		_testAppVm = vm;
+#endif
 
 		_presenter.StateChanged += OnPresenterStateChanged;
 		// ViewHost is a cached ShellContent (DataTemplate) — the same instance is
@@ -83,6 +92,7 @@ public partial class ViewHost : ContentPage
 		AddTestNavigateHomeSeam();
 		AddTestStateSeams();
 		ApplyTestStateSeams(_presenter.CurrentState);
+		AddTestIsInfoRowTransitionSeam();
 #endif
 
 		logger.Trace("Created");
@@ -197,6 +207,62 @@ public partial class ViewHost : ContentPage
 	{
 		_testTitleSeamLabel.Text = TestTitleSeamPrefix + (state.TitleText ?? string.Empty);
 		_testTimeSeamLabel.Text = TestTimeSeamPrefix + (state.TimeLabelText ?? string.Empty);
+	}
+
+	// UI_TEST-only seam: invisible 24×24 button at the top-right of the main content area.
+	// Tapping it modifies the first TimetableRow of the currently selected train from a
+	// station row (IsInfoRow=false) to an info row (IsInfoRow=true), then re-sets
+	// AppViewModel.SelectedTrainData with the modified clone. This exercises the same
+	// WebSocket soft-update code path (same train ID → ApplyPositionAlignedDiff →
+	// ApplyRowToExistingModel → PropertyChanged("IsInfoRow") → UpdateAllComponents).
+	// Used to reproduce and verify the fix for "non-InfoRow components remain visible
+	// after IsInfoRow false→true transition via WebSocket edit".
+	private void AddTestIsInfoRowTransitionSeam()
+	{
+		var seam = new Button
+		{
+			AutomationId = AutomationIdValueForTestIsInfoRowTransition,
+			HorizontalOptions = LayoutOptions.End,
+			VerticalOptions = LayoutOptions.Start,
+			WidthRequest = 24,
+			HeightRequest = 24,
+			BackgroundColor = Colors.Transparent,
+			BorderColor = Colors.Transparent,
+			Padding = 0,
+			Margin = 0,
+		};
+		seam.Clicked += TestIsInfoRowTransitionButton_Clicked;
+		Grid.SetRow(seam, 2);
+		MainGrid.Children.Add(seam);
+	}
+
+	private const string AutomationIdValueForTestIsInfoRowTransition = "DTAC.TestSeedIsInfoRowTransitionButton";
+
+	void TestIsInfoRowTransitionButton_Clicked(object? sender, EventArgs e)
+	{
+		if (_testAppVm?.SelectedTrainData is not TrainData current || current.Rows is not { Length: > 0 } rows)
+			return;
+
+		// Find the first non-InfoRow and change it to IsInfoRow=true.
+		int target = -1;
+		for (int i = 0; i < rows.Length; i++)
+		{
+			if (!rows[i].IsInfoRow)
+			{
+				target = i;
+				break;
+			}
+		}
+		if (target < 0)
+			return;
+
+		TimetableRow[] modified = (TimetableRow[])rows.Clone();
+		modified[target] = rows[target] with { IsInfoRow = true };
+
+		// Re-assign via AppViewModel so the presenter soft-update path is exercised
+		// (same train ID → canSoftUpdate=true → VerticalTimetableViewModel.SetTrainData).
+		_testAppVm.SelectedTrainData = current with { Rows = modified };
+		logger.Debug("TestIsInfoRowTransitionButton: changed row {0} to IsInfoRow=true", target);
 	}
 #endif
 

--- a/TRViS/DTAC/ViewModels/VerticalTimetableRowModel.cs
+++ b/TRViS/DTAC/ViewModels/VerticalTimetableRowModel.cs
@@ -17,6 +17,13 @@ public partial class VerticalTimetableRowModel : ObservableObject, ILocationMark
 	[ObservableProperty]
 	public partial int RowIndex { get; set; } = -1;
 
+	/// <summary>
+	/// この行に対応する <see cref="TimetableRow.Id"/>。WS リアルタイム編集で行が
+	/// 追加・削除された時、index ベースの mutate 更新を当てて良いか
+	/// (= position alignment) を判定するために保持する。表示には使わない。
+	/// </summary>
+	public string? RowId { get; set; }
+
 	[ObservableProperty]
 	public partial bool IsInfoRow { get; set; } = false;
 	[ObservableProperty]

--- a/TRViS/DTAC/ViewModels/VerticalTimetableRowModel.cs
+++ b/TRViS/DTAC/ViewModels/VerticalTimetableRowModel.cs
@@ -1,10 +1,11 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 
+using TRViS.DTAC.Logic;
 using TRViS.IO.Models;
 
 namespace TRViS.DTAC.ViewModels;
 
-public partial class VerticalTimetableRowModel : ObservableObject
+public partial class VerticalTimetableRowModel : ObservableObject, ILocationMarkerHighlightTarget
 {
 	public enum LocationStates
 	{

--- a/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
+++ b/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
@@ -19,6 +19,10 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	// 一貫して管理する。詳細は LocationMarkerRowCoordinator のコメント参照。
 	private readonly LocationMarkerRowCoordinator _markerCoordinator = new();
 
+	// 直近に表示中の Train の Id。SetTrainData が「同じ列車の field 編集」を検知し、
+	// ObservableCollection 差し替えではなく in-place 更新に倒すために使う。
+	private string? _lastTrainId = null;
+
 	[ObservableProperty]
 	public partial ObservableCollection<VerticalTimetableRowModel> CurrentRows { get; set; } = [];
 
@@ -69,34 +73,41 @@ public partial class VerticalTimetableViewModel : ObservableObject
 		=> _markerCoordinator.IsMarkerVisible = value;
 
 	/// <summary>
-	/// Updates timetable view with train data - extracts only display-necessary information
+	/// Updates timetable view with train data - extracts only display-necessary information.
+	///
+	/// 同じ列車 (TrainId 一致 + 行数一致) の更新では、既存の行モデルに対して field 単位で
+	/// 上書きする (= ObservableCollection は触らない)。これにより:
+	///   - 行 UI の dispose / 再生成が発生しない (1 行の DriveTime を直しただけで全行が
+	///     消えて上から再描画される、というユーザー視点の不具合が解消される)
+	///   - スクロール位置・走行フラグ・マーカー被り行の DriveTime 反転色などの View 状態が維持される
+	///   - 値が変わっていない field は ObservableObject の同値ガードで PropertyChanged が
+	///     飛ばないので、本当に変わった行 / 本当に変わった field の UI だけが更新される
+	/// 列車自体が変わった or 行数が変わった場合のみ ObservableCollection を作り直して
+	/// 従来通り全面再構築する。
 	/// </summary>
 	public void SetTrainData(TrainData? trainData)
 	{
-		// Extract and set display information
+		string? newId = trainData?.Id;
+		int newCount = trainData?.Rows?.Length ?? 0;
+
+		if (TimetableRebuildPolicy.CanUpdateInPlace(_lastTrainId, CurrentRows.Count, newId, newCount)
+			&& trainData?.Rows is not null)
+		{
+			for (int i = 0; i < trainData.Rows.Length; i++)
+				ApplyRowToExistingModel(CurrentRows[i], i, trainData.Rows[i]);
+
+			AfterRemarksText = trainData.AfterRemarks;
+			AfterArriveText = trainData.AfterArrive;
+			NextTrainId = trainData.NextTrainId;
+			// CurrentRows 自体は差し替えていないので、IsRunStarted リセットも
+			// marker の再配信も行わない (どちらも UI を巻き戻す方向の副作用なので)。
+			return;
+		}
+
+		// 全面再構築パス。列車切替 / 初回ロード / 行数変化 / 列車解除 のいずれかに該当。
+		_lastTrainId = newId;
 		CurrentRows = new ObservableCollection<VerticalTimetableRowModel>(
-			(trainData?.Rows ?? []).Select((row, index) => new VerticalTimetableRowModel
-			{
-				RowIndex = index,
-				IsInfoRow = row.IsInfoRow,
-				InfoText = row.IsInfoRow ? row.StationName : null,
-				IsMarkingMode = IsMarkingMode,
-				DriveTimeMM = row.DriveTimeMM?.ToString(),
-				DriveTimeSS = row.DriveTimeSS?.ToString(),
-				StationName = row.StationName,
-				IsPass = row.IsPass,
-				ArrivalTime = row.ArriveTime,
-				HasBracket = row.HasBracket,
-				DepartureTime = row.DepartureTime,
-				IsLastStop = row.IsLastStop,
-				IsOperationOnlyStop = row.IsOperationOnlyStop,
-				TrackName = row.TrackName,
-				RunInLimit = row.RunInLimit?.ToString(),
-				RunOutLimit = row.RunOutLimit?.ToString(),
-				Remarks = row.Remarks,
-				MarkerColor = row.DefaultMarkerColor_RGB is not null ? Color.FromRgb((byte)((row.DefaultMarkerColor_RGB >> 16) & 0xFF), (byte)((row.DefaultMarkerColor_RGB >> 8) & 0xFF), (byte)(row.DefaultMarkerColor_RGB & 0xFF)) : null,
-				MarkerText = row.DefaultMarkerText,
-			})
+			(trainData?.Rows ?? []).Select((row, index) => BuildRowModel(index, row))
 		);
 		AfterRemarksText = trainData?.AfterRemarks;
 		AfterArriveText = trainData?.AfterArrive;
@@ -109,4 +120,61 @@ public partial class VerticalTimetableViewModel : ObservableObject
 		// Reset run started state
 		IsRunStarted = false;
 	}
+
+	private VerticalTimetableRowModel BuildRowModel(int index, TimetableRow row)
+		=> new()
+		{
+			RowIndex = index,
+			IsInfoRow = row.IsInfoRow,
+			InfoText = row.IsInfoRow ? row.StationName : null,
+			IsMarkingMode = IsMarkingMode,
+			DriveTimeMM = row.DriveTimeMM?.ToString(),
+			DriveTimeSS = row.DriveTimeSS?.ToString(),
+			StationName = row.StationName,
+			IsPass = row.IsPass,
+			ArrivalTime = row.ArriveTime,
+			HasBracket = row.HasBracket,
+			DepartureTime = row.DepartureTime,
+			IsLastStop = row.IsLastStop,
+			IsOperationOnlyStop = row.IsOperationOnlyStop,
+			TrackName = row.TrackName,
+			RunInLimit = row.RunInLimit?.ToString(),
+			RunOutLimit = row.RunOutLimit?.ToString(),
+			Remarks = row.Remarks,
+			MarkerColor = ToMarkerColor(row.DefaultMarkerColor_RGB),
+			MarkerText = row.DefaultMarkerText,
+		};
+
+	/// <summary>
+	/// 既存の行モデルに field 単位で上書きする。各 setter は <c>ObservableObject</c> の
+	/// 同値ガードで PropertyChanged を抑制するので、変更のあった field の UI だけが更新される。
+	/// <c>IsMarkingMode</c> / <c>IsLocationMarkerOnThisRow</c> は別経路 (toggle / coordinator) で
+	/// 管理されているのでここでは触らない。
+	/// </summary>
+	private static void ApplyRowToExistingModel(VerticalTimetableRowModel model, int index, TimetableRow row)
+	{
+		model.RowIndex = index;
+		model.IsInfoRow = row.IsInfoRow;
+		model.InfoText = row.IsInfoRow ? row.StationName : null;
+		model.DriveTimeMM = row.DriveTimeMM?.ToString();
+		model.DriveTimeSS = row.DriveTimeSS?.ToString();
+		model.StationName = row.StationName;
+		model.IsPass = row.IsPass;
+		model.ArrivalTime = row.ArriveTime;
+		model.HasBracket = row.HasBracket;
+		model.DepartureTime = row.DepartureTime;
+		model.IsLastStop = row.IsLastStop;
+		model.IsOperationOnlyStop = row.IsOperationOnlyStop;
+		model.TrackName = row.TrackName;
+		model.RunInLimit = row.RunInLimit?.ToString();
+		model.RunOutLimit = row.RunOutLimit?.ToString();
+		model.Remarks = row.Remarks;
+		model.MarkerColor = ToMarkerColor(row.DefaultMarkerColor_RGB);
+		model.MarkerText = row.DefaultMarkerText;
+	}
+
+	private static Color? ToMarkerColor(int? rgb)
+		=> rgb is null
+			? null
+			: Color.FromRgb((byte)((rgb >> 16) & 0xFF), (byte)((rgb >> 8) & 0xFF), (byte)(rgb & 0xFF));
 }

--- a/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
+++ b/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
@@ -75,21 +75,19 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	/// <summary>
 	/// Updates timetable view with train data.
 	///
-	/// 同じ列車 (= TrainId 一致) の更新では、ObservableCollection 自体を作り直さず、
-	/// 既存の行モデル列を mutate する形で差分を反映する:
-	///   - 重なっている position (= 既存と新の両方に存在する 0..min(N) -1) は field 上書き。
-	///     ObservableObject の同値ガードにより、本当に変わった field の PropertyChanged だけ
-	///     飛ぶので、変更のあった行 (例: DriveTimeMM を直した 1 行) の UI だけが再描画される。
-	///   - 新規行は末尾に Add (= CollectionChanged.Add)。View 側は incremental に行 UI を 1 つ追加する。
-	///   - 余剰行は末尾から Remove (= CollectionChanged.Remove)。View 側は対応する行 UI を 1 つ捨てる。
+	/// 同じ列車 (= TrainId 一致) の更新では、RowId ベースでモデルインスタンスを再利用しながら
+	/// 差分を反映する (ApplySmartDiff):
+	///   - RowId が一致する行はインスタンスを再利用し、変更フィールドのみ PropertyChanged が
+	///     発火する (= 本当に変わったセルの UI だけが再描画される)。
+	///   - 位置だけが変わった行は RowIndex のみ更新 (= Grid.SetRow の呼び出しだけ)。行 UI の
+	///     dispose/再生成は一切行われない。
+	///   - 新規行は CollectionChanged.Add → View が行 UI を 1 つ追加する。
+	///   - 消えた行は CollectionChanged.Remove → View が対応する行 UI を破棄する。
+	///   - 並び替えは CollectionChanged.Move → View は RowViewList のエントリを組み替えるだけ。
 	/// これにより、行 UI 全体の dispose / 再生成 (= 上から再描画される flash) と、
 	/// 走行中フラグ / スクロール位置 / マーカー被り行ハイライトの View 状態リセットを回避する。
 	///
-	/// ただし「行が中間で挿入・削除された」場合は position が Id でずれるので、上記 mutate を
-	/// 適用すると見た目上 行のデータが横滑り表示されてしまう。RowId による position alignment
-	/// チェックでこれを検出し、ずれた場合のみ ObservableCollection を作り直す fallback に倒す。
-	///
-	/// 列車自体が違う (= 異なる TrainId) / 初回ロード / null クリアの場合も
+	/// 列車自体が違う (= 異なる TrainId) / 初回ロード / null クリアの場合は
 	/// ObservableCollection を作り直す全面再構築になる。
 	/// </summary>
 	public void SetTrainData(TrainData? trainData)
@@ -100,18 +98,14 @@ public partial class VerticalTimetableViewModel : ObservableObject
 			&& TimetableRebuildPolicy.IsSameTrainEdit(_lastTrainId, newId))
 		{
 			TimetableRow[] newRows = trainData.Rows ?? [];
-			if (IsPositionAlignedByRowId(CurrentRows, newRows))
-			{
-				ApplyPositionAlignedDiff(newRows);
-				AfterRemarksText = trainData.AfterRemarks;
-				AfterArriveText = trainData.AfterArrive;
-				NextTrainId = trainData.NextTrainId;
-				// 新規に Add された行は IsLocationMarkerOnThisRow が既定 false で生まれているので、
-				// 保持中のマーカー位置をもう一度全行に分配する。同 index 同値ならば内部で no-op。
-				_markerCoordinator.SetRows(CurrentRows);
-				return;
-			}
-			// position alignment 不一致 (= 中間挿入/削除) は fall-through で全面再構築。
+			ApplySmartDiff(newRows);
+			AfterRemarksText = trainData.AfterRemarks;
+			AfterArriveText = trainData.AfterArrive;
+			NextTrainId = trainData.NextTrainId;
+			// 新規に Add された行は IsLocationMarkerOnThisRow が既定 false で生まれているので、
+			// 保持中のマーカー位置をもう一度全行に分配する。同 index 同値ならば内部で no-op。
+			_markerCoordinator.SetRows(CurrentRows);
+			return;
 		}
 
 		// 全面再構築パス: 列車切替 / 初回ロード / null クリア / 中間挿入/削除のいずれか。
@@ -132,47 +126,92 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	}
 
 	/// <summary>
-	/// 現在の行列と新しい行配列が「同 index に同じ RowId が並ぶ」関係になっているかを返す。
-	/// true なら mutate ベースの差分更新で対応可能 (= 末尾の Add / Remove + field 上書き)。
-	/// false (= 中間挿入や中間削除で position が Id ベースでずれた) なら、ObservableCollection を
-	/// 作り直す全面再構築に倒す必要がある。
+	/// RowId ベースで既存モデルのインスタンスを再利用しながら差分を反映する。
+	///
+	/// - RowId が一致する既存モデルはインスタンスを再利用し、位置変更は RowIndex 更新
+	///   (→ Grid.SetRow のみ) で対応する。フィールドが同じなら PropertyChanged も抑制される。
+	/// - RowId が新しい行はモデルを新規生成 (CollectionChanged.Add → View が行 UI を追加)。
+	/// - RowId が消えた行はモデルを削除 (CollectionChanged.Remove → View が行 UI を破棄)。
+	/// - 位置変更がある場合は ObservableCollection.Move を発火し、View 側は RowViewList の
+	///   エントリだけを組み替える (行 UI の dispose/再生成なし)。
 	/// </summary>
-	private static bool IsPositionAlignedByRowId(
-		IReadOnlyList<VerticalTimetableRowModel> oldRows,
-		TimetableRow[] newRows
-	)
+	private void ApplySmartDiff(TimetableRow[] newRows)
 	{
-		int overlap = Math.Min(oldRows.Count, newRows.Length);
-		for (int i = 0; i < overlap; i++)
+		// Step 1: 既存モデルの RowId → インデックス マップを構築する。
+		var oldIndexById = new Dictionary<string, int>(CurrentRows.Count, StringComparer.Ordinal);
+		for (int i = 0; i < CurrentRows.Count; i++)
 		{
-			if (!string.Equals(oldRows[i].RowId, newRows[i].Id, StringComparison.Ordinal))
-				return false;
+			string? rid = CurrentRows[i].RowId;
+			if (rid is not null)
+				oldIndexById[rid] = i;
 		}
-		return true;
-	}
 
-	/// <summary>
-	/// 同 index 同 RowId の前提のもと、既存行を field 上書き、超過分を末尾 Add、不足分を末尾 Remove する。
-	/// ObservableCollection の Add / Remove は CollectionChanged を発火するため、View 側は incremental
-	/// に対応する行 UI を追加/削除できる (= 全 dispose の flash を回避できる)。
-	/// </summary>
-	private void ApplyPositionAlignedDiff(TimetableRow[] newRows)
-	{
-		int oldCount = CurrentRows.Count;
-		int newCount = newRows.Length;
-		int overlap = Math.Min(oldCount, newCount);
+		// Step 2: 新しい各行について、再利用できる既存モデルを決定する。
+		var finalModels = new List<(VerticalTimetableRowModel model, bool isNew)>(newRows.Length);
+		var usedOldIndices = new HashSet<int>(newRows.Length);
+		for (int i = 0; i < newRows.Length; i++)
+		{
+			if (oldIndexById.TryGetValue(newRows[i].Id, out int oldIdx))
+			{
+				finalModels.Add((CurrentRows[oldIdx], false));
+				usedOldIndices.Add(oldIdx);
+			}
+			else
+			{
+				finalModels.Add((BuildRowModel(i, newRows[i]), true));
+			}
+		}
 
-		// 1. 重なっている position は field 上書き。
-		for (int i = 0; i < overlap; i++)
+		// Step 3: 新しい行リストに存在しない古い行を削除する (後ろから削除して index を安定させる)。
+		for (int i = CurrentRows.Count - 1; i >= 0; i--)
+		{
+			if (!usedOldIndices.Contains(i))
+				CurrentRows.RemoveAt(i);
+		}
+		// 削除後は CurrentRows = [生き残った既存モデル (旧い相対順序を保持)]。
+
+		// Step 4: 新しい順序になるよう Move / Insert を発火しながら CurrentRows を組み替える。
+		// 左から処理する。処理済み位置 0..i-1 には正しいモデルが収まっているため、
+		// 対象モデルは常に CurrentRows[i..] の中に存在する (= currentPos >= i が成立する)。
+		for (int i = 0; i < finalModels.Count; i++)
+		{
+			var (model, isNew) = finalModels[i];
+			if (isNew)
+			{
+				// 新規モデルは正しい位置に挿入する (CollectionChanged.Add → View が行 UI を追加)。
+				if (i >= CurrentRows.Count)
+					CurrentRows.Add(model);
+				else
+					CurrentRows.Insert(i, model);
+			}
+			else
+			{
+				// 既存モデルが既に正しい位置にあれば何もしない。
+				// 異なる位置にいれば Move する (CollectionChanged.Move → View は RowViewList を並び替える)。
+				int currentPos = -1;
+				for (int j = i; j < CurrentRows.Count; j++)
+				{
+					if (ReferenceEquals(CurrentRows[j], model))
+					{
+						currentPos = j;
+						break;
+					}
+				}
+				if (currentPos > i)
+					CurrentRows.Move(currentPos, i);
+				else if (currentPos < 0)
+					logger.Warn("ApplySmartDiff: model at new index {0} (RowId={1}) not found in CurrentRows; likely a duplicate RowId", i, model.RowId);
+			}
+		}
+
+		// Step 5: フィールドを更新する (RowIndex を含む)。
+		// 変更がなければ ObservableObject の同値ガードが PropertyChanged を抑制するため、
+		// 「位置のみ移動」な行の再描画は Grid.SetRow の呼び出しだけになる。
+		// CurrentRows.Count との Min は、重複 RowId など不正データで Step 4 が currentPos=-1 の
+		// ままになった行が存在する場合の IndexOutOfRangeException を防ぐ防御的ガード。
+		int updateCount = Math.Min(newRows.Length, CurrentRows.Count);
+		for (int i = 0; i < updateCount; i++)
 			ApplyRowToExistingModel(CurrentRows[i], i, newRows[i]);
-
-		// 2. 末尾追加 (newCount > oldCount のときだけ実行される)。
-		for (int i = oldCount; i < newCount; i++)
-			CurrentRows.Add(BuildRowModel(i, newRows[i]));
-
-		// 3. 末尾削除 (oldCount > newCount のときだけ実行される)。逆順で index 安定。
-		for (int i = oldCount - 1; i >= newCount; i--)
-			CurrentRows.RemoveAt(i);
 	}
 
 	private VerticalTimetableRowModel BuildRowModel(int index, TimetableRow row)
@@ -204,8 +243,8 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	/// 既存の行モデルに field 単位で上書きする。各 setter は <c>ObservableObject</c> の
 	/// 同値ガードで PropertyChanged を抑制するので、変更のあった field の UI だけが更新される。
 	/// <c>IsMarkingMode</c> / <c>IsLocationMarkerOnThisRow</c> は別経路 (toggle / coordinator) で
-	/// 管理されているのでここでは触らない。<c>RowId</c> は position alignment 判定で使った後の
-	/// 同じ row に当てに行っているはずなので明示的に上書きしない (元から同じ Id)。
+	/// 管理されているのでここでは触らない。<c>RowId</c> は ApplySmartDiff が RowId で
+	/// 既存モデルを引いているため、model.RowId == row.Id が保証されており上書き不要。
 	/// </summary>
 	private static void ApplyRowToExistingModel(VerticalTimetableRowModel model, int index, TimetableRow row)
 	{

--- a/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
+++ b/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
 
+using TRViS.DTAC.Logic;
 using TRViS.IO.Models;
 using TRViS.Services;
 using NLog;
@@ -12,6 +13,11 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	private static readonly Logger logger = LoggerService.GetGeneralLogger();
 
 	public static readonly GridLength RowHeight = new(60);
+
+	// CurrentLocationMarker と重なる行の DriveTime ラベル色 (白文字反転) を、
+	// 行モデル列の差し替え (= SetTrainData) と View 側のマーカー位置更新の双方から
+	// 一貫して管理する。詳細は LocationMarkerRowCoordinator のコメント参照。
+	private readonly LocationMarkerRowCoordinator _markerCoordinator = new();
 
 	[ObservableProperty]
 	public partial ObservableCollection<VerticalTimetableRowModel> CurrentRows { get; set; } = [];
@@ -34,6 +40,20 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	[ObservableProperty]
 	public partial bool IsLocationServiceEnabled { get; set; } = false;
 
+	/// <summary>
+	/// CurrentLocationMarker (現在位置マーカー) が指している行 index。
+	/// View が ApplyPresenterState から書き込む。
+	/// </summary>
+	[ObservableProperty]
+	public partial int MarkerRowIndex { get; set; } = -1;
+
+	/// <summary>
+	/// CurrentLocationMarker を画面に出しているかどうか。
+	/// View が ApplyPresenterState から書き込む。
+	/// </summary>
+	[ObservableProperty]
+	public partial bool IsMarkerVisible { get; set; } = false;
+
 	partial void OnIsMarkingModeChanged(bool value)
 	{
 		foreach (var row in CurrentRows)
@@ -41,6 +61,12 @@ public partial class VerticalTimetableViewModel : ObservableObject
 			row.IsMarkingMode = value;
 		}
 	}
+
+	partial void OnMarkerRowIndexChanged(int value)
+		=> _markerCoordinator.MarkerRowIndex = value;
+
+	partial void OnIsMarkerVisibleChanged(bool value)
+		=> _markerCoordinator.IsMarkerVisible = value;
 
 	/// <summary>
 	/// Updates timetable view with train data - extracts only display-necessary information
@@ -75,6 +101,10 @@ public partial class VerticalTimetableViewModel : ObservableObject
 		AfterRemarksText = trainData?.AfterRemarks;
 		AfterArriveText = trainData?.AfterArrive;
 		NextTrainId = trainData?.NextTrainId;
+
+		// 行モデルが差し替わったので、保持中のマーカー位置を新しい行へ反映する。
+		// (これを忘れると、マーカーが同じ index にあるのに新しい行が黒文字のまま残る)
+		_markerCoordinator.SetRows(CurrentRows);
 
 		// Reset run started state
 		IsRunStarted = false;

--- a/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
+++ b/TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs
@@ -73,38 +73,48 @@ public partial class VerticalTimetableViewModel : ObservableObject
 		=> _markerCoordinator.IsMarkerVisible = value;
 
 	/// <summary>
-	/// Updates timetable view with train data - extracts only display-necessary information.
+	/// Updates timetable view with train data.
 	///
-	/// 同じ列車 (TrainId 一致 + 行数一致) の更新では、既存の行モデルに対して field 単位で
-	/// 上書きする (= ObservableCollection は触らない)。これにより:
-	///   - 行 UI の dispose / 再生成が発生しない (1 行の DriveTime を直しただけで全行が
-	///     消えて上から再描画される、というユーザー視点の不具合が解消される)
-	///   - スクロール位置・走行フラグ・マーカー被り行の DriveTime 反転色などの View 状態が維持される
-	///   - 値が変わっていない field は ObservableObject の同値ガードで PropertyChanged が
-	///     飛ばないので、本当に変わった行 / 本当に変わった field の UI だけが更新される
-	/// 列車自体が変わった or 行数が変わった場合のみ ObservableCollection を作り直して
-	/// 従来通り全面再構築する。
+	/// 同じ列車 (= TrainId 一致) の更新では、ObservableCollection 自体を作り直さず、
+	/// 既存の行モデル列を mutate する形で差分を反映する:
+	///   - 重なっている position (= 既存と新の両方に存在する 0..min(N) -1) は field 上書き。
+	///     ObservableObject の同値ガードにより、本当に変わった field の PropertyChanged だけ
+	///     飛ぶので、変更のあった行 (例: DriveTimeMM を直した 1 行) の UI だけが再描画される。
+	///   - 新規行は末尾に Add (= CollectionChanged.Add)。View 側は incremental に行 UI を 1 つ追加する。
+	///   - 余剰行は末尾から Remove (= CollectionChanged.Remove)。View 側は対応する行 UI を 1 つ捨てる。
+	/// これにより、行 UI 全体の dispose / 再生成 (= 上から再描画される flash) と、
+	/// 走行中フラグ / スクロール位置 / マーカー被り行ハイライトの View 状態リセットを回避する。
+	///
+	/// ただし「行が中間で挿入・削除された」場合は position が Id でずれるので、上記 mutate を
+	/// 適用すると見た目上 行のデータが横滑り表示されてしまう。RowId による position alignment
+	/// チェックでこれを検出し、ずれた場合のみ ObservableCollection を作り直す fallback に倒す。
+	///
+	/// 列車自体が違う (= 異なる TrainId) / 初回ロード / null クリアの場合も
+	/// ObservableCollection を作り直す全面再構築になる。
 	/// </summary>
 	public void SetTrainData(TrainData? trainData)
 	{
 		string? newId = trainData?.Id;
-		int newCount = trainData?.Rows?.Length ?? 0;
 
-		if (TimetableRebuildPolicy.CanUpdateInPlace(_lastTrainId, CurrentRows.Count, newId, newCount)
-			&& trainData?.Rows is not null)
+		if (trainData is not null
+			&& TimetableRebuildPolicy.IsSameTrainEdit(_lastTrainId, newId))
 		{
-			for (int i = 0; i < trainData.Rows.Length; i++)
-				ApplyRowToExistingModel(CurrentRows[i], i, trainData.Rows[i]);
-
-			AfterRemarksText = trainData.AfterRemarks;
-			AfterArriveText = trainData.AfterArrive;
-			NextTrainId = trainData.NextTrainId;
-			// CurrentRows 自体は差し替えていないので、IsRunStarted リセットも
-			// marker の再配信も行わない (どちらも UI を巻き戻す方向の副作用なので)。
-			return;
+			TimetableRow[] newRows = trainData.Rows ?? [];
+			if (IsPositionAlignedByRowId(CurrentRows, newRows))
+			{
+				ApplyPositionAlignedDiff(newRows);
+				AfterRemarksText = trainData.AfterRemarks;
+				AfterArriveText = trainData.AfterArrive;
+				NextTrainId = trainData.NextTrainId;
+				// 新規に Add された行は IsLocationMarkerOnThisRow が既定 false で生まれているので、
+				// 保持中のマーカー位置をもう一度全行に分配する。同 index 同値ならば内部で no-op。
+				_markerCoordinator.SetRows(CurrentRows);
+				return;
+			}
+			// position alignment 不一致 (= 中間挿入/削除) は fall-through で全面再構築。
 		}
 
-		// 全面再構築パス。列車切替 / 初回ロード / 行数変化 / 列車解除 のいずれかに該当。
+		// 全面再構築パス: 列車切替 / 初回ロード / null クリア / 中間挿入/削除のいずれか。
 		_lastTrainId = newId;
 		CurrentRows = new ObservableCollection<VerticalTimetableRowModel>(
 			(trainData?.Rows ?? []).Select((row, index) => BuildRowModel(index, row))
@@ -121,9 +131,54 @@ public partial class VerticalTimetableViewModel : ObservableObject
 		IsRunStarted = false;
 	}
 
+	/// <summary>
+	/// 現在の行列と新しい行配列が「同 index に同じ RowId が並ぶ」関係になっているかを返す。
+	/// true なら mutate ベースの差分更新で対応可能 (= 末尾の Add / Remove + field 上書き)。
+	/// false (= 中間挿入や中間削除で position が Id ベースでずれた) なら、ObservableCollection を
+	/// 作り直す全面再構築に倒す必要がある。
+	/// </summary>
+	private static bool IsPositionAlignedByRowId(
+		IReadOnlyList<VerticalTimetableRowModel> oldRows,
+		TimetableRow[] newRows
+	)
+	{
+		int overlap = Math.Min(oldRows.Count, newRows.Length);
+		for (int i = 0; i < overlap; i++)
+		{
+			if (!string.Equals(oldRows[i].RowId, newRows[i].Id, StringComparison.Ordinal))
+				return false;
+		}
+		return true;
+	}
+
+	/// <summary>
+	/// 同 index 同 RowId の前提のもと、既存行を field 上書き、超過分を末尾 Add、不足分を末尾 Remove する。
+	/// ObservableCollection の Add / Remove は CollectionChanged を発火するため、View 側は incremental
+	/// に対応する行 UI を追加/削除できる (= 全 dispose の flash を回避できる)。
+	/// </summary>
+	private void ApplyPositionAlignedDiff(TimetableRow[] newRows)
+	{
+		int oldCount = CurrentRows.Count;
+		int newCount = newRows.Length;
+		int overlap = Math.Min(oldCount, newCount);
+
+		// 1. 重なっている position は field 上書き。
+		for (int i = 0; i < overlap; i++)
+			ApplyRowToExistingModel(CurrentRows[i], i, newRows[i]);
+
+		// 2. 末尾追加 (newCount > oldCount のときだけ実行される)。
+		for (int i = oldCount; i < newCount; i++)
+			CurrentRows.Add(BuildRowModel(i, newRows[i]));
+
+		// 3. 末尾削除 (oldCount > newCount のときだけ実行される)。逆順で index 安定。
+		for (int i = oldCount - 1; i >= newCount; i--)
+			CurrentRows.RemoveAt(i);
+	}
+
 	private VerticalTimetableRowModel BuildRowModel(int index, TimetableRow row)
 		=> new()
 		{
+			RowId = row.Id,
 			RowIndex = index,
 			IsInfoRow = row.IsInfoRow,
 			InfoText = row.IsInfoRow ? row.StationName : null,
@@ -149,7 +204,8 @@ public partial class VerticalTimetableViewModel : ObservableObject
 	/// 既存の行モデルに field 単位で上書きする。各 setter は <c>ObservableObject</c> の
 	/// 同値ガードで PropertyChanged を抑制するので、変更のあった field の UI だけが更新される。
 	/// <c>IsMarkingMode</c> / <c>IsLocationMarkerOnThisRow</c> は別経路 (toggle / coordinator) で
-	/// 管理されているのでここでは触らない。
+	/// 管理されているのでここでは触らない。<c>RowId</c> は position alignment 判定で使った後の
+	/// 同じ row に当てに行っているはずなので明示的に上書きしない (元から同じ Id)。
 	/// </summary>
 	private static void ApplyRowToExistingModel(VerticalTimetableRowModel model, int index, TimetableRow row)
 	{


### PR DESCRIPTION
## Issueへのリンク

- closes #245 (WebSocketからデータ受信時、全部が更新されるほか、運行中でも運行前状態に戻されてしまう)
- 加えて、ユーザー指摘の派生不具合 2 件を同 PR で対応:
  - 横型時刻表ページに行って帰ってくると `TimetableRow` が全て再描画される
  - `CurrentLocationMarker` と同じ位置に重なった `DriveTime` ラベルが、マーカーが同じ位置に再描画されたとき黒文字のままになる

## 実装した機能の説明

WebSocket 経由のリアルタイム編集や、画面遷移・横型時刻表往復の最中でも、運行中の状態 (現在駅 index / 走行フラグ / 行描画 / マーカー被り行の文字色) が意図せず巻き戻ったりチラついたりしないようにする。

### 1. WebSocket Timetable 更新で運行中状態が巻き戻る (#245)

[TRViS.NetworkSyncService/NetworkSyncServiceBase.cs](TRViS.NetworkSyncService/NetworkSyncServiceBase.cs) :

- `Scope.All` 受信時のリセットを「無条件」から「現在追跡中の `TrainId` が新ペイロードに残っていない場合のみ」に変更。
  - `protected virtual bool IsCurrentTrainStillTracked()` フックを追加し、[WebSocketNetworkSyncService](TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs) で `_TrainDataCache.ContainsKey(TrainId)` を返すように override。`RaiseTimetableUpdated` は `CacheTimetableData` の後に呼ばれるため、ここでチェックするキャッシュは新ペイロード反映済み。
- `StaLocationInfo` setter を「current 駅 (Location_m) を新配列で検索し、index を再計算」する実装に変更。
  - 前駅削除なら index は自動的に繰り上がり、走行フラグも維持される。
  - 現在駅自体が消えた場合は従来通りリセット。
  - 駅 index が変わらないケースでは余計な `LocationStateChanged` を抑制。

### 2. 横型時刻表ページから戻ったときの全行再描画

[TRViS/DTAC/VerticalStylePage.xaml.cs](TRViS/DTAC/VerticalStylePage.xaml.cs) :

- `Shell.Current.Navigated` ハンドラが毎回 `VerticalStylePageView.OnViewBecameActive()` → `ApplyPresenterState(All)` → 無条件の `TimetableView.ViewModel.SetTrainData(...)` を呼んでおり、`ObservableCollection` が都度作り直されることで行 UI が完全再構築されていた (`IsRunStarted` も `SetTrainData` 内でリセットされる副作用つき)。
- `_lastAppliedTrainData` を保持し、`_presenter.CurrentTrainData` の参照が変わったときだけ再構築・スクロールリセットを行う。実列車切替時は presenter 側で参照が新インスタンスに置き換わるので従来通り再構築される。

### 3. マーカー被り行の `DriveTime` ラベルが黒文字のまま残る

旧 View 実装は `ApplyPresenterState` 内で `RowViewList[i].Model.IsLocationMarkerOnThisRow = ...` を for-loop で同期適用していたが、`SetRowViewsAsync` は async で行リストを後から差し替えるため、for-loop は廃棄予定の古い行に flag を書き、新行は初期値 `false` のまま残るレースになっていた (新行コンストラクタ `UpdateDriveTimeTextColor()` 時点で flag=false → 黒文字。マーカー位置が変わらないので後続の再適用も走らない)。

修正:

- [TRViS.DTAC.Logic/LocationMarkerRowCoordinator.cs](TRViS.DTAC.Logic/LocationMarkerRowCoordinator.cs) を新設。`MarkerRowIndex` / `IsMarkerVisible` / `SetRows()` のどれが変わっても必ず `IsLocationMarkerOnThisRow` を再適用する純ロジッククラス。
- [VerticalTimetableRowModel](TRViS/DTAC/ViewModels/VerticalTimetableRowModel.cs) を `ILocationMarkerHighlightTarget` 実装に。
- [VerticalTimetableViewModel](TRViS/DTAC/ViewModels/VerticalTimetableViewModel.cs) に coordinator を持たせ、`SetTrainData` 末尾で `_markerCoordinator.SetRows(CurrentRows)` を呼ぶことで、新行が出来た瞬間に flag が反映された状態にする。
- [VerticalTimetableView.ApplyPresenterState](TRViS/DTAC/TimetableParts/VerticalTimetableView.cs) の for-loop を廃止し、`ViewModel.MarkerRowIndex` / `IsMarkerVisible` への代入に置き換え。

## 仕様の説明

### Scope.All 受信時の動作 (#245)

| 状況 | 動作 |
| --- | --- |
| `TrainId` 未選択 | 従来通り `(0, false)` にリセット |
| 現在の `TrainId` が新ペイロードに残っている (運行中の編集など) | 駅 index / 走行フラグを維持 |
| 現在の `TrainId` が新ペイロードから消えた (列車削除など) | 駅 index リセット |

### `StaLocationInfo` 差し替え時の駅 index 再計算

| 旧配列の current 駅 (`Location_m`) を新配列で検索 | 動作 |
| --- | --- |
| 見つかった (同じ Location_m) | 新 index に追従、走行フラグ維持 (前駅削除/後駅追加の編集に追従) |
| 見つからない | `(0, false)` にリセット |

`newIndex == oldIndex` のケースでは `LocationStateChanged` を発火しない。

### 横型時刻表ページから戻ったとき

`_presenter.CurrentTrainData` の参照が前回と同じ → 行再構築・スクロールリセットをスキップ。`SectionState` の他フィールド (PageHeader / TrainInfo / Destination 等) は通常通り適用される。

### `CurrentLocationMarker` 被り行の `DriveTime` ラベル色

`ViewModel.MarkerRowIndex` / `ViewModel.IsMarkerVisible` のいずれかの代入、または `CurrentRows` の差し替え (= `SetTrainData`) のたびに、coordinator が現在のマーカー状態を全行へ再適用する。これにより:

- 横型時刻表ページから戻った後でもマーカー被り行は白文字で描画される。
- WebSocket でリアルタイム編集して行が差し替わってもマーカー被り行の色が維持される。
- マーカー index がそのままで行構造だけ変わっても確実に追従する。

## テスト

| Suite | 件数 | 備考 |
| --- | --- | --- |
| `TRViS.NetworkSyncService.IntegrationTests` | 81 (+6 新規) | #245 / 駅 index 再計算 |
| `TRViS.DTAC.Logic.Tests` | 205 (+8 新規) | `LocationMarkerRowCoordinator` |
| `TRViS.Core.Tests` | 22 | 既存通過 |
| `TRViS.IO.Tests` | 49 | 既存通過 |
| `TRViS.TimetableService.Tests` | 10 | 既存通過 |
| `TRViS.LocationService.Tests` | 24 | 既存通過 |

新規追加した代表的テスト:

- `Timetable_AllScopeUpdate_PreservesLocationStateWhenCurrentTrainStillExists` — 修正前は失敗することを確認済み。
- `Timetable_AllScopeUpdate_ResetsLocationStateWhenCurrentTrainGone` / `…_WhenNoTrainSelected`
- `StaLocationInfo_StationBeforeCurrentRemoved_ShiftsIndexUp` — ご指摘ケース (前駅削除で index が繰り上がる)
- `StaLocationInfo_StationAfterCurrentRemoved_PreservesIndex` / `…_CurrentStationRemoved_ResetsLocationInfo`
- `LocationMarkerRowCoordinatorTests.SetRows_ReplacingRowsWhileMarkerStaysAtSameIndex_HighlightsNewRow` — 本 PR 第 3 項の核心。
- `LocationMarkerRowCoordinatorTests.DemonstrateBug_LegacyApplyOnceThenReplaceRows_NewRowsNotHighlighted` — 旧 for-loop 実装を inline 関数で再現し、新行に flag が立たないことをコードで明示するデモテスト。

## 将来的にやりたいこと

- `StaLocationInfo` の照合キーを `Location_m` 一致のみで判定しているが、`Location_m` が NaN になり得る運用に備えて緯度経度フォールバックを足してもよい (現状は NaN なら fall through で reset)。
- `_lastAppliedTrainData` の参照同一性に頼っている再描画スキップは、`Refresh()` 系で同じ Id の新インスタンスが来るケースでは効かない。`SelectedTrainData` の Id 同値判定や差分検出を入れると、WS 経由のリアルタイム編集時も無駄な行リセットを避けられる。

## スクリーンショット

該当なし (修正は描画・状態管理ロジックのみ。動作確認は単体・統合テストで実施)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)