### PR TITLE
Add diagram info request and display on connection

### DIFF
--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -62,6 +62,17 @@ internal class FakeNetworkSyncService : NetworkSyncServiceBase
 	public new void RaiseConnectionClosed() => base.RaiseConnectionClosed();
 	public new void RaiseConnectionFailed() => base.RaiseConnectionFailed();
 
+	public int RequestDiagramInfoCallCount { get; private set; }
+	public string? LastRequestedDiagramId { get; private set; }
+	public override Task RequestDiagramInfoAsync(string? diagramId = null, CancellationToken cancellationToken = default)
+	{
+		RequestDiagramInfoCallCount++;
+		LastRequestedDiagramId = diagramId;
+		return Task.CompletedTask;
+	}
+
+	public void SimulateDiagramInfoUpdated(DiagramInfo info) => RaiseDiagramInfoUpdated(info);
+
 	public void SimulateProcessSyncedData(SyncedData syncedData) => ProcessSyncedData(syncedData);
 
 	protected override Task<SyncedData> GetSyncedDataAsync(CancellationToken token)
@@ -408,6 +419,78 @@ public class LocationServiceIntegrationTests
 			Longitude_deg: 139.0,
 			Accuracy_m: null
 		));
+
+		Assert.That(callCount, Is.EqualTo(0));
+	}
+
+	// -------------------------------------------------------
+	// 16. NetworkSyncService 設定時にカレントダイヤ情報を要求する
+	// -------------------------------------------------------
+	[Test]
+	public void SetNetworkSyncService_RequestsCurrentDiagramInfo()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		Assert.That(fakeNs.RequestDiagramInfoCallCount, Is.EqualTo(1));
+		Assert.That(fakeNs.LastRequestedDiagramId, Is.Null);
+	}
+
+	// -------------------------------------------------------
+	// 17. RequestDiagramInfoAsync は現在の NetworkSyncService に委譲する
+	// -------------------------------------------------------
+	[Test]
+	public async Task RequestDiagramInfoAsync_DelegatesToCurrentService()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		await _locationService.RequestDiagramInfoAsync("d-1");
+
+		// 接続時の1回 + 明示要求の1回
+		Assert.That(fakeNs.RequestDiagramInfoCallCount, Is.EqualTo(2));
+		Assert.That(fakeNs.LastRequestedDiagramId, Is.EqualTo("d-1"));
+	}
+
+	// -------------------------------------------------------
+	// 18. NetworkSyncService の DiagramInfoUpdated は pass-through される
+	// -------------------------------------------------------
+	[Test]
+	public void DiagramInfoUpdated_PassedThroughFromNetworkSyncService()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		DiagramInfo? received = null;
+		_locationService.DiagramInfoUpdated += (_, info) => received = info;
+
+		fakeNs.SimulateDiagramInfoUpdated(new DiagramInfo
+		{
+			Id = "d-1",
+			Name = "平日ダイヤ",
+			Description = "2024年3月改正",
+		});
+
+		Assert.That(received, Is.Not.Null);
+		Assert.That(received!.Id, Is.EqualTo("d-1"));
+		Assert.That(received!.Name, Is.EqualTo("平日ダイヤ"));
+		Assert.That(received!.Description, Is.EqualTo("2024年3月改正"));
+	}
+
+	// -------------------------------------------------------
+	// 19. LonLat に戻すと DiagramInfoUpdated は二重発火しない
+	// -------------------------------------------------------
+	[Test]
+	public void DiagramInfoUpdated_Unsubscribed_AfterSwitchToLonLat()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		_locationService.SetLonLatLocationService();
+
+		int callCount = 0;
+		_locationService.DiagramInfoUpdated += (_, _) => callCount++;
+
+		fakeNs.SimulateDiagramInfoUpdated(new DiagramInfo { Id = "d-1" });
 
 		Assert.That(callCount, Is.EqualTo(0));
 	}

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -450,6 +450,37 @@ void OnIsEnabledChanged(bool value)
 			// バックグラウンドで実行し続ける
 			_ = Task.Run(() => NetworkSyncServiceTask(nextService, nextTokenSource.Token));
 		}
