### PR TITLE
fix: HTTP/WebSocket realtime location & clock not updating

### DIFF
--- a/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
+++ b/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
@@ -248,6 +248,43 @@ public class TimetableSelectionManagerTests
 	}
 
 	[Fact]
+	public void Refresh_AutoSelectsSingleWorkGroup_WhenListArrivesAsync()
+	{
+		// WebSocket: Loader is set before the WorkGroup list arrives, so
+		// OnLoaderChanged saw an empty list and could not apply the
+		// single-WorkGroup auto-pick. When the server push lands and Refresh
+		// runs, the single-WorkGroup convenience must finally kick in
+		// (otherwise a single-WG WebSocket connection is never selected).
+		var loader = new FakeLoader();
+		loader.Setup(new SampleData()); // empty at connect time
+		var manager = new TimetableSelectionManager { Loader = loader };
+		Assert.Null(manager.SelectedWorkGroup);
+
+		loader.Setup(BuildSampleData()); // single-WG data arrives via push
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-0", manager.SelectedWork?.Id);      // cascade
+		Assert.Equal("t-1-0-0", manager.SelectedTrainData?.Id); // cascade
+	}
+
+	[Fact]
+	public void Refresh_DoesNotAutoSelect_WhenMultipleWorkGroupsArriveAsync()
+	{
+		// Multi-WorkGroup remains a genuine choice owned by the Home picker:
+		// even when the list arrives late, Refresh must NOT force a default.
+		var loader = new FakeLoader();
+		loader.Setup(new SampleData());
+		var manager = new TimetableSelectionManager { Loader = loader };
+
+		loader.Setup(BuildMultiWgSampleData());
+		manager.Refresh();
+
+		Assert.True(manager.WorkGroupList!.Count >= 2);
+		Assert.Null(manager.SelectedWorkGroup);
+	}
+
+	[Fact]
 	public void Refresh_WhenNewWorkListBecomesEmpty_ClearsTrainSelection()
 	{
 		var loader = new FakeLoader();

--- a/TRViS.Core/TimetableSelectionManager.cs
+++ b/TRViS.Core/TimetableSelectionManager.cs
@@ -123,30 +123,48 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		RaisePropertyChanged(nameof(SelectedTrainData));
 		WorkGroupList = loader?.GetWorkGroupList();
 
-		if (WorkGroupList?.Count == 1)
+		TryAutoSelectSingleWorkGroup();
+	}
+
+	/// <summary>
+	/// Single-WorkGroup convenience auto-pick (scoped re-introduction of the
+	/// pre-#224 behavior): a one-item picker is pure friction, so commit it
+	/// straight away and let the cascade pick the first Work and Train.
+	/// A genuine multi-WorkGroup choice is left to the Home picker (stays null).
+	///
+	/// Shared by <see cref="OnLoaderChanged"/> and <see cref="Refresh"/>:
+	/// synchronous loaders have the WorkGroup list ready at load time, but
+	/// async loaders (WebSocket) only populate it later via a server push,
+	/// so OnLoaderChanged sees an empty list and Refresh must retry once the
+	/// data arrives — otherwise a single-WorkGroup WebSocket connection is
+	/// never auto-selected.
+	///
+	/// Auto-select is a convenience, never a load requirement. Committing the
+	/// WorkGroup cascades into loader.GetWorkList / GetTrainDataList; on a
+	/// malformed or partial source those throw, and a cascade failure must
+	/// roll back to the "WorkGroup picker" state, not fail the whole load.
+	/// </summary>
+	private void TryAutoSelectSingleWorkGroup()
+	{
+		if (_selectedWorkGroup is not null)
+			return;
+		if (WorkGroupList?.Count != 1)
+			return;
+
+		try
 		{
-			// Auto-select is a convenience, never a load requirement. Committing
-			// the WorkGroup cascades into loader.GetWorkList / GetTrainDataList;
-			// on a malformed or partial source (e.g. a SQLite DB that has a
-			// WorkGroup row but no Work table yet) those throw. Before this
-			// auto-pick existed, opening such a source still succeeded and just
-			// showed the WorkGroup picker — so a cascade failure must roll back
-			// to that exact state, not bubble up and fail the whole load.
-			try
-			{
-				SelectedWorkGroup = WorkGroupList[0];
-			}
-			catch
-			{
-				_selectedWorkGroup = null;
-				_selectedWork = null;
-				_selectedTrainData = null;
-				WorkList = null;
-				OrderedTrainDataList = null;
-				RaisePropertyChanged(nameof(SelectedWorkGroup));
-				RaisePropertyChanged(nameof(SelectedWork));
-				RaisePropertyChanged(nameof(SelectedTrainData));
-			}
+			SelectedWorkGroup = WorkGroupList[0];
+		}
+		catch
+		{
+			_selectedWorkGroup = null;
+			_selectedWork = null;
+			_selectedTrainData = null;
+			WorkList = null;
+			OrderedTrainDataList = null;
+			RaisePropertyChanged(nameof(SelectedWorkGroup));
+			RaisePropertyChanged(nameof(SelectedWork));
+			RaisePropertyChanged(nameof(SelectedTrainData));
 		}
 	}
 
@@ -265,13 +283,19 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		var newWorkGroupList = _loader.GetWorkGroupList();
 		WorkGroupList = newWorkGroupList;
 
-		// No prior commit: keep selection null. The Home picker is the source of
-		// truth for tentative state; we must not yank the user into a forced commit
-		// just because new list data arrived (would make the "no default selection"
-		// rule inconsistent across loader types — websocket pushes would still pick
-		// a default).
+		// No prior commit: keep selection null so the Home picker stays the source
+		// of truth for a *genuine* (multi-WorkGroup) choice. The single-WorkGroup
+		// case is the exception — it is auto-committed at load time, but async
+		// loaders (WebSocket) only deliver the WorkGroup list via a later server
+		// push, so OnLoaderChanged saw an empty list. Retry the single-WorkGroup
+		// auto-pick here now that the data has arrived; multi-WorkGroup still
+		// stays null (picker owns it).
 		if (_selectedWorkGroup is null)
-			return;
+		{
+			TryAutoSelectSingleWorkGroup();
+			if (_selectedWorkGroup is null)
+				return;
+		}
 
 		string? prevWorkGroupId = _selectedWorkGroup.Id;
 		var matchedWorkGroup = newWorkGroupList.FirstOrDefault(wg => wg.Id == prevWorkGroupId);

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using TRViS.DTAC.Logic;
 using TRViS.DTAC.Logic.Abstractions;
 using TRViS.DTAC.Logic.Presenter;
@@ -912,6 +913,74 @@ public class VerticalStylePagePresenterTests
 		presenter.OnStartButtonClicked();
 		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
 		Assert.True(presenter.CurrentState.PageHeaderState.CanUseLocationService);
+	}
+
+	// 弁別テスト (始発駅マーカー不具合): サーバ駆動 WS 接続では列車確定 →
+	// presenter ctor の順で、ctor 内 reconcile が SetIsRunning(true) を走らせる。
+	// その fallback が「アクティブなマーカーが無ければ最初の非 info 行に
+	// AroundThisStation を置く」ので、ctor 完了時点で presenter state には
+	// 始発駅マーカーが入っているはず。ここが PASS なら presenter state は
+	// 正しく、不具合は下流 (View の初期描画 / StateChanged 購読タイミング)。
+	// FAIL なら presenter state 側でマーカーが欠落している。
+	[Fact]
+	public void PresenterCtor_ServerDriven_SetsFirstStationMarker()
+	{
+		var locationService = new FakeLocationService
+		{
+			IsEnabled = true,
+			CanUseService = true,
+			NetworkSyncServiceCanStart = true,
+		};
+		var markerToggle = new FakeMarkerToggle();
+		var clock = new FakeClock();
+		var appVm = new FakeAppViewModelProvider();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+
+		var presenter = new VerticalStylePagePresenter(locationService, markerToggle, clock, appVm);
+
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+			"server-driven run must auto-start at ctor");
+
+		var firstStationKey = presenter.CurrentState.RowStates
+			.Where(kvp => !kvp.Value.IsInfoRow)
+			.Select(kvp => (int?)kvp.Key)
+			.FirstOrDefault();
+		Assert.NotNull(firstStationKey);
+		Assert.Equal(TimetableLocationState.AroundThisStation,
+			presenter.CurrentState.RowStates[firstStationKey!.Value].LocationState);
+	}
+
+	// 弁別テスト (info 行混在): 先頭が info 行のとき、始発駅マーカーは
+	// info 行ではなく最初の「駅」行に入らなければならない。RowStates は
+	// info 行込みで採番、StaLocationInfo は info 行除外で採番される
+	// (index 不整合の懸念) ため、両方を検証する。
+	[Fact]
+	public void PresenterCtor_ServerDriven_LeadingInfoRow_MarksFirstStationNotInfoRow()
+	{
+		var locationService = new FakeLocationService
+		{
+			IsEnabled = true,
+			CanUseService = true,
+			NetworkSyncServiceCanStart = true,
+		};
+		var markerToggle = new FakeMarkerToggle();
+		var clock = new FakeClock();
+		var appVm = new FakeAppViewModelProvider();
+		appVm.SelectedTrainData = CreateTrainDataWithInfoRow(rowCount: 4, infoRowIndex: 0);
+
+		var presenter = new VerticalStylePagePresenter(locationService, markerToggle, clock, appVm);
+
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		// info 行 (key 0) にはマーカーが付かないこと
+		Assert.True(presenter.CurrentState.RowStates[0].IsInfoRow);
+		Assert.Equal(TimetableLocationState.Undefined,
+			presenter.CurrentState.RowStates[0].LocationState);
+
+		// 最初の「駅」行 (key 1) にマーカーが付くこと
+		Assert.False(presenter.CurrentState.RowStates[1].IsInfoRow);
+		Assert.Equal(TimetableLocationState.AroundThisStation,
+			presenter.CurrentState.RowStates[1].LocationState);
 	}
 
 	#endregion

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -805,6 +805,43 @@ public class VerticalStylePagePresenterTests
 			presenter.CurrentState.RowStates[1].LocationState);
 	}
 
+	// サーバ駆動 (NetworkSyncServiceCanStart) で位置情報が自動 ON になったとき、
+	// 運行も自動開始し「運行開始」ボタンが運行前のまま残らないこと。
+	// CanUseServiceChanged はエッジトリガで再接続時に取り逃し得るため、
+	// レベル補正される IsEnabled 経由でも運行開始が走る必要がある。
+	[Fact]
+	public void ServerDrivenEnable_WhenNetworkSyncCanStart_AlsoAutoStartsRun()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+		locationService.NetworkSyncServiceCanStart = true;
+
+		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		locationService.RaiseIsEnabledChanged(true);
+
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+			"server-driven enable should auto-start the run");
+		Assert.True(presenter.CurrentState.TimetableViewState.IsRunStarted);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+	}
+
+	// GPS / ローカルファイル (NetworkSyncServiceCanStart=false) では、手動で
+	// 位置情報を ON にしても運行は自動開始しない (従来の手動フロー維持)。
+	[Fact]
+	public void Enable_WhenNotNetworkSyncDriven_DoesNotAutoStartRun()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+		locationService.NetworkSyncServiceCanStart = false;
+
+		locationService.RaiseIsEnabledChanged(true);
+
+		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning,
+			"non-network-driven enable must NOT auto-start the run");
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+	}
+
 	#endregion
 
 }

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -875,6 +875,45 @@ public class VerticalStylePagePresenterTests
 			presenter.CurrentState.RowStates[1].LocationState);
 	}
 
+	// 回帰テスト: 位置情報ボタンの「押下可能」状態は CanUseLocationService
+	// && IsRunning。サーバ駆動接続では CanUseServiceChanged も presenter 生成
+	// 前に発火するため、ctor で CanUse をレベル補正しないとボタンが永久に
+	// disabled (ON でも OFF にできない / 運行終了→運行開始しても enabled に
+	// 戻らない) になる不具合の防止。
+	[Fact]
+	public void PresenterCtor_ReconcilesCanUse_ButtonUsableAcrossRunCycle()
+	{
+		var locationService = new FakeLocationService
+		{
+			IsEnabled = true,
+			CanUseService = true,
+			NetworkSyncServiceCanStart = true,
+		};
+		var markerToggle = new FakeMarkerToggle();
+		var clock = new FakeClock();
+		var appVm = new FakeAppViewModelProvider();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+
+		var presenter = new VerticalStylePagePresenter(locationService, markerToggle, clock, appVm);
+
+		// ctor reconcile: CanUse が反映され、運行も自動開始
+		// (ボタン押下可能 = CanUseLocationService && IsRunning)
+		Assert.True(presenter.CurrentState.PageHeaderState.CanUseLocationService,
+			"CanUseLocationService must be reconciled at ctor");
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		// 運行終了 → 位置情報は自動 OFF だが CanUse は維持される
+		presenter.OnStartButtonClicked();
+		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+		Assert.True(presenter.CurrentState.PageHeaderState.CanUseLocationService,
+			"CanUseLocationService must survive 運行終了 so the button can be re-enabled");
+
+		// 運行開始 → ボタンは再び押下可能 (CanUse && IsRunning 共に true)
+		presenter.OnStartButtonClicked();
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+		Assert.True(presenter.CurrentState.PageHeaderState.CanUseLocationService);
+	}
+
 	#endregion
 
 }

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -35,11 +35,22 @@ public class VerticalStylePagePresenterTests
 		public event EventHandler<LocationStateChangedEventArgs>? LocationStateChanged;
 		public event EventHandler<GpsLocationUpdate>? GpsLocationUpdated;
 		public event EventHandler<Exception>? ExceptionThrown;
+		public event EventHandler<bool>? IsEnabledChanged;
 
 		public void RaiseCanUseServiceChanged(bool value)
 		{
 			CanUseService = value;
 			CanUseServiceChanged?.Invoke(this, value);
+		}
+
+		/// <summary>
+		/// Simulates a server-driven enable change (NetworkSyncService CanStart
+		/// auto-enable) that flips IsEnabled without going through the toggle.
+		/// </summary>
+		public void RaiseIsEnabledChanged(bool value)
+		{
+			IsEnabled = value;
+			IsEnabledChanged?.Invoke(this, value);
 		}
 
 		public void RaiseLocationStateChanged(int stationIndex, bool isRunningToNextStation)
@@ -624,6 +635,39 @@ public class VerticalStylePagePresenterTests
 		presenter.OnNetworkSyncAutoStartRequested();
 
 		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+		Assert.False(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+	}
+
+	// 回帰テスト: サーバ駆動の自動 ON (NetworkSyncService の CanStart) で
+	// LocationService.IsEnabled がトグルを経由せず true になったとき、
+	// presenter が自前の状態フラグ (特に位置マーカーのゲートである
+	// TimetableViewState.IsLocationServiceEnabled) に反映しないと、自動 ON
+	// されても位置マーカーが動かず手動 OFF→ON するまで直らない不具合の防止。
+	[Fact]
+	public void ServerDrivenIsEnabledChanged_MirrorsPresenterState_AndOpensMarkerGate()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+
+		// 前提: 画面トグルでは有効化していない
+		Assert.False(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+
+		// サーバ駆動の自動 ON (ボタンを経由しない)
+		locationService.RaiseIsEnabledChanged(true);
+
+		// presenter の全状態フラグに反映される
+		Assert.True(presenter.CurrentState.LocationServiceState.IsEnabled);
+		Assert.True(presenter.CurrentState.PageHeaderState.IsLocationServiceEnabled);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+
+		// よってサービスからの位置更新でマーカーが動く
+		// (修正前は OnLocationStateChanged_Internal のゲートで握り潰されていた)
+		locationService.RaiseLocationStateChanged(1, false);
+		Assert.Equal(TimetableLocationState.AroundThisStation,
+			presenter.CurrentState.RowStates[1].LocationState);
+
+		// サーバ駆動の OFF も同様に反映される
+		locationService.RaiseIsEnabledChanged(false);
 		Assert.False(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
 	}
 

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -842,6 +842,39 @@ public class VerticalStylePagePresenterTests
 		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
 	}
 
+	// 回帰テスト: サーバ駆動の自動 ON は presenter 生成前に発火する
+	// (WebSocket は 接続→CanStart有効化→DTAC遷移→presenter ctor の順)。
+	// IsEnabledChanged のエッジは購読前に消えるため、ctor で現在値を
+	// レベル補正しないとボタン/ゲートが OFF のまま・運行も開始されない。
+	[Fact]
+	public void PresenterCtor_ReconcilesAlreadyEnabledServerDrivenState()
+	{
+		var locationService = new FakeLocationService
+		{
+			IsEnabled = true,
+			NetworkSyncServiceCanStart = true,
+		};
+		var markerToggle = new FakeMarkerToggle();
+		var clock = new FakeClock();
+		var appVm = new FakeAppViewModelProvider();
+		// 列車は presenter 生成前に確定済み (WS の Refresh cascade 相当)
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+
+		var presenter = new VerticalStylePagePresenter(locationService, markerToggle, clock, appVm);
+
+		Assert.True(presenter.CurrentState.LocationServiceState.IsEnabled);
+		Assert.True(presenter.CurrentState.PageHeaderState.IsLocationServiceEnabled);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled,
+			"marker gate must be open from the ctor level-reconcile");
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+			"server-driven run must auto-start from the ctor level-reconcile");
+
+		// ゲートが開いているので位置更新でマーカーが動く
+		locationService.RaiseLocationStateChanged(1, false);
+		Assert.Equal(TimetableLocationState.AroundThisStation,
+			presenter.CurrentState.RowStates[1].LocationState);
+	}
+
 	#endregion
 
 }

--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -777,6 +777,34 @@ public class VerticalStylePagePresenterTests
 		Assert.False(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
 	}
 
+	// 回帰テスト: 位置情報が有効な状態で別の列車が選択された (cascade /
+	// サーバ push) とき、状態再構築 (CreateStateFromTrainData) が
+	// TimetableViewState.IsLocationServiceEnabled (マーカーのゲート) を
+	// 落としていたため、ボタンは ON でも位置マーカーが動かない不具合の防止。
+	[Fact]
+	public void SelectingTrainWhileLocationEnabled_KeepsMarkerGateOpen()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, id: "train-A");
+
+		// サーバ駆動で有効化 (ボタン ON / ゲート開)
+		locationService.RaiseIsEnabledChanged(true);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+
+		// 別の列車が選択される (full-reset path = CreateStateFromTrainData)
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, id: "train-B");
+
+		Assert.True(presenter.CurrentState.LocationServiceState.IsEnabled);
+		Assert.True(presenter.CurrentState.PageHeaderState.IsLocationServiceEnabled);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled,
+			"marker gate must survive a train reselection while location is enabled");
+
+		// ゲートが開いているので位置更新でマーカーが動く
+		locationService.RaiseLocationStateChanged(1, false);
+		Assert.Equal(TimetableLocationState.AroundThisStation,
+			presenter.CurrentState.RowStates[1].LocationState);
+	}
+
 	#endregion
 
 }

--- a/TRViS.DTAC.Logic.Tests/VerticalTimetableViewPresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalTimetableViewPresenterTests.cs
@@ -100,6 +100,19 @@ public class VerticalTimetableViewPresenterTests
 				rs.LocationState = TimetableLocationState.Undefined;
 			StateChanged?.Invoke(this, new VerticalPageStateChangedEventArgs(VerticalPageStateSection.RowStates));
 		}
+
+		/// <summary>
+		/// Seeds a marker WITHOUT raising StateChanged — simulates the page
+		/// presenter having set the first-station marker inside its own ctor,
+		/// before the view presenter is constructed and subscribes (so the
+		/// edge-triggered StateChanged is gone by then).
+		/// </summary>
+		public void PreSeedMarker(int row, TimetableLocationState state)
+		{
+			if (!_rowStates.ContainsKey(row))
+				_rowStates[row] = new VerticalTimetableRowState();
+			_rowStates[row].LocationState = state;
+		}
 	}
 
 	private static VerticalTimetableViewPresenter CreatePresenter(
@@ -236,6 +249,40 @@ public class VerticalTimetableViewPresenterTests
 
 		Assert.True(p.CurrentState.Marker.IsBoxVisible);
 		Assert.True(p.CurrentState.Marker.IsLineVisible);
+	}
+
+	// 回帰テスト (始発駅マーカー不具合): page presenter が自身の ctor で
+	// 始発駅マーカーを RowStates に立てるのは、この view presenter が構築・
+	// 購読するより前 (VerticalStylePage.xaml.cs:63 → :64)。エッジトリガの
+	// StateChanged は購読時には消えているため、ctor で現在の RowStates レベルを
+	// 補正しないと、運行開始時のマーカーが「発車して検出器が次の StateChanged を
+	// 出すまで」表示されない。ctor 構築前に marker source を seed して再現する。
+	[Fact]
+	public void Ctor_ReconcilesPreExistingMarker_FromSource()
+	{
+		var markerToggle = new FakeMarkerToggle();
+		var crashLogger = new FakeCrashLogger();
+		var dataSource = new FakeDataSource();
+		var markerSource = new FakeLocationMarkerSource();
+
+		// page presenter ctor 相当: 購読前に始発駅マーカーが既に立っている
+		markerSource.PreSeedMarker(1, TimetableLocationState.AroundThisStation);
+
+		var p = new VerticalTimetableViewPresenter(markerToggle, crashLogger, dataSource, markerSource);
+
+		Assert.True(p.CurrentState.Marker.IsBoxVisible,
+			"ctor must level-reconcile the marker that was set before subscription");
+		Assert.False(p.CurrentState.Marker.IsLineVisible);
+		Assert.Equal(1, p.CurrentState.Marker.MarkerRow);
+	}
+
+	[Fact]
+	public void Ctor_NoPreExistingMarker_MarkerStaysHidden()
+	{
+		var p = CreatePresenter(out _, out _, out _, out _);
+
+		Assert.False(p.CurrentState.Marker.IsBoxVisible);
+		Assert.False(p.CurrentState.Marker.IsLineVisible);
 	}
 
 	[Fact]

--- a/TRViS.DTAC.Logic/Abstractions/IDtacLocationServiceController.cs
+++ b/TRViS.DTAC.Logic/Abstractions/IDtacLocationServiceController.cs
@@ -32,4 +32,13 @@ public interface IDtacLocationServiceController : ILocationService
 	/// Fired when the location service encounters an exception.
 	/// </summary>
 	event EventHandler<Exception>? ExceptionThrown;
+
+	/// <summary>
+	/// Fired when the underlying location service enabled state changes,
+	/// including server-driven changes (NetworkSyncService CanStart auto-enable)
+	/// that do not go through the on-screen toggle. The argument is the new
+	/// enabled value. The presenter must mirror this into its own state so the
+	/// position-marker gate opens for server-driven enablement.
+	/// </summary>
+	event EventHandler<bool>? IsEnabledChanged;
 }

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -328,9 +328,7 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 			return;
 		}
 
-		_currentState.LocationServiceState.IsEnabled = enabled;
-		_currentState.PageHeaderState.IsLocationServiceEnabled = enabled;
-		_currentState.TimetableViewState.IsLocationServiceEnabled = enabled;
+		VerticalPageStateUpdater.UpdateLocationServiceEnabledState(_currentState, enabled);
 
 		RaiseStateChanged(
 			VerticalPageStateSection.LocationService

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -56,10 +56,15 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 
 		// Server-driven auto-enable fires on the LocationService BEFORE this
 		// presenter exists: the WebSocket flow is connect → CanStart enable →
-		// (navigate to DTAC) → presenter ctor. The IsEnabledChanged edge is
-		// gone by the time we subscribe above, so reconcile the current level
-		// now (after the train state is built) — otherwise the button/gate
-		// stay OFF and the server-driven run never starts on first display.
+		// (navigate to DTAC) → presenter ctor. The CanUseServiceChanged /
+		// IsEnabledChanged edges are gone by the time we subscribe above, so
+		// reconcile the current levels now (after the train state is built).
+		// CanUse must be reconciled too: the LocationService button's
+		// *tappable* state is CanUseLocationService && IsRunning, so a missed
+		// CanUseServiceChanged leaves the button permanently disabled (cannot
+		// be turned OFF, and stays disabled across 運行終了→運行開始) even
+		// though it correctly reads ON.
+		OnLocationServiceCanUseChanged(this, _locationService.CanUseService);
 		OnLocationServiceIsEnabledChanged_Internal(this, _locationService.IsEnabled);
 	}
 

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -48,6 +48,7 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 		_locationService.CanUseServiceChanged += OnLocationServiceCanUseChanged;
 		_locationService.LocationStateChanged += OnLocationStateChanged_Internal;
 		_locationService.GpsLocationUpdated += OnGpsLocationUpdated_Internal;
+		_locationService.IsEnabledChanged += OnLocationServiceIsEnabledChanged_Internal;
 		_appViewModelProvider.PropertyChanged += OnAppViewModelPropertyChanged;
 
 		// Sync initial train: PropertyChanged may have fired before this presenter subscribed.
@@ -276,6 +277,30 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 	private void SetLocationServiceEnabled(bool enabled)
 	{
 		_locationService.IsEnabled = enabled;
+		ApplyLocationServiceEnabledState(enabled);
+	}
+
+	/// <summary>
+	/// Mirrors the location-service enabled state into presenter state (button,
+	/// page header, and the position-marker gate in
+	/// <see cref="OnLocationStateChanged_Internal"/>). Split out from
+	/// <see cref="SetLocationServiceEnabled"/> so server-driven enable
+	/// (NetworkSyncService CanStart auto-enable, via
+	/// <see cref="OnLocationServiceIsEnabledChanged_Internal"/>) opens the same
+	/// gate the on-screen toggle does — without this, the marker stays frozen
+	/// after an auto-enable until the user manually toggles OFF→ON.
+	/// Idempotent so the echo from our own <see cref="SetLocationServiceEnabled"/>
+	/// write is a no-op.
+	/// </summary>
+	private void ApplyLocationServiceEnabledState(bool enabled)
+	{
+		if (_currentState.LocationServiceState.IsEnabled == enabled
+			&& _currentState.PageHeaderState.IsLocationServiceEnabled == enabled
+			&& _currentState.TimetableViewState.IsLocationServiceEnabled == enabled)
+		{
+			return;
+		}
+
 		_currentState.LocationServiceState.IsEnabled = enabled;
 		_currentState.PageHeaderState.IsLocationServiceEnabled = enabled;
 		_currentState.TimetableViewState.IsLocationServiceEnabled = enabled;
@@ -284,6 +309,11 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 			VerticalPageStateSection.LocationService
 			| VerticalPageStateSection.PageHeader
 			| VerticalPageStateSection.TimetableView);
+	}
+
+	private void OnLocationServiceIsEnabledChanged_Internal(object? sender, bool enabled)
+	{
+		ApplyLocationServiceEnabledState(enabled);
 	}
 
 	/// <summary>
@@ -339,6 +369,7 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 		_locationService.CanUseServiceChanged -= OnLocationServiceCanUseChanged;
 		_locationService.LocationStateChanged -= OnLocationStateChanged_Internal;
 		_locationService.GpsLocationUpdated -= OnGpsLocationUpdated_Internal;
+		_locationService.IsEnabledChanged -= OnLocationServiceIsEnabledChanged_Internal;
 		_appViewModelProvider.PropertyChanged -= OnAppViewModelPropertyChanged;
 	}
 }

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -53,6 +53,14 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 
 		// Sync initial train: PropertyChanged may have fired before this presenter subscribed.
 		SetSelectedTrainData(_appViewModelProvider.SelectedTrainData);
+
+		// Server-driven auto-enable fires on the LocationService BEFORE this
+		// presenter exists: the WebSocket flow is connect → CanStart enable →
+		// (navigate to DTAC) → presenter ctor. The IsEnabledChanged edge is
+		// gone by the time we subscribe above, so reconcile the current level
+		// now (after the train state is built) — otherwise the button/gate
+		// stay OFF and the server-driven run never starts on first display.
+		OnLocationServiceIsEnabledChanged_Internal(this, _locationService.IsEnabled);
 	}
 
 	private void OnAppViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -339,6 +339,21 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 	private void OnLocationServiceIsEnabledChanged_Internal(object? sender, bool enabled)
 	{
 		ApplyLocationServiceEnabledState(enabled);
+
+		// Server-driven integration (WebSocket / HTTP NetworkSyncService): when
+		// the server reports it can start, the run is server-driven too — auto
+		// start it so we don't leave a stale "運行開始" button while location is
+		// ON. Same intent as OnLocationServiceCanUseChanged's block, but driven
+		// off the (race-robust, level-reconciled) IsEnabled signal so a missed
+		// edge-triggered CanUseServiceChanged on (re)connect can't strand the
+		// run. NetworkSyncServiceCanStart is false for GPS/local sources, so the
+		// manual local-file flow is unaffected.
+		if (enabled
+			&& _locationService.NetworkSyncServiceCanStart
+			&& !_currentState.PageHeaderState.IsRunning)
+		{
+			SetIsRunning(true);
+		}
 	}
 
 	/// <summary>

--- a/TRViS.DTAC.Logic/Presenter/VerticalTimetableViewPresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalTimetableViewPresenter.cs
@@ -56,6 +56,15 @@ public sealed class VerticalTimetableViewPresenter : IDisposable
 
 		// Sync initial state
 		_currentState.IsMarkingMode = _markerToggle.IsToggled;
+
+		// Level-reconcile the marker now: the page presenter sets the
+		// first-station marker in its RowStates inside *its* ctor, which runs
+		// (VerticalStylePage.xaml.cs) before this presenter is constructed and
+		// subscribes above — so the edge-triggered StateChanged for that marker
+		// is already gone. Without this, the start-of-run marker stays hidden
+		// until the next StateChanged (the detector firing post-departure),
+		// which is exactly the "始発駅でマーカーが出ない" symptom.
+		ReconcileMarkerFromSource();
 	}
 
 	// ---------- Intents from View ----------
@@ -103,6 +112,11 @@ public sealed class VerticalTimetableViewPresenter : IDisposable
 			&& e.Changed != VerticalPageStateSection.All)
 			return;
 
+		ReconcileMarkerFromSource();
+	}
+
+	private void ReconcileMarkerFromSource()
+	{
 		var rowStates = _locationMarkerSource.RowStates;
 
 		int markerRow = -1;

--- a/TRViS.DTAC.Logic/VerticalPageStateFactory.cs
+++ b/TRViS.DTAC.Logic/VerticalPageStateFactory.cs
@@ -21,8 +21,13 @@ internal static class VerticalPageStateFactory
 		bool isLocationServiceEnabled)
 	{
 		var state = new VerticalPageState();
-		state.LocationServiceState.IsEnabled = isLocationServiceEnabled;
-		state.PageHeaderState.IsLocationServiceEnabled = isLocationServiceEnabled;
+		// Set all three location-enabled flags in lockstep (incl. the
+		// TimetableView marker gate read by OnLocationStateChanged_Internal).
+		// Setting only LocationServiceState/PageHeader left the gate false on
+		// every train (re)selection, so a server-driven-enabled session showed
+		// the button ON but the position marker never moved until a manual
+		// OFF→ON. Use the canonical helper so the flags cannot drift again.
+		VerticalPageStateUpdater.UpdateLocationServiceEnabledState(state, isLocationServiceEnabled);
 		ApplyTrainDataFields(state, trainData, affectDate);
 		return state;
 	}

--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -280,6 +280,28 @@ public class LocationServiceIntegrationTests
 	}
 
 	// -------------------------------------------------------
+	// 7b. WebSocket が SetNetworkSyncService より前に CanStart=true に
+	//     なっていても (購読前にエッジを取り逃しても) IsEnabled=true になる
+	//     回帰テスト: 再接続時にサーバが接続直後 SyncedData を push し、
+	//     LocationService の購読が間に合わず位置情報が disable のまま
+	//     固定される不具合 (Bug 2) の防止。
+	// -------------------------------------------------------
+	[Test]
+	public void WebSocketCanStartBeforeSubscribe_StillEnablesLocationService()
+	{
+		var fakeWs = new FakeWebSocketNetworkSyncService();
+
+		// 購読される前に CanStart が true に遷移してしまうケースを再現する。
+		// (CanStartChanged はエッジトリガなので、この時点では誰も受け取れない)
+		fakeWs.SimulateCanStart(true);
+
+		_locationService.SetNetworkSyncService(fakeWs);
+
+		Assert.That(_locationService.IsEnabled, Is.True,
+			"Should be enabled even when CanStart became true before SetNetworkSyncService subscribed");
+	}
+
+	// -------------------------------------------------------
 	// 8. Interval property 書き込み → 内部参照値が更新される
 	// -------------------------------------------------------
 	[Test]

--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -321,6 +321,40 @@ public class LocationServiceIntegrationTests
 	}
 
 	// -------------------------------------------------------
+	// 7d. SetStationLocations は NetworkSyncService (サーバ駆動) では
+	//     IsEnabled を落とさない。落とすと CanStart のエッジを取り逃して
+	//     二度と自動 ON されず位置マーカーが固まる不具合の防止。
+	//     GPS (LonLat) では従来どおり一旦停止する。
+	// -------------------------------------------------------
+	[Test]
+	public void SetStationLocations_NetworkSyncService_KeepsEnabled()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		fakeNs.SimulateCanStart(true);
+		Assert.That(_locationService.IsEnabled, Is.True, "precondition: auto-enabled");
+
+		_locationService.SetStationLocations(SampleStations());
+
+		Assert.That(_locationService.IsEnabled, Is.True,
+			"NetworkSyncService must stay enabled across SetStationLocations");
+		Assert.That(_locationService.CurrentService!.StaLocationInfo, Is.Not.Null);
+	}
+
+	[Test]
+	public void SetStationLocations_GpsService_StillDisables()
+	{
+		_locationService.SetLonLatLocationService();
+		_locationService.IsEnabled = true;
+		Assert.That(_locationService.IsEnabled, Is.True, "precondition: GPS enabled");
+
+		_locationService.SetStationLocations(SampleStations());
+
+		Assert.That(_locationService.IsEnabled, Is.False,
+			"GPS path must still disable on station change (re-acquire first fix)");
+	}
+
+	// -------------------------------------------------------
 	// 8. Interval property 書き込み → 内部参照値が更新される
 	// -------------------------------------------------------
 	[Test]

--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -302,6 +302,25 @@ public class LocationServiceIntegrationTests
 	}
 
 	// -------------------------------------------------------
+	// 7c. HTTP (非WebSocket) の NetworkSyncService でも CanStart=true で
+	//     位置情報が自動 ON になる (WebSocket と挙動を揃える)。
+	//     HTTP 連携で位置情報が更新されない不具合の修正。
+	// -------------------------------------------------------
+	[Test]
+	public void NonWebSocketNetworkSyncService_CanStartTrue_AlsoEnablesLocationService()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		Assert.That(_locationService.IsEnabled, Is.False, "Initially should be disabled");
+
+		fakeNs.SimulateCanStart(true);
+
+		Assert.That(_locationService.IsEnabled, Is.True,
+			"HTTP/non-WebSocket NetworkSyncService should also auto-enable on CanStart=true");
+	}
+
+	// -------------------------------------------------------
 	// 8. Interval property 書き込み → 内部参照値が更新される
 	// -------------------------------------------------------
 	[Test]

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -443,6 +443,17 @@ void OnIsEnabledChanged(bool value)
 		if (currentService is IDisposable disposable)
 			disposable.Dispose();
 
+		// CanStartChanged は値の遷移時にしか発火しない (エッジトリガ)。WebSocket は
+		// SetNetworkSyncService より前に ConnectAsync 済みで、最初の SyncedData
+		// (CanStart false->true) をここで購読する前に受信し得る。その場合 false->true
+		// の遷移が失われ、以後 SyncedData が来ても CanStart は true のまま遷移しないため
+		// 自動 IsEnabled=true が二度と走らない (特にサーバが接続直後に状態を push する
+		// 再接続時に位置情報が disable のまま固定される)。購読完了後に現在の CanStart
+		// レベルを取り込んで補正する。OnNetworkSyncServiceCanStartChanged 側で
+		// WebSocket 限定ガードが掛かっているため HTTP の挙動は変わらない。
+		if (nextService.CanStart)
+			OnNetworkSyncServiceCanStartChanged(nextService, true);
+
 		if (nextService is not WebSocketNetworkSyncService)
 		{
 			CancellationTokenSource nextTokenSource = new();

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -345,7 +345,13 @@ void OnIsEnabledChanged(bool value)
 	{
 		logger.Trace("Setting StationLocations...");
 
-		IsEnabled = false;
+		// GPS (LonLat) は駅集合が変わると初回測位からやり直す必要があるため一旦停止する。
+		// サーバ駆動 (NetworkSyncService) は次の同期で新しい駅集合に対して再評価され
+		// (NetworkSyncServiceBase.StaLocationInfo セッタが検出器をリセットする)、
+		// かつ自動 ON は CanStart のエッジトリガなので、ここで IsEnabled を落とすと
+		// 二度と自動 ON されず位置マーカーが固まる。NetworkSyncService では落とさない。
+		if (_CurrentService is not NetworkSyncServiceBase)
+			IsEnabled = false;
 		if (_CurrentService is null)
 		{
 			logger.Debug("_CurrentService is null -> do nothing");

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -208,10 +208,14 @@ void OnIsEnabledChanged(bool value)
 	{
 		logger.Debug("NetworkSyncServiceCanStartChanged: {0}", canStart);
 
-		// WebSocket接続時にのみ、CanStartがtrueになったら自動で「運行開始」と「位置情報ON」をする
-		if (canStart && _CurrentService is WebSocketNetworkSyncService)
+		// NetworkSyncService (HTTP / WebSocket) 接続時は、サーバが CanStart=true を
+		// 通知したら自動で「運行開始」=「位置情報ON」にする。サーバ駆動の連携
+		// (TRViS.LocalServers 等) では利用者が手動でトグルする想定がないため。
+		// HTTP も同じ連携形態なので WebSocket と挙動を揃える。
+		// LonLatLocationService (GPS) は NetworkSyncServiceBase ではないので対象外。
+		if (canStart && _CurrentService is NetworkSyncServiceBase)
 		{
-			logger.Info("CanStart is true and WebSocket is being used -> automatically enable location service");
+			logger.Info("CanStart is true on a NetworkSyncService -> automatically enable location service");
 			IsEnabled = true;
 		}
 	}

--- a/TRViS.NetworkSyncService.IntegrationTests/HttpSyncDataNoContentTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/HttpSyncDataNoContentTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+
+using NUnit.Framework;
+
+using TRViS.NetworkSyncService;
+
+namespace TRViS.NetworkSyncService.IntegrationTests;
+
+/// <summary>
+/// 連携元 (ゲーム等) がまだシナリオ/列車を読み込んでいないとき、TRViS.LocalServers の
+/// 同期エンドポイントは 204 No Content や空ボディを返す。その際に
+/// <see cref="HttpNetworkSyncService.GetSyncedDataAsync"/> が例外を投げると
+/// NetworkSyncServiceTask が規定回数で GPS 測位へフォールバックし、時計が止まり
+/// 位置情報も更新されなくなる (HTTP 連携で報告された不具合)。
+/// 204/空ボディを一時的状態として握りつぶし、ポーリングを継続することを確認する。
+/// </summary>
+[TestFixture]
+public class HttpSyncDataNoContentTests
+{
+	private sealed class StubHandler : HttpMessageHandler
+	{
+		public Func<HttpResponseMessage> ResponseFactory { get; set; } =
+			() => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+			=> Task.FromResult(ResponseFactory());
+	}
+
+	private static HttpNetworkSyncService MakeService(StubHandler handler)
+		=> new(new Uri("http://localhost/syncdata.json"), new HttpClient(handler));
+
+	[Test]
+	public void TickAsync_204NoContent_DoesNotThrow_AndKeepsPolling()
+	{
+		var handler = new StubHandler
+		{
+			ResponseFactory = () => new HttpResponseMessage(HttpStatusCode.NoContent),
+		};
+		using var service = MakeService(handler);
+
+		Assert.DoesNotThrowAsync(async () =>
+		{
+			await service.TickAsync();
+			await service.TickAsync();
+		});
+		Assert.That(service.CanStart, Is.False, "204 should be treated as a benign no-data state");
+	}
+
+	[Test]
+	public void TickAsync_200EmptyBody_DoesNotThrow()
+	{
+		var handler = new StubHandler
+		{
+			ResponseFactory = () => new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(string.Empty),
+			},
+		};
+		using var service = MakeService(handler);
+
+		Assert.DoesNotThrowAsync(async () => await service.TickAsync());
+		Assert.That(service.CanStart, Is.False);
+	}
+
+	[Test]
+	public async Task TickAsync_RecoversToRealDataAfterNoContent()
+	{
+		bool serveData = false;
+		var handler = new StubHandler
+		{
+			ResponseFactory = () => serveData
+				? new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("{\"Location_m\":null,\"Time_ms\":43200000,\"CanStart\":true}"),
+				}
+				: new HttpResponseMessage(HttpStatusCode.NoContent),
+		};
+		using var service = MakeService(handler);
+
+		int? lastTime = null;
+		service.TimeChanged += (_, t) => lastTime = t;
+
+		await service.TickAsync(); // 204 -> benign, no throw
+		Assert.That(service.CanStart, Is.False);
+
+		serveData = true;
+		await service.TickAsync(); // now real data flows through
+
+		Assert.That(service.CanStart, Is.True);
+		Assert.That(lastTime, Is.EqualTo(43_200));
+	}
+}

--- a/TRViS.NetworkSyncService/HttpNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/HttpNetworkSyncService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -101,7 +102,35 @@ public class HttpNetworkSyncService : NetworkSyncServiceBase
 			);
 		}
 
-		using JsonDocument? json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(), cancellationToken: token);
+		// 連携元 (ゲーム等) がまだシナリオ/列車を読み込んでいない間、サーバは
+		// 204 No Content や空ボディを返す。これは一時的な正常状態。ここで例外を
+		// 投げると NetworkSyncServiceTask が規定回数で GPS 測位へフォールバック
+		// してしまい、時計が止まり位置も更新されなくなる。良性の SyncedData を
+		// 返してポーリングを継続させ、データが届き次第そのまま復帰させる。
+		if (response.StatusCode == HttpStatusCode.NoContent)
+		{
+			Logger.Debug("GetSyncedDataAsync: 204 No Content (scenario not loaded yet)");
+			return new(
+				Location_m: double.NaN,
+				Time_ms: (long)DateTime.Now.TimeOfDay.TotalMilliseconds,
+				CanStart: false
+			);
+		}
+
+		JsonDocument? json;
+		try
+		{
+			json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(token), cancellationToken: token);
+		}
+		catch (JsonException ex)
+		{
+			Logger.Warn(ex, "GetSyncedDataAsync: response body was not valid JSON (empty/partial?) -> treat as no-data");
+			return new(
+				Location_m: double.NaN,
+				Time_ms: (long)DateTime.Now.TimeOfDay.TotalMilliseconds,
+				CanStart: false
+			);
+		}
 		if (json is null)
 		{
 			Logger.Error("GetSyncedDataAsync: Failed to parse JSON response");
@@ -111,6 +140,8 @@ public class HttpNetworkSyncService : NetworkSyncServiceBase
 				CanStart: false
 			);
 		}
+		using (json)
+		{
 		JsonElement root = json.RootElement;
 		double location_m = double.NaN;
 		try
@@ -146,6 +177,7 @@ public class HttpNetworkSyncService : NetworkSyncServiceBase
 			Time_ms: time_ms,
 			CanStart: canStart
 		);
+		}
 	}
 
 	public override void Dispose()

--- a/TRViS/DTAC/Adapters/LocationServiceAdapter.cs
+++ b/TRViS/DTAC/Adapters/LocationServiceAdapter.cs
@@ -18,6 +18,10 @@ internal class LocationServiceAdapter : IDtacLocationServiceController
 
 		// Bridge GPS location updates
 		_locationService.OnGpsLocationUpdated += OnGpsLocationUpdatedInternal;
+		// Bridge enabled-state changes (incl. server-driven CanStart auto-enable)
+		// so the presenter can mirror them; the on-screen toggle is not the only
+		// thing that flips IsEnabled.
+		_locationService.IsEnabledChanged += OnLocationServiceIsEnabledChangedInternal;
 	}
 
 	private void OnGpsLocationUpdatedInternal(object? sender, (double Longitude, double Latitude, double? Accuracy) location)
@@ -26,6 +30,11 @@ internal class LocationServiceAdapter : IDtacLocationServiceController
 			location.Latitude,
 			location.Longitude,
 			location.Accuracy));
+	}
+
+	private void OnLocationServiceIsEnabledChangedInternal(object? sender, TRViS.Utils.ValueChangedEventArgs<bool> e)
+	{
+		IsEnabledChanged?.Invoke(this, e.NewValue);
 	}
 
 	public bool IsEnabled
@@ -65,6 +74,8 @@ internal class LocationServiceAdapter : IDtacLocationServiceController
 	}
 
 	public event EventHandler<GpsLocationUpdate>? GpsLocationUpdated;
+
+	public event EventHandler<bool>? IsEnabledChanged;
 
 	public event EventHandler<Exception>? ExceptionThrown
 	{


### PR DESCRIPTION
## Summary

Fixes two reported field bugs in the realtime sync / location subsystem (HTTP TRViS.LocalServers integration and WebSocket). The three commits are independent and kept separate for review/bisection within this single branch.

### 1. WebSocket reconnect: location stays disabled (`bae8e06`)
`CanStart`/`CanStartChanged` in `NetworkSyncServiceBase` is **edge-triggered** (fires only on a false→true transition). `OpenWebSocketAppLinkAsync` connects the socket and starts the receive loop *before* `LocationService.ChangeNetworkSyncService` subscribes. On a reconnect the server pushes `SyncedData` (CanStart=true) immediately → the transition is delivered to no subscriber and lost; subsequent messages keep CanStart=true (no transition) → WebSocket auto-enable never runs → location stuck off.
**Fix:** reconcile the current `CanStart` *level* after handlers are wired in `ChangeNetworkSyncService`.

### 2. HTTP: clock frozen / position not updating — 204 handling (`2ba7b9b`)
While the linked game has not loaded a scenario, the `rts` sync endpoint returns **204 / empty body**. `JsonDocument.ParseAsync` threw an uncaught `JsonException` → propagated through `TickAsync` to `NetworkSyncServiceTask` → after the retry budget it fell back to GPS (`SetLonLatLocationService`). On a desktop/game (no GPS) this froze the clock and stopped position. Same 204 family as the earlier timetable-loader fix, but a distinct code path (the realtime sync endpoint).
**Fix:** handle 204 and guard the parse, returning the benign `SyncedData` the failure path already uses; polling stays alive and self-recovers.

### 3. HTTP auto-enable parity (`8be946b`)
`OnNetworkSyncServiceCanStartChanged` only auto-enabled location for WebSocket. HTTP is the same server-driven integration but carries no `OperationCommand`, so position never moved without a manual toggle. Broadened the guard to any `NetworkSyncServiceBase` (GPS `LonLatLocationService` is unaffected).

## Test plan

- [x] `TRViS.LocationService.Tests` — 26/26 (adds WS-before-subscribe + HTTP-auto-enable regression tests)
- [x] `TRViS.NetworkSyncService.IntegrationTests` — 79/79 (adds 204 / empty-body / recovery tests)
- [x] `TRViS.Core.Tests` — 22/22
- [x] Each fix verified to fail without its change and pass with it
- [ ] Manual: real-device QR connect to TRViS.LocalServers over HTTP (scenario not yet started → started) — clock ticks and position follows without manual toggle
- [ ] Manual: WebSocket drop + reconnect — location re-enables automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)