### PR TITLE
feat: auto-select timetable on single-WorkGroup / server loads

### DIFF
--- a/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
+++ b/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
@@ -173,19 +173,37 @@ public class TimetableSelectionManagerTests
 	}
 
 	[Fact]
-	public void OnLoaderChanged_DoesNotAutoSelectFirstWorkGroup()
+	public void OnLoaderChanged_DoesNotAutoSelectFirstWorkGroup_WhenMultipleWorkGroups()
 	{
-		// #224 — OnLoaderChanged は auto-pick せず、選択を null にする。
-		// ホーム画面の tentative-selection 設計に合わせた契約。
+		// #224 の契約は「実際に選択肢がある (WorkGroup が 2 個以上)」場合に限り維持。
+		// 複数 WorkGroup ではホーム画面の tentative-selection picker を見せたいので
+		// auto-pick しない。単一 WorkGroup の場合は下のテストの通り自動選択する。
 		var loader = new FakeLoader();
-		loader.Setup(BuildSampleData());
+		loader.Setup(BuildMultiWgSampleData());
 
 		var manager = new TimetableSelectionManager { Loader = loader };
 
-		Assert.NotEmpty(manager.WorkGroupList!);
+		Assert.True(manager.WorkGroupList!.Count >= 2);
 		Assert.Null(manager.SelectedWorkGroup);
 		Assert.Null(manager.SelectedWork);
 		Assert.Null(manager.SelectedTrainData);
+	}
+
+	[Fact]
+	public void OnLoaderChanged_AutoSelectsWhenSingleWorkGroup()
+	{
+		// 単一 WorkGroup のときは #224 の auto-pick 抑止をスコープ付きで巻き戻す:
+		// 1 項目だけの picker は摩擦でしかないため即コミットし、cascade で
+		// 先頭 Work / 先頭 Train まで自動選択して時刻表を即表示できる状態にする。
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData()); // BuildSampleData は WorkGroup 1 個構成
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+
+		Assert.Single(manager.WorkGroupList!);
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-0", manager.SelectedWork?.Id);     // cascade: 先頭 Work
+		Assert.Equal("t-1-0-0", manager.SelectedTrainData?.Id); // cascade: 先頭 Train
 	}
 
 	[Fact]
@@ -194,8 +212,10 @@ public class TimetableSelectionManagerTests
 		// #224 — Refresh は「すでにコミット済み」のときだけフォールバックする。
 		// 未コミット状態 (Home picker 上で何も選んでいない) で WebSocket Refresh が
 		// 飛んできても勝手に最初の項目を選んではならない。
+		// 単一 WorkGroup は OnLoaderChanged 時点で自動コミットされてしまうため、
+		// 「未コミット」状態を作るには複数 WorkGroup の構成が必要。
 		var loader = new FakeLoader();
-		loader.Setup(BuildSampleData());
+		loader.Setup(BuildMultiWgSampleData());
 
 		var manager = new TimetableSelectionManager { Loader = loader };
 		Assert.Null(manager.SelectedWorkGroup);
@@ -268,6 +288,24 @@ public class TimetableSelectionManagerTests
 		foreach (var workTrains in d.TrainListsByWorkId.Values)
 			foreach (var t in workTrains)
 				d.TrainDataById[t.Id] = t;
+		return d;
+	}
+
+	/// <summary>
+	/// 2 個以上の WorkGroup を持つ構成。OnLoaderChanged の単一 WorkGroup
+	/// auto-select が発火しないため、「未コミット (= ユーザーが picker で
+	/// 未選択)」の契約を検証するテストで使う。
+	/// </summary>
+	private static SampleData BuildMultiWgSampleData()
+	{
+		var d = BuildSampleData();
+		d.WorkGroups.Add(new WorkGroup("wg-2", "WG2"));
+		d.WorkLists["wg-2"] =
+		[
+			new Work("w-2-0", "wg-2", "Work2-0"),
+		];
+		d.TrainListsByWorkId["w-2-0"] = [SimpleTrain("t-2-0-0")];
+		d.TrainDataById["t-2-0-0"] = d.TrainListsByWorkId["w-2-0"][0];
 		return d;
 	}
 

--- a/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
+++ b/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
@@ -207,6 +207,26 @@ public class TimetableSelectionManagerTests
 	}
 
 	[Fact]
+	public void OnLoaderChanged_SingleWorkGroup_CascadeThrows_LoadStillSucceeds()
+	{
+		// 不完全なソース (WorkGroup 行はあるが Work テーブルが無い SQLite 等):
+		// 単一 WG 自動選択の cascade で GetWorkList が例外を投げても、Loader 設定
+		// 自体は失敗してはならない (= auto-pick 導入前と同じく「開けて WG ピッカー
+		// 表示」まで成功する)。選択は巻き戻り null、WorkGroupList は維持される。
+		var loader = new FakeLoader { ThrowOnGetWorkList = true };
+		loader.Setup(BuildSampleData()); // WorkGroup 1 個
+
+		// コンストラクタ内の Loader 設定 (= OnLoaderChanged) が例外を伝播しない
+		var manager = new TimetableSelectionManager { Loader = loader };
+
+		Assert.Single(manager.WorkGroupList!);          // 一覧は読めている
+		Assert.Null(manager.SelectedWorkGroup);         // auto-pick はロールバック
+		Assert.Null(manager.SelectedWork);
+		Assert.Null(manager.SelectedTrainData);
+		Assert.Null(manager.WorkList);
+	}
+
+	[Fact]
 	public void Refresh_DoesNotAutoCommit_WhenNoPriorSelection()
 	{
 		// #224 — Refresh は「すでにコミット済み」のときだけフォールバックする。
@@ -327,10 +347,18 @@ public class TimetableSelectionManagerTests
 		public TrainData? GetTrainData(string trainId) =>
 			TrainDataById.TryGetValue(trainId, out var t) ? t : null;
 
+		/// <summary>
+		/// Simulates a malformed/partial source (e.g. SQLite with a WorkGroup
+		/// row but no Work table): GetWorkGroupList works, GetWorkList throws.
+		/// </summary>
+		public bool ThrowOnGetWorkList { get; set; }
+
 		public IReadOnlyList<WorkGroup> GetWorkGroupList() => WorkGroups;
 
 		public IReadOnlyList<Work> GetWorkList(string workGroupId) =>
-			WorkLists.TryGetValue(workGroupId, out var list) ? list : [];
+			ThrowOnGetWorkList
+				? throw new InvalidOperationException("no such table: Work")
+				: WorkLists.TryGetValue(workGroupId, out var list) ? list : [];
 
 		public IReadOnlyList<TrainData> GetTrainDataList(string workId) =>
 			TrainListsByWorkId.TryGetValue(workId, out var list) ? list : [];

--- a/TRViS.Core/TimetableSelectionManager.cs
+++ b/TRViS.Core/TimetableSelectionManager.cs
@@ -124,7 +124,30 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		WorkGroupList = loader?.GetWorkGroupList();
 
 		if (WorkGroupList?.Count == 1)
-			SelectedWorkGroup = WorkGroupList[0];
+		{
+			// Auto-select is a convenience, never a load requirement. Committing
+			// the WorkGroup cascades into loader.GetWorkList / GetTrainDataList;
+			// on a malformed or partial source (e.g. a SQLite DB that has a
+			// WorkGroup row but no Work table yet) those throw. Before this
+			// auto-pick existed, opening such a source still succeeded and just
+			// showed the WorkGroup picker — so a cascade failure must roll back
+			// to that exact state, not bubble up and fail the whole load.
+			try
+			{
+				SelectedWorkGroup = WorkGroupList[0];
+			}
+			catch
+			{
+				_selectedWorkGroup = null;
+				_selectedWork = null;
+				_selectedTrainData = null;
+				WorkList = null;
+				OrderedTrainDataList = null;
+				RaisePropertyChanged(nameof(SelectedWorkGroup));
+				RaisePropertyChanged(nameof(SelectedWork));
+				RaisePropertyChanged(nameof(SelectedTrainData));
+			}
+		}
 	}
 
 	/// <summary>

--- a/TRViS.Core/TimetableSelectionManager.cs
+++ b/TRViS.Core/TimetableSelectionManager.cs
@@ -105,10 +105,14 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 
 	private void OnLoaderChanged(ILoader? loader)
 	{
-		// Selection is intentionally cleared rather than auto-picking the first
-		// WorkGroup. The Home page presents a tentative-selection picker; the
-		// committed selection on this manager only changes when the user presses
-		// "Open" (StartHomePage) or via Refresh() (websocket flows).
+		// When there is a *real* choice (2+ WorkGroups) selection is intentionally
+		// cleared rather than auto-picking the first one: the Home page presents a
+		// tentative-selection picker and the committed selection only changes when
+		// the user presses "Open" (StartHomePage) or via Refresh() (websocket flows).
+		// This was the #224 contract. The single-WorkGroup case below is a scoped
+		// re-introduction of the pre-#224 auto-pick: a one-item picker is pure
+		// friction, so commit it straight away (the cascade then picks the first
+		// Work and Train, so the timetable is ready without any user taps).
 		_selectedWorkGroup = null;
 		_selectedWork = null;
 		_selectedTrainData = null;
@@ -118,7 +122,9 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		RaisePropertyChanged(nameof(SelectedWork));
 		RaisePropertyChanged(nameof(SelectedTrainData));
 		WorkGroupList = loader?.GetWorkGroupList();
-		// (intentional: no SelectedWorkGroup auto-pick — see comment above)
+
+		if (WorkGroupList?.Count == 1)
+			SelectedWorkGroup = WorkGroupList[0];
 	}
 
 	/// <summary>

--- a/TRViS/RootPages/HomeGridView.xaml.cs
+++ b/TRViS/RootPages/HomeGridView.xaml.cs
@@ -420,6 +420,15 @@ public partial class HomeGridView : Grid
 			// Work list for the new group.
 			_pendingWork = null;
 			RebuildWorkItems();
+			// Symmetric with the single-WorkGroup auto-select in
+			// TimetableSelectionManager: a Work list with exactly one entry is a
+			// no-choice step, so auto-pick it here too — the user goes straight
+			// to 開く instead of tapping a one-item list. (The committed-state and
+			// single-WG load paths already get the only Work via
+			// TimetableSelectionManager.OnWorkGroupChanged; this covers the
+			// remaining gap: manually picking a WG in the multi-WG picker.)
+			if (_workItems.Count == 1)
+				_pendingWork = _workItems[0].Source;
 			SyncListViewSelections();
 			RefreshStepUi();
 		}

--- a/TRViS/RootPages/StartHomePage.xaml.cs
+++ b/TRViS/RootPages/StartHomePage.xaml.cs
@@ -643,33 +643,31 @@ public partial class StartHomePage : ContentPage
 		viewModel.AutoNavigateToTimetableRequested -= OnAutoNavigateToTimetableRequested;
 	}
 
-	// Set when AppViewModel raises AutoNavigateToTimetableRequested (HTTP /
-	// WebSocket TRViS.LocalServers load). Consumed either immediately (deep-link
-	// path: we're already foreground, no modal) or on the next OnAppearing
-	// (ConnectServerDialog path: the dialog modal is still up when the event
-	// fires, so we wait for it to pop). Fail-safe: if neither path consumes it,
-	// the user simply stays on Home — no crash.
-	bool _pendingAutoNavigateToTimetable;
-
+	// The pending intent is latched on AppViewModel (not a field here): a
+	// cold-start deeplink can raise it before this page subscribes, so the
+	// subscriber must not own the state. We consume it on the live event (warm
+	// path: already subscribed → immediate) AND on every OnAppearing (cold-start
+	// race, and the ConnectServerDialog-modal path where the event fires while
+	// the dialog is still up). Fail-safe: if nothing consumes it the user just
+	// stays on Home — no crash.
 	void OnAutoNavigateToTimetableRequested(object? sender, EventArgs e)
 	{
-		_pendingAutoNavigateToTimetable = true;
 		// Hop to the UI thread (the event may be raised from an off-thread WS
 		// callback) and try now; if a modal is still up this no-ops and the
-		// pending flag is consumed by the next OnAppearing instead.
+		// latched flag is consumed by the next OnAppearing instead.
 		MainThread.BeginInvokeOnMainThread(async () => await TryConsumeAutoNavigateAsync());
 	}
 
 	async Task TryConsumeAutoNavigateAsync()
 	{
-		if (!_pendingAutoNavigateToTimetable)
+		if (!viewModel.AutoNavigateToTimetablePending)
 			return;
 		// Don't navigate while a modal (e.g. ConnectServerDialog) is still on the
 		// stack — Shell.GoToAsync underneath a modal is ill-defined. Leave the
-		// flag set; OnAppearing retries once the modal pops and reveals us.
+		// flag latched; OnAppearing retries once the modal pops and reveals us.
 		if ((Shell.Current?.Navigation?.ModalStack?.Count ?? 0) > 0)
 			return;
-		_pendingAutoNavigateToTimetable = false;
+		viewModel.ConsumeAutoNavigateToTimetablePending();
 		await HomeGridView.NavigateToDTACAsync();
 	}
 

--- a/TRViS/RootPages/StartHomePage.xaml.cs
+++ b/TRViS/RootPages/StartHomePage.xaml.cs
@@ -609,6 +609,8 @@ public partial class StartHomePage : ContentPage
 		// unsubscribe — avoids accumulating handlers if Shell recreates the page.
 		viewModel.PropertyChanged -= OnViewModelPropertyChanged;
 		viewModel.PropertyChanged += OnViewModelPropertyChanged;
+		viewModel.AutoNavigateToTimetableRequested -= OnAutoNavigateToTimetableRequested;
+		viewModel.AutoNavigateToTimetableRequested += OnAutoNavigateToTimetableRequested;
 
 		UpdatePrivacyDependentControls();
 
@@ -627,12 +629,48 @@ public partial class StartHomePage : ContentPage
 		// here. The user opens files explicitly via the "ファイルを選択" button
 		// (SelectFileDialog) or via a `trvis://app/open/json?local=…` AppLink.
 		await ApplyModeForCurrentLoaderAsync();
+
+		// A server-driven load that fired while the ConnectServerDialog modal was
+		// still up could not navigate then; this OnAppearing (after the modal
+		// popped and revealed us) is where that deferred jump finally runs.
+		await TryConsumeAutoNavigateAsync();
 	}
 
 	protected override void OnDisappearing()
 	{
 		base.OnDisappearing();
 		viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+		viewModel.AutoNavigateToTimetableRequested -= OnAutoNavigateToTimetableRequested;
+	}
+
+	// Set when AppViewModel raises AutoNavigateToTimetableRequested (HTTP /
+	// WebSocket TRViS.LocalServers load). Consumed either immediately (deep-link
+	// path: we're already foreground, no modal) or on the next OnAppearing
+	// (ConnectServerDialog path: the dialog modal is still up when the event
+	// fires, so we wait for it to pop). Fail-safe: if neither path consumes it,
+	// the user simply stays on Home — no crash.
+	bool _pendingAutoNavigateToTimetable;
+
+	void OnAutoNavigateToTimetableRequested(object? sender, EventArgs e)
+	{
+		_pendingAutoNavigateToTimetable = true;
+		// Hop to the UI thread (the event may be raised from an off-thread WS
+		// callback) and try now; if a modal is still up this no-ops and the
+		// pending flag is consumed by the next OnAppearing instead.
+		MainThread.BeginInvokeOnMainThread(async () => await TryConsumeAutoNavigateAsync());
+	}
+
+	async Task TryConsumeAutoNavigateAsync()
+	{
+		if (!_pendingAutoNavigateToTimetable)
+			return;
+		// Don't navigate while a modal (e.g. ConnectServerDialog) is still on the
+		// stack — Shell.GoToAsync underneath a modal is ill-defined. Leave the
+		// flag set; OnAppearing retries once the modal pops and reveals us.
+		if ((Shell.Current?.Navigation?.ModalStack?.Count ?? 0) > 0)
+			return;
+		_pendingAutoNavigateToTimetable = false;
+		await HomeGridView.NavigateToDTACAsync();
 	}
 
 	void UpdatePrivacyDependentControls()

--- a/TRViS/Utils/SelectFileDialogTestSeams.cs
+++ b/TRViS/Utils/SelectFileDialogTestSeams.cs
@@ -34,15 +34,25 @@ internal static class SelectFileDialogTestSeams
 	public const string BrowseFallbackFileName = "ui-test-browse-fallback.json";
 
 	/// <summary>
-	/// Minimal-but-non-empty WorkGroup payload. One WorkGroup, one Work, no
-	/// Trains. LoaderJson accepts this and the resulting Loader exposes a
+	/// Minimal-but-non-empty WorkGroup payload. TWO WorkGroups (each one Work,
+	/// no Trains). LoaderJson accepts this and the resulting Loader exposes a
 	/// non-empty WorkGroupList — the load-success test asserts against that
 	/// instead of just modal dismiss, so an "always returns true" regression
 	/// in TryLoadFileAsync would still fail the test.
+	///
+	/// Two WorkGroups (not one) on purpose: TimetableSelectionManager auto-
+	/// commits a *single* WorkGroup on load (zero-friction for the common
+	/// 1-WG case), which makes the Home picker skip the WorkGroup-list step.
+	/// These SelectFileDialog tests assert the post-load picker via
+	/// IsWorkGroupListVisible, so they need a multi-WG fixture to keep the
+	/// list step on screen. Single-WG auto-select itself is covered by
+	/// TimetableSelectionManagerTests.OnLoaderChanged_AutoSelectsWhenSingleWorkGroup.
 	/// </summary>
 	private const string FixtureJson =
 		"[{\"Id\":\"ui-test-wg\",\"Name\":\"UITest WG\",\"Works\":[" +
-		"{\"Id\":\"ui-test-work\",\"Name\":\"UITest Work\",\"AffectDate\":\"20260101\",\"Trains\":[]}]}]";
+		"{\"Id\":\"ui-test-work\",\"Name\":\"UITest Work\",\"AffectDate\":\"20260101\",\"Trains\":[]}]}," +
+		"{\"Id\":\"ui-test-wg2\",\"Name\":\"UITest WG2\",\"Works\":[" +
+		"{\"Id\":\"ui-test-work2\",\"Name\":\"UITest Work2\",\"AffectDate\":\"20260101\",\"Trains\":[]}]}]";
 
 	/// <summary>
 	/// Writes the canonical SelectFileDialog fixture into TimetableFileDirectory:

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -191,6 +191,18 @@ public partial class AppViewModel
 		lastLoader?.Dispose();
 		logger.Debug("Last Loader Disposed");
 
+		// HTTP(S) integration (TRViS.LocalServers): the user explicitly pointed the
+		// app at a server to show its timetable, so skip the Home picker entirely.
+		// SelectionManager.OnLoaderChanged already auto-committed when there was a
+		// single WorkGroup; force the first one here for the multi-WorkGroup case
+		// so a timetable is always ready, then ask the UI to jump to it.
+		if (appLinkInfo.ResourceUri?.Scheme is "http" or "https")
+		{
+			if (SelectionManager.SelectedWorkGroup is null)
+				SelectionManager.SelectedWorkGroup = SelectionManager.WorkGroupList?.FirstOrDefault();
+			RequestAutoNavigateToTimetable();
+		}
+
 		// 履歴に追加（HTTPSのURLまたはAppLink）
 		string? historyEntry = addToHistory ? (decodedUrl ?? appLinkString) : null;
 		if (historyEntry is not null)
@@ -276,6 +288,15 @@ public partial class AppViewModel
 			logger.Debug("Last Loader Disposed");
 
 			InstanceManager.LocationService.SetNetworkSyncService(service);
+
+			// WebSocket is a server-driven integration: jump straight to the
+			// timetable. WorkGroup data may still be arriving via server push, so
+			// the selection is best-effort here (SelectionManager.OnLoaderChanged
+			// already auto-committed if a single WorkGroup was present); the
+			// server's SelectTrain push refines it afterwards regardless.
+			if (SelectionManager.SelectedWorkGroup is null)
+				SelectionManager.SelectedWorkGroup = SelectionManager.WorkGroupList?.FirstOrDefault();
+			RequestAutoNavigateToTimetable();
 
 			// WebSocketのAppLinkを履歴に追加
 			if (addToHistory && originalAppLink is not null)

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -37,6 +37,20 @@ public partial class AppViewModel : ObservableObject
 		Loader = loader;
 	}
 
+	/// <summary>
+	/// Raised after a server-driven load (HTTP / WebSocket TRViS.LocalServers
+	/// integration) has set the loader and committed a WorkGroup selection, to
+	/// request that the UI jump straight to the timetable instead of leaving the
+	/// user on the Home picker. StartHomePage subscribes and performs the actual
+	/// navigation (it owns navigation + modal lifecycle; raising an event here
+	/// avoids doing Shell navigation from the AppLink handler while the
+	/// ConnectServerDialog modal may still be on the stack).
+	/// </summary>
+	public event EventHandler? AutoNavigateToTimetableRequested;
+
+	internal void RequestAutoNavigateToTimetable()
+		=> AutoNavigateToTimetableRequested?.Invoke(this, EventArgs.Empty);
+
 	public IReadOnlyList<WorkGroup>? WorkGroupList => SelectionManager.WorkGroupList;
 	public IReadOnlyList<Work>? WorkList => SelectionManager.WorkList;
 	public IReadOnlyList<TrainData>? OrderedTrainDataList => SelectionManager.OrderedTrainDataList;

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -48,8 +48,29 @@ public partial class AppViewModel : ObservableObject
 	/// </summary>
 	public event EventHandler? AutoNavigateToTimetableRequested;
 
+	/// <summary>
+	/// Latched intent backing <see cref="AutoNavigateToTimetableRequested"/>.
+	/// The event alone is fire-and-forget: a cold-start deeplink
+	/// (App handles a <c>trvis://…path=http…</c> AppLink while Shell is still
+	/// navigating to StartHomePage) can raise the request before StartHomePage
+	/// has subscribed, losing it and stranding the user on the Home picker.
+	/// AppViewModel always exists, so the intent is stored here and StartHomePage
+	/// also consumes it on OnAppearing — covering the race regardless of
+	/// subscribe-vs-raise ordering.
+	/// </summary>
+	public bool AutoNavigateToTimetablePending { get; private set; }
+
+	public void ConsumeAutoNavigateToTimetablePending()
+		=> AutoNavigateToTimetablePending = false;
+
 	internal void RequestAutoNavigateToTimetable()
-		=> AutoNavigateToTimetableRequested?.Invoke(this, EventArgs.Empty);
+	{
+		AutoNavigateToTimetablePending = true;
+		// Still raise the event for the warm path (StartHomePage already
+		// subscribed) so navigation happens immediately rather than waiting
+		// for the next OnAppearing.
+		AutoNavigateToTimetableRequested?.Invoke(this, EventArgs.Empty);
+	}
 
 	public IReadOnlyList<WorkGroup>? WorkGroupList => SelectionManager.WorkGroupList;
 	public IReadOnlyList<Work>? WorkList => SelectionManager.WorkList;


### PR DESCRIPTION
## 背景 / Why

「HTTP連携 (TRViS.LocalServers) が動作しなくなった」報告の有力な一因は、データは読み込めても **時刻表が自動選択されず Home picker で止まる**ため「何も起きない＝動かない」ように見えること（#224 で意図的に導入された tentative-picker 設計とのミスマッチ）。本PRはその摩擦を、スコープを絞って解消する。

> 元報告の確定的な再現環境は無いため「有力な改善」であり断定ではない。別途 [fix/http-localservers-204](https://github.com/TetsuOtter/TRViS/pull/new/fix/http-localservers-204) で 204/空ボディの分かりにくいエラーも改善済み（本PRとは独立）。

## 変更 / What

- **要件A — HTTP/WebSocket 連携時は時刻表へ自動遷移**: `http(s)`/`ws(s)` ロード成功時、未選択なら先頭 WorkGroup を強制選択し `AppViewModel.AutoNavigateToTimetableRequested` を発火。`StartHomePage` が購読し DTAC へ遷移（`ConnectServerDialog` モーダルが残る間は遷移せず、pop 後の `OnAppearing` で消化）。
- **要件B — 単一 WorkGroup は自動選択**: `TimetableSelectionManager.OnLoaderChanged` で `WorkGroupList.Count == 1` のとき即コミット（cascade で先頭 Work/Train まで自動選択）。#224 以前の auto-pick をスコープ付きで部分復活。「1 Work」はWGコミット時に既存 cascade が唯一のWorkを自動選択するため自動充足。
- **堅牢性**: 自動選択 cascade（`GetWorkList`/`GetTrainDataList`）が不完全ソース（WorkGroup行のみで Work テーブル無しの SQLite 等）で例外を投げても、**ロード自体は従来どおり成功**するよう例外安全化（失敗時は選択なし状態へロールバック＝auto-pick 導入前と同一）。

## 設計境界（意図的に維持）

- 複数 WorkGroup の**ファイル**読み込み → #224 の tentative-picker 契約はそのまま（実選択肢があるので自動選択しない）。
- `Refresh()`（WebSocket ライブ更新）は**不変** — セッション中の勝手な選択移動を防ぐ既存契約を尊重。

## テスト / Verification

- TRViS.Core.Tests: **24/24** 緑（単一WG自動選択・複数WG非選択・cascade例外ロールバックの回帰テスト追加）
- TRViS.NetworkSyncService.IntegrationTests: **76/76** 緑
- iOS UI (iPhone, Appium): **25 passed / 0 failed / 1 platform-skip**（`SeededSqlite_TappingCard` 含む全 Pass）
- `db.sample.json` は2 WorkGroup構成のため Appium `LoadSample_DoesNotAutoSelectWorkGroup` は無修正で Pass（複数WG=非自動選択の契約維持）

## Test plan

- [x] 単体: 単一WG自動選択 / 複数WG非選択 / cascade例外時ロード継続
- [x] 統合: NetworkSync 76/76
- [x] iOS 実機相当(シミュレータ) UI 全 Pass
- [ ] 実機での HTTP連携(QR `trvis://`)エンドツーエンド確認（任意・推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)