+
+		// 接続確立直後にカレントダイヤ情報を要求する。
+		// WebSocket 以外では基底実装が no-op、応答／ブロードキャストは
+		// DiagramInfoUpdated イベントで通知される。
+		_ = RequestDiagramInfoOnConnectAsync(nextService);
+	}
+
+	async Task RequestDiagramInfoOnConnectAsync(NetworkSyncServiceBase service)
+	{
+		try
+		{
+			await service.RequestDiagramInfoAsync();
+		}
+		catch (Exception ex)
+		{
+			logger.Warn(ex, "RequestDiagramInfoAsync failed on connect");
+		}
+	}
+
+	/// <summary>
+	/// 現在使用中の NetworkSyncService にダイヤ情報を要求する。
+	/// NetworkSyncService が使用されていない場合は何もしない。
+	/// 応答は <see cref="DiagramInfoUpdated"/> イベントで通知される。
+	/// </summary>
+	/// <param name="diagramId">取得対象のダイヤID。null でカレントダイヤ。</param>
+	/// <param name="token">キャンセルトークン</param>
+	public Task RequestDiagramInfoAsync(string? diagramId = null, CancellationToken token = default)
+	{
+		if (_CurrentService is NetworkSyncServiceBase networkSyncService)
+			return networkSyncService.RequestDiagramInfoAsync(diagramId, token);
+		return Task.CompletedTask;
 	}
 
 	/// <summary>

--- a/TRViS.NetworkSyncService/DiagramInfo.cs
+++ b/TRViS.NetworkSyncService/DiagramInfo.cs
@@ -27,4 +27,12 @@ public class DiagramInfo
 	/// サーバーが提供する場合のみ設定される。
 	/// </summary>
 	public string[]? WorkGroupIds { get; set; }
+
+	/// <summary>
+	/// 接続情報カードに表示できるダイヤ情報 (名称か説明の少なくとも一方) を持つか。
+	/// null、または名称・説明とも空白なら false。LoaderInfoCard の行高を未受信時の
+	/// コンパクト表示と受信時の拡張表示で切り替える唯一の判定点。
+	/// </summary>
+	public static bool HasDisplayableContent(DiagramInfo? info) =>
+		!string.IsNullOrWhiteSpace(info?.Name) || !string.IsNullOrWhiteSpace(info?.Description);
 }

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -69,6 +69,11 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	private Task? _ReceiveLoopTask;
 	private volatile bool _isDisconnecting = false;
 
+	// ClientWebSocket は同時に 1 つの SendAsync しか許さない。ID 更新 / 各種 Request
+	// (ServerInfo / DiagramInfo) / 再接続後の再送が fire-and-forget で重なり得るため、
+	// すべての送信をこのセマフォで直列化する。
+	private readonly SemaphoreSlim _sendLock = new(1, 1);
+
 	// 再接続管理用
 	private readonly int _reconnectAttemptMax;  // 最大再接続試行回数
 	private readonly int _reconnectIntervalMs;  // 再接続間隔
@@ -832,12 +837,20 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			string json = JsonSerializer.Serialize(payload);
 			logger.Debug("SendRequestMessageAsync: Sending request: {0}", json);
 			byte[] bytes = Encoding.UTF8.GetBytes(json);
-			await _WebSocket.SendAsync(
-				new ArraySegment<byte>(bytes),
-				WebSocketMessageType.Text,
-				endOfMessage: true,
-				cancellationToken
-			);
+			await _sendLock.WaitAsync(cancellationToken);
+			try
+			{
+				await _WebSocket.SendAsync(
+					new ArraySegment<byte>(bytes),
+					WebSocketMessageType.Text,
+					endOfMessage: true,
+					cancellationToken
+				);
+			}
+			finally
+			{
+				_sendLock.Release();
+			}
 		}
 		catch (WebSocketException ex)
 		{
@@ -866,12 +879,20 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			string json = JsonSerializer.Serialize(updateMessage);
 			logger.Debug("SendIdUpdateAsync: Sending ID update: {0}", json);
 			byte[] bytes = Encoding.UTF8.GetBytes(json);
-			await _WebSocket.SendAsync(
-				new ArraySegment<byte>(bytes),
-				WebSocketMessageType.Text,
-				endOfMessage: true,
-				CancellationToken.None
-			);
+			await _sendLock.WaitAsync();
+			try
+			{
+				await _WebSocket.SendAsync(
+					new ArraySegment<byte>(bytes),
+					WebSocketMessageType.Text,
+					endOfMessage: true,
+					CancellationToken.None
+				);
+			}
+			finally
+			{
+				_sendLock.Release();
+			}
 		}
 		catch (WebSocketException ex)
 		{
@@ -1038,5 +1059,6 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		_ReceiveLoopCts?.Cancel();
 		_ReceiveLoopCts?.Dispose();
 		_WebSocket.Dispose();
+		_sendLock.Dispose();
 	}
 }

--- a/TRViS/RootPages/HomeGridView.xaml
+++ b/TRViS/RootPages/HomeGridView.xaml
@@ -60,6 +60,26 @@
 					LineBreakMode="MiddleTruncation"
 					TextColor="{x:Static local:RootStyles.TableDetailColor}"
 					Text=""/>
+				<!-- ダイヤ情報 (サーバーから RequestDiagramInfo の応答 / ブロードキャストで
+				     受信)。未受信時は両ラベルとも IsVisible=false で行が潰れる。読み取り専用。 -->
+				<Label
+					AutomationId="StartHome.DiagramInfoName"
+					x:Name="DiagramInfoNameLabel"
+					FontSize="13"
+					FontAttributes="Bold"
+					Margin="0,4,0,0"
+					LineBreakMode="TailTruncation"
+					TextColor="{x:Static local:RootStyles.TableTextColor}"
+					IsVisible="False"
+					Text=""/>
+				<Label
+					AutomationId="StartHome.DiagramInfoDescription"
+					x:Name="DiagramInfoDescriptionLabel"
+					FontSize="11"
+					LineBreakMode="TailTruncation"
+					TextColor="{x:Static local:RootStyles.TableDetailColor}"
+					IsVisible="False"
+					Text=""/>
 			</VerticalStackLayout>
 		</Grid>
 	</Border>

--- a/TRViS/RootPages/HomeGridView.xaml.cs
+++ b/TRViS/RootPages/HomeGridView.xaml.cs
@@ -77,6 +77,7 @@ public partial class HomeGridView : Grid
 	{
 		RebuildWorkGroupItems();
 		SyncPendingFromCommitted();
+		UpdateDiagramInfoLabels();
 	}
 
 	/// <summary>
@@ -97,6 +98,11 @@ public partial class HomeGridView : Grid
 
 			case nameof(AppViewModel.LoaderSourceLabel):
 				UpdateLoaderInfoLabels();
+				break;
+
+			case nameof(AppViewModel.CurrentDiagramInfo):
+				// サーバーがダイヤ情報を送ってきた (RequestDiagramInfo 応答 or ブロードキャスト)。
+				UpdateDiagramInfoLabels();
 				break;
 
 			case nameof(AppViewModel.WorkGroupList):
@@ -141,6 +147,8 @@ public partial class HomeGridView : Grid
 	/// </summary>
 	public void UpdateLoaderInfoLabels()
 	{
+		UpdateDiagramInfoLabels();
+
 		ILoader? loader = viewModel.Loader;
 		if (loader is null)
 		{
@@ -163,6 +171,25 @@ public partial class HomeGridView : Grid
 		LoaderInfoTitleLabel.Text = title;
 		LoaderInfoGlyphLabel.Text = glyph;
 		LoaderInfoDetailLabel.Text = viewModel.LoaderSourceLabel ?? string.Empty;
+	}
+
+	/// <summary>
+	/// サーバーから受信したダイヤ情報 (ダイヤ名・説明) を接続情報カードに読み取り専用で
+	/// 反映する。未受信時は両ラベルを非表示にして行を潰す。
+	/// </summary>
+	public void UpdateDiagramInfoLabels()
+	{
+		DiagramInfo? info = viewModel.CurrentDiagramInfo;
+
+		string? name = info?.Name;
+		bool hasName = !string.IsNullOrWhiteSpace(name);
+		DiagramInfoNameLabel.IsVisible = hasName;
+		DiagramInfoNameLabel.Text = hasName ? $"ダイヤ: {name}" : string.Empty;
+
+		string? description = info?.Description;
+		bool hasDescription = !string.IsNullOrWhiteSpace(description);
+		DiagramInfoDescriptionLabel.IsVisible = hasDescription;
+		DiagramInfoDescriptionLabel.Text = hasDescription ? description ?? string.Empty : string.Empty;
 	}
 
 	// ----- Two-step picker (WorkGroup -> Work) -----

--- a/TRViS/RootPages/StartHomePage.xaml.cs
+++ b/TRViS/RootPages/StartHomePage.xaml.cs
@@ -1,4 +1,5 @@
 using TRViS.IO;
+using TRViS.NetworkSyncService;
 using TRViS.Services;
 using TRViS.Utils;
 using TRViS.ViewModels;
@@ -92,6 +93,10 @@ public partial class StartHomePage : ContentPage
 	const double HOME_HEADER_ROW_HEIGHT_LARGE_BASE = 208.0;
 	const double FOOTER_ROW_HEIGHT_BASE = 36.0;
 	const double LOADER_INFO_ROW_HEIGHT_BASE = 60.0;
+	// ダイヤ情報 (ダイヤ名・説明) を受信すると LoaderInfoCard は 4 行 (種別 / ソース /
+	// ダイヤ名 / 説明) になり 60pt では潰れる。受信後はこの拡張高さに切り替える。
+	// 未受信時は従来どおりコンパクトな 60pt 行のまま。
+	const double LOADER_INFO_ROW_HEIGHT_WITH_DIAGRAM_BASE = 104.0;
 	const double HOME_BUTTONS_ROW_HEIGHT_BASE = 44.0;
 	const double START_BODY_ROW_HEIGHT_FULL_BASE = 280.0;
 	const double START_BODY_ROW_HEIGHT_COMPACT_BASE = 200.0;
@@ -105,6 +110,7 @@ public partial class StartHomePage : ContentPage
 	static readonly double HOME_HEADER_ROW_HEIGHT_LARGE = HOME_HEADER_ROW_HEIGHT_LARGE_BASE * _fontScale;
 	static readonly double FOOTER_ROW_HEIGHT = FOOTER_ROW_HEIGHT_BASE * _fontScale;
 	static readonly double LOADER_INFO_ROW_HEIGHT = LOADER_INFO_ROW_HEIGHT_BASE * _fontScale;
+	static readonly double LOADER_INFO_ROW_HEIGHT_WITH_DIAGRAM = LOADER_INFO_ROW_HEIGHT_WITH_DIAGRAM_BASE * _fontScale;
 	static readonly double HOME_BUTTONS_ROW_HEIGHT = HOME_BUTTONS_ROW_HEIGHT_BASE * _fontScale;
 	static readonly double START_BODY_ROW_HEIGHT_FULL = START_BODY_ROW_HEIGHT_FULL_BASE * _fontScale;
 	static readonly double START_BODY_ROW_HEIGHT_COMPACT = START_BODY_ROW_HEIGHT_COMPACT_BASE * _fontScale;
@@ -250,6 +256,13 @@ public partial class StartHomePage : ContentPage
 		{
 			logger.Debug("Loader changed -> evaluate page mode");
 			_ = ApplyModeForCurrentLoaderAsync();
+		}
+		else if (propertyName == nameof(AppViewModel.CurrentDiagramInfo))
+		{
+			// Diagram info just arrived/cleared; HomeGrid above already settled the
+			// label IsVisible flags. Now grow/shrink the LoaderInfoCard band so the
+			// (now visible) ダイヤ名・説明 lines aren't squeezed into the 60pt row.
+			RefreshLoaderInfoRowHeight();
 		}
 	}
 
@@ -442,6 +455,18 @@ public partial class StartHomePage : ContentPage
 	double EffectiveHomeHeaderRowHeight() =>
 		(Height > 0 && Height <= HOME_SMALL_HEIGHT_THRESHOLD) ? HOME_HEADER_ROW_HEIGHT : HOME_HEADER_ROW_HEIGHT_LARGE;
 
+	// LoaderInfoCard 行の実効高さ。サーバーからダイヤ情報 (名称/説明) を受信して
+	// いる間はカードが 4 行に増えるため拡張高さ、未受信時は従来の 60pt 行。
+	// PortraitHomeRows[1] / PortraitHomeRowsBg[1] / LandscapePhoneRows[3] と
+	// TransitionToAsync の Row3 アニメ目標値がすべてこの一点を参照することで、
+	// 接続済みのまま回転・モード遷移しても拡張高さが維持される。
+	// InstanceManager.AppViewModel を直接読むのは、コンストラクタで viewModel
+	// 代入より前に UpdateGridRowDefinitions が呼ばれるため (その時点では未受信)。
+	double EffectiveLoaderInfoRowHeight() =>
+		DiagramInfo.HasDisplayableContent(InstanceManager.AppViewModel.CurrentDiagramInfo)
+			? LOADER_INFO_ROW_HEIGHT_WITH_DIAGRAM
+			: LOADER_INFO_ROW_HEIGHT;
+
 	/// <summary>
 	/// When in Home mode on a small screen (≤ HOME_SMALL_HEIGHT_THRESHOLD), shrinks
 	/// the AppHeader to a compact icon-only band so the WorkGroup/Work list has
@@ -584,21 +609,52 @@ public partial class StartHomePage : ContentPage
 			// Home-only), so collapse it and give the Star row that extra space.
 			LandscapePhoneRows[3].Height = mode == PageMode.Start
 				? new GridLength(0)
-				: new GridLength(LOADER_INFO_ROW_HEIGHT);
+				: new GridLength(EffectiveLoaderInfoRowHeight());
 			BackgroundGrid.RowDefinitions = LandscapePhoneRows;
 			StartGrid.RowDefinitions = LandscapePhoneRows;
 			HomeGrid.RowDefinitions = LandscapePhoneRows;
 			return;
 		}
 		double headerHeight = EffectiveHomeHeaderRowHeight();
+		double loaderInfoHeight = EffectiveLoaderInfoRowHeight();
 		PortraitStartRowsBg[0].Height = GridLength.Star;
 		// Both body-grid and BG-grid Home row 0 must match so AppHeader's row
 		// stays in sync with the body grids (which depend on the same scheme).
 		PortraitHomeRows[0].Height = new GridLength(headerHeight);
 		PortraitHomeRowsBg[0].Height = new GridLength(headerHeight);
+		// Same alignment rule for Row 1: the LoaderInfoCard band grows when
+		// diagram info is received, so keep body-grid and BG-grid in lockstep.
+		PortraitHomeRows[1].Height = new GridLength(loaderInfoHeight);
+		PortraitHomeRowsBg[1].Height = new GridLength(loaderInfoHeight);
 		StartGrid.RowDefinitions = PortraitStartRows;
 		HomeGrid.RowDefinitions = PortraitHomeRows;
 		BackgroundGrid.RowDefinitions = mode == PageMode.Start ? PortraitStartRowsBg : PortraitHomeRowsBg;
+	}
+
+	/// <summary>
+	/// Snaps just the LoaderInfoCard row to its effective height when diagram
+	/// info is received/cleared while the page is already laid out. Deliberately
+	/// does NOT call UpdateGridRowDefinitions: that also resets Row 0 / reassigns
+	/// the BackgroundGrid scheme, which would fight an in-flight Start↔Home
+	/// transition animation. Mutating the shared collection's row height alone
+	/// invalidates layout and keeps body grid + BackgroundGrid aligned (portrait
+	/// uses the paired *Home/*HomeBg collections; landscape shares one instance).
+	/// </summary>
+	void RefreshLoaderInfoRowHeight()
+	{
+		double h = EffectiveLoaderInfoRowHeight();
+		if (_isLandscapePhone)
+		{
+			// Start mode collapses Row 3 to 0 (LoaderInfoCard is Home-only); leave
+			// it alone so we don't reveal the card behind the Start layout.
+			if (_currentMode != PageMode.Start)
+				LandscapePhoneRows[3].Height = new GridLength(h);
+		}
+		else
+		{
+			PortraitHomeRows[1].Height = new GridLength(h);
+			PortraitHomeRowsBg[1].Height = new GridLength(h);
+		}
 	}
 
 	protected override async void OnAppearing()
@@ -787,7 +843,7 @@ public partial class StartHomePage : ContentPage
 		if (landscapePhone)
 		{
 			fromRow3 = LandscapePhoneRows[3].Height.Value;
-			toRow3 = target == PageMode.Home ? LOADER_INFO_ROW_HEIGHT : 0;
+			toRow3 = target == PageMode.Home ? EffectiveLoaderInfoRowHeight() : 0;
 			animateRow3 = Math.Abs(fromRow3 - toRow3) > 0.5;
 		}
 

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -37,6 +37,13 @@ public partial class AppViewModel : ObservableObject
 		Loader = loader;
 	}
 
+	/// <summary>
+	/// サーバーから受信した最新のダイヤ情報 (ダイヤ名・説明など)。未受信／非接続時は null。
+	/// 接続情報画面で読み取り専用表示するために購読される。
+	/// </summary>
+	[ObservableProperty]
+	public partial DiagramInfo? CurrentDiagramInfo { get; set; }
+
 	public IReadOnlyList<WorkGroup>? WorkGroupList => SelectionManager.WorkGroupList;
 	public IReadOnlyList<Work>? WorkList => SelectionManager.WorkList;
 	public IReadOnlyList<TrainData>? OrderedTrainDataList => SelectionManager.OrderedTrainDataList;
@@ -138,17 +145,32 @@ public partial class AppViewModel : ObservableObject
 		locationService.TrainSelectionRequested += OnTrainSelectionRequested;
 		locationService.HeaderColorChangeRequested += OnHeaderColorChangeRequested;
 		locationService.TimeFormatChangeRequested += OnTimeFormatChangeRequested;
-		// NotificationReceived / OperationCommandReceived / ServerInfo / DiagramInfo は
+		locationService.DiagramInfoUpdated += OnDiagramInfoUpdated;
+		// NotificationReceived / OperationCommandReceived / ServerInfo は
 		// LocationService 側で受信される。OperationCommand の動作 (位置情報 ON/OFF) は
-		// LocationService が直接適用する。Notification / ServerInfo / DiagramInfo の UI 表示は
+		// LocationService が直接適用する。Notification / ServerInfo の UI 表示は
 		// 個別画面側で必要に応じて購読する。
+	}
+
+	/// <summary>
+	/// サーバーからダイヤ情報を受信した際に最新値を保持する。
+	/// WebSocket 受信スレッドから呼ばれるため、UI 反映側 (View) で
+	/// メインスレッドへのマーシャリングを行う。
+	/// </summary>
+	void OnDiagramInfoUpdated(object? sender, DiagramInfo info)
+	{
+		logger.Info("DiagramInfoUpdated: Id={0}, Name={1}", info.Id, info.Name);
+		CurrentDiagramInfo = info;
 	}
 
 	partial void OnLoaderChanged(ILoader? value)
 	{
 		SelectionManager.Loader = value;
 		if (value is null)
+		{
 			LoaderSourceLabel = null;
+			CurrentDiagramInfo = null;
+		}
 	}
 
 	void OnTimetableUpdated(object? sender, TimetableData timetableData)

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -166,11 +166,13 @@ public partial class AppViewModel : ObservableObject
 	partial void OnLoaderChanged(ILoader? value)
 	{
 		SelectionManager.Loader = value;
+		// ローダーが切り替わったら以前のダイヤ情報は無効。サーバー接続なら
+		// 接続時に再要求され DiagramInfoUpdated で改めて設定される。SetLoader は
+		// この後に NetworkSyncService を接続するため、ここでのクリアが新しい応答を
+		// 消すことはない。
+		CurrentDiagramInfo = null;
 		if (value is null)
-		{
 			LoaderSourceLabel = null;
-			CurrentDiagramInfo = null;
-		}
 	}
 
 	void OnTimetableUpdated(object? sender, TimetableData timetableData)


### PR DESCRIPTION
## Summary
This PR adds functionality to request and display diagram information (name and description) from the server when a NetworkSyncService is connected, and displays this information in the home view's connection info card.

## Key Changes

- **LocationService**: 
  - Added `RequestDiagramInfoAsync()` public method to request diagram information from the current NetworkSyncService
  - Automatically requests current diagram info when a NetworkSyncService is set via `SetNetworkSyncService()`
  - Handles `DiagramInfoUpdated` event from NetworkSyncService and passes it through to subscribers

- **AppViewModel**:
  - Added `CurrentDiagramInfo` observable property to store the latest received diagram information
  - Subscribes to `LocationService.DiagramInfoUpdated` event and updates `CurrentDiagramInfo`
  - Clears diagram info when loader is unset (disconnected)

- **HomeGridView (UI)**:
  - Added two new labels to display diagram name and description in the connection info card
  - Labels are hidden when diagram info is not available
  - Added `UpdateDiagramInfoLabels()` method to refresh display when diagram info changes
  - Updates diagram info on page appearing and when `CurrentDiagramInfo` property changes

- **Tests**:
  - Added test helper methods to FakeNetworkSyncService for tracking `RequestDiagramInfoAsync` calls
  - Added 4 new integration tests covering:
    - Automatic diagram info request on service connection
    - Explicit diagram info requests
    - Event pass-through from NetworkSyncService
    - Proper cleanup when switching back to LonLat service

## Implementation Details

- Diagram info requests are fire-and-forget (not awaited) to avoid blocking service initialization
- Failures in automatic diagram info requests are logged but don't affect service operation
- The feature gracefully degrades when NetworkSyncService is not available (no-op)
- UI labels collapse when diagram info is unavailable, maintaining clean layout

https://claude.ai/code/session_01PyFijgetbz1iHD49XpPZZN