### PR TITLE
ci(cd): CDワークフローをreusable workflow + composite actionに分割

### DIFF
--- a/.github/actions/dump-third-party-licenses/action.yml
+++ b/.github/actions/dump-third-party-licenses/action.yml
@@ -1,0 +1,70 @@
+name: Dump Third Party License Info
+description: >
+  Install the Python tooling and generate the third-party license JSON for
+  the given platform, retrying once on failure.
+
+inputs:
+  platform:
+    description: Platform argument for tools/getThirdPartyLicenseJson.py (ios|maccatalyst|android|windows)
+    required: true
+  license-info-dir:
+    description: Output directory for the generated license info
+    required: true
+  license-list-name:
+    description: Base name (no extension) of the generated license list JSON
+    required: true
+  github-token:
+    # Composite actions cannot read the `secrets` context, so the token the
+    # license fetch script needs must be passed in explicitly by the caller.
+    description: Token used by the license fetch script
+    required: true
+  clear-pip-cache:
+    description: Clear the stale macOS-runner pip HTTP cache before setup-python (set 'true' on macOS runners)
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Clear stale pip HTTP cache
+      # The macos-26 runner image pre-populates ~/Library/Caches/pip with
+      # cachecontrol entries written by a different pip version than the
+      # one bundled with the Python actions/setup-python@v6 installs.
+      # That mismatch surfaces during setup-python's internal "Install
+      # OpenSSL certificates" sub-step as
+      #   WARNING: Cache entry deserialization failed, entry ignored
+      # which GitHub Actions renders as ##[error] in the log. The warning
+      # is benign (pip refetches on cache miss), but the spurious error
+      # indicator hides real failures. Clearing the cache removes it.
+      if: ${{ inputs.clear-pip-cache == 'true' }}
+      shell: bash
+      run: rm -rf "$HOME/Library/Caches/pip"
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+    - name: Prepare Python Package
+      shell: bash
+      run: |
+        python --version
+        python -m pip install aiofiles aiohttp
+    - name: Dump Third Party License Info
+      id: dump-third-party-license-info
+      continue-on-error: true
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        python ./tools/getThirdPartyLicenseJson.py ${{ inputs.platform }} ${{ inputs.license-info-dir }}
+        ls -l ${{ inputs.license-info-dir }}
+    - name: Dump Third Party License Info (Retry)
+      if: steps.dump-third-party-license-info.outcome == 'failure'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        python ./tools/getThirdPartyLicenseJson.py ${{ inputs.platform }} ${{ inputs.license-info-dir }}
+        ls -l ${{ inputs.license-info-dir }}
+    - name: Print Third Party License Info Files
+      shell: bash
+      run: cat ${{ inputs.license-info-dir }}/${{ inputs.license-list-name }}.json

--- a/.github/workflows/_cd-build-android.yml
+++ b/.github/workflows/_cd-build-android.yml
@@ -53,30 +53,13 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ env.CSPROJ_PATH }}
 
-      - uses: actions/setup-python@v6
+      - name: Dump third-party license info
+        uses: ./.github/actions/dump-third-party-licenses
         with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py android ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py android ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+          platform: android
+          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Google-services.json
         env:

--- a/.github/workflows/_cd-build-android.yml
+++ b/.github/workflows/_cd-build-android.yml
@@ -9,33 +9,30 @@ on:
       build_number:
         required: true
         type: string
-
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
+      AAB_PATH:
+        required: true
+        type: string
+      APK_PATH:
+        required: true
+        type: string
+      CSPROJ_PATH:
+        required: true
+        type: string
+      OUTPUT_DIR:
+        required: true
+        type: string
+      SDK_VERSION:
+        required: true
+        type: string
+      TARGET_FRAMEWORK_ANDROID:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_INFO_DIR:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_LIST_NAME:
+        required: true
+        type: string
 
 jobs:
   build-android:
@@ -46,19 +43,19 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.SDK_VERSION }}
+          dotnet-version: ${{ inputs.SDK_VERSION }}
       - name: Install dotnet workloads
         run: dotnet workload install maui-android
 
       - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }}
+        run: dotnet restore ${{ inputs.CSPROJ_PATH }}
 
       - name: Dump third-party license info
         uses: ./.github/actions/dump-third-party-licenses
         with:
           platform: android
-          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          license-info-dir: ${{ inputs.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ inputs.THIRD_PARTY_LICENSE_LIST_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Google-services.json
@@ -78,10 +75,10 @@ jobs:
         run: echo "${{ secrets.ANDROID_SIGNING_KEY_STORE }}" | base64 --decode > '${{ github.workspace }}/keystore.jks'
       - name: Build
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_ANDROID }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK_ANDROID }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
           /p:AndroidKeyStore=true
@@ -94,12 +91,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: aab
-          path: ${{ env.AAB_PATH }}
+          path: ${{ inputs.AAB_PATH }}
           retention-days: 3
 
       - name: Upload APK
         uses: actions/upload-artifact@v7
         with:
           name: apk
-          path: ${{ env.APK_PATH }}
+          path: ${{ inputs.APK_PATH }}
           retention-days: 3

--- a/.github/workflows/_cd-build-android.yml
+++ b/.github/workflows/_cd-build-android.yml
@@ -1,0 +1,122 @@
+name: CD - Build Android
+
+on:
+  workflow_call:
+    inputs:
+      display_version:
+        required: true
+        type: string
+      build_number:
+        required: true
+        type: string
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.SDK_VERSION }}
+      - name: Install dotnet workloads
+        run: dotnet workload install maui-android
+
+      - name: Install dependencies
+        run: dotnet restore ${{ env.CSPROJ_PATH }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Prepare Python Package
+        run: |
+          python --version
+          python -m pip install aiofiles aiohttp
+      - name: Dump Third Party License Info
+        id: dump-third-party-license-info
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py android ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Dump Third Party License Info (Retry)
+        if: steps.dump-third-party-license-info.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py android ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Print Third Party License Info Files
+        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+
+      - name: Add Google-services.json
+        env:
+          FIREBASE_ANDROID_JSON: ${{ secrets.FIREBASE_ANDROID_JSON }}
+        run: |
+          echo "$FIREBASE_ANDROID_JSON" > TRViS/Google-services.json
+          ls -l TRViS/Google-services.json
+
+      # ref: https://github.com/actions/runner-images/issues/8952#issuecomment-1886084791
+      - name: Install Android SDK Platform Tools
+        run: >
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          --sdk_root="$ANDROID_SDK_ROOT"
+          "platform-tools"
+      - name: Create Android Signing Key
+        run: echo "${{ secrets.ANDROID_SIGNING_KEY_STORE }}" | base64 --decode > '${{ github.workspace }}/keystore.jks'
+      - name: Build
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK_ANDROID }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+          /p:AndroidKeyStore=true
+          /p:AndroidSigningKeyAlias='${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}'
+          /p:AndroidSigningKeyPass='${{ secrets.ANDROID_SIGNING_KEY_PASS }}'
+          /p:AndroidSigningKeyStore='${{ github.workspace }}/keystore.jks'
+          /p:AndroidSigningStorePass='${{ secrets.ANDROID_SIGNING_KEY_STORE_PASS }}'
+
+      - name: Upload AAB
+        uses: actions/upload-artifact@v7
+        with:
+          name: aab
+          path: ${{ env.AAB_PATH }}
+          retention-days: 3
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: apk
+          path: ${{ env.APK_PATH }}
+          retention-days: 3

--- a/.github/workflows/_cd-build-ios.yml
+++ b/.github/workflows/_cd-build-ios.yml
@@ -1,0 +1,175 @@
+name: CD - Build iOS
+
+on:
+  workflow_call:
+    inputs:
+      display_version:
+        required: true
+        type: string
+      build_number:
+        required: true
+        type: string
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  build-ios:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      WITHOUT_ANDROID: true
+
+    steps:
+      - name: Import Provisioning Profile
+        run: |
+          mkdir -p ${{ env.TARGET_DIR }}
+
+          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
+            echo -n ${{ secrets.PROVISIONING_PROFILE }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+          fi
+        env:
+          TARGET_DIR: ~/Library/MobileDevice/Provisioning\ Profiles
+          TARGET_FILE: distribution.mobileprovision
+
+      - name: Generate Keychain Name
+        id: gen-keychain-name
+        run: echo "keychain-name=${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+
+      # ref: https://github.com/Apple-Actions/import-codesign-certs/pull/27#issuecomment-1298231619
+      - name: Build keychain
+        id: import-code-sign-cert
+        run: |
+          echo "${{ secrets.P12_FILE_BASE64 }}" | base64 --decode > certificate.p12
+          security create-keychain -p "${{ secrets.P12_PASSWORD }}" "${{ env.KEYCHAIN_NAME }}"
+          security default-keychain -s "${{ env.KEYCHAIN_NAME }}"
+          security unlock-keychain -p "${{ secrets.P12_PASSWORD }}" "${{ env.KEYCHAIN_NAME }}"
+          security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
+          security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P "${{ secrets.P12_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/xcrun
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.P12_PASSWORD }}" "${{ env.KEYCHAIN_NAME }}"
+        env:
+          KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
+
+      - uses: actions/checkout@v6
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.7.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.SDK_VERSION }}
+      - name: Install dotnet workloads
+        run: dotnet workload install maui-ios maccatalyst
+
+      - name: Install dependencies
+        run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME }}
+
+      - name: Clear stale pip HTTP cache
+        # The macos-26 runner image pre-populates ~/Library/Caches/pip with
+        # cachecontrol entries written by a different pip version than the
+        # one bundled with the Python actions/setup-python@v6 installs.
+        # That mismatch surfaces during setup-python's internal "Install
+        # OpenSSL certificates" sub-step as
+        #   WARNING: Cache entry deserialization failed, entry ignored
+        # which GitHub Actions renders as ##[error] in the log. The warning
+        # is benign (pip refetches on cache miss), but the spurious error
+        # indicator hides real failures. Clearing the cache removes it.
+        run: rm -rf "$HOME/Library/Caches/pip"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Prepare Python Package
+        run: |
+          python --version
+          python -m pip install aiofiles aiohttp
+      - name: Dump Third Party License Info
+        id: dump-third-party-license-info
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py ios ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Dump Third Party License Info (Retry)
+        if: steps.dump-third-party-license-info.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py ios ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Print Third Party License Info Files
+        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+
+      - name: Add GoogleService-Info.plist
+        env:
+          FIREBASE_IOS_PLIST: ${{ secrets.FIREBASE_IOS_PLIST }}
+        run: |
+          printf '%s' "$FIREBASE_IOS_PLIST" > TRViS/GoogleService-Info.plist
+          ls -l TRViS/GoogleService-Info.plist
+          plutil -lint TRViS/GoogleService-Info.plist
+
+      - name: Build
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
+          ACTOOL_SKIP_SIMULATOR_RUNTIME_CHECK: true
+          DOTNET_CLI_UI_LANGUAGE: en-US
+          ACTOOL_DISABLE: true
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK }}
+          -r ${{ env.TARGET_RUNTIME }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+          /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_IOS }}"
+          /p:CodesignProvision="${{ secrets.CODESIGN_PROVISION_NAME_IOS }}"
+          /p:_RequireCodeSigning=true
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v7
+        with:
+          name: ipa
+          path: ${{ env.IPA_PATH }}
+          retention-days: 3
+
+      - name: tar dSYM
+        run: cd ${{ env.IOS_DSYM_PATH }} && tar -czf ${{ env.IOS_DSYM_FILENAME }}.tar.gz ${{ env.IOS_DSYM_FILENAME }}
+      - name: Upload dSYM
+        uses: actions/upload-artifact@v7
+        with:
+          name: dSYM
+          path: ${{ env.IOS_DSYM_PATH }}/${{ env.IOS_DSYM_FILENAME }}.tar.gz
+          retention-days: 3
+
+      - name: Post 'Import Code Sign Certificates'
+        if: always() && steps.import-code-sign-cert.conclusion == 'success'
+        run: /usr/bin/security delete-keychain ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain

--- a/.github/workflows/_cd-build-ios.yml
+++ b/.github/workflows/_cd-build-ios.yml
@@ -9,33 +9,39 @@ on:
       build_number:
         required: true
         type: string
-
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
+      CSPROJ_PATH:
+        required: true
+        type: string
+      IOS_DSYM_FILENAME:
+        required: true
+        type: string
+      IOS_DSYM_PATH:
+        required: true
+        type: string
+      IPA_PATH:
+        required: true
+        type: string
+      OUTPUT_DIR:
+        required: true
+        type: string
+      SDK_VERSION:
+        required: true
+        type: string
+      TARGET_FRAMEWORK:
+        required: true
+        type: string
+      TARGET_RUNTIME:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_INFO_DIR:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_LIST_NAME:
+        required: true
+        type: string
+      XCODE_VERSION:
+        required: true
+        type: string
 
 jobs:
   build-ios:
@@ -80,23 +86,23 @@ jobs:
       - name: Setup Xcode version
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+          xcode-version: ${{ inputs.XCODE_VERSION }}
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.SDK_VERSION }}
+          dotnet-version: ${{ inputs.SDK_VERSION }}
       - name: Install dotnet workloads
         run: dotnet workload install maui-ios maccatalyst
 
       - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME }}
+        run: dotnet restore ${{ inputs.CSPROJ_PATH }} -r ${{ inputs.TARGET_RUNTIME }}
 
       - name: Dump third-party license info
         uses: ./.github/actions/dump-third-party-licenses
         with:
           platform: ios
-          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          license-info-dir: ${{ inputs.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ inputs.THIRD_PARTY_LICENSE_LIST_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           clear-pip-cache: "true"
 
@@ -115,11 +121,11 @@ jobs:
           DOTNET_CLI_UI_LANGUAGE: en-US
           ACTOOL_DISABLE: true
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK }}
-          -r ${{ env.TARGET_RUNTIME }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK }}
+          -r ${{ inputs.TARGET_RUNTIME }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
           /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_IOS }}"
@@ -130,16 +136,16 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ipa
-          path: ${{ env.IPA_PATH }}
+          path: ${{ inputs.IPA_PATH }}
           retention-days: 3
 
       - name: tar dSYM
-        run: cd ${{ env.IOS_DSYM_PATH }} && tar -czf ${{ env.IOS_DSYM_FILENAME }}.tar.gz ${{ env.IOS_DSYM_FILENAME }}
+        run: cd ${{ inputs.IOS_DSYM_PATH }} && tar -czf ${{ inputs.IOS_DSYM_FILENAME }}.tar.gz ${{ inputs.IOS_DSYM_FILENAME }}
       - name: Upload dSYM
         uses: actions/upload-artifact@v7
         with:
           name: dSYM
-          path: ${{ env.IOS_DSYM_PATH }}/${{ env.IOS_DSYM_FILENAME }}.tar.gz
+          path: ${{ inputs.IOS_DSYM_PATH }}/${{ inputs.IOS_DSYM_FILENAME }}.tar.gz
           retention-days: 3
 
       - name: Post 'Import Code Sign Certificates'

--- a/.github/workflows/_cd-build-ios.yml
+++ b/.github/workflows/_cd-build-ios.yml
@@ -91,42 +91,14 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME }}
 
-      - name: Clear stale pip HTTP cache
-        # The macos-26 runner image pre-populates ~/Library/Caches/pip with
-        # cachecontrol entries written by a different pip version than the
-        # one bundled with the Python actions/setup-python@v6 installs.
-        # That mismatch surfaces during setup-python's internal "Install
-        # OpenSSL certificates" sub-step as
-        #   WARNING: Cache entry deserialization failed, entry ignored
-        # which GitHub Actions renders as ##[error] in the log. The warning
-        # is benign (pip refetches on cache miss), but the spurious error
-        # indicator hides real failures. Clearing the cache removes it.
-        run: rm -rf "$HOME/Library/Caches/pip"
-
-      - uses: actions/setup-python@v6
+      - name: Dump third-party license info
+        uses: ./.github/actions/dump-third-party-licenses
         with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py ios ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py ios ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+          platform: ios
+          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          clear-pip-cache: "true"
 
       - name: Add GoogleService-Info.plist
         env:

--- a/.github/workflows/_cd-build-mac.yml
+++ b/.github/workflows/_cd-build-mac.yml
@@ -1,0 +1,155 @@
+name: CD - Build macOS
+
+on:
+  workflow_call:
+    inputs:
+      display_version:
+        required: true
+        type: string
+      build_number:
+        required: true
+        type: string
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  build-mac:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      WITHOUT_ANDROID: true
+
+    steps:
+      - name: Import Provisioning Profile
+        run: |
+          mkdir -p ${{ env.TARGET_DIR }}
+
+          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
+            echo -n ${{ secrets.PROVISIONING_PROFILE_MAC }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+          fi
+        env:
+          TARGET_DIR: ~/Library/MobileDevice/Provisioning\ Profiles
+          TARGET_FILE: distribution.provisionprofile
+
+      - name: Generate Keychain Name
+        id: gen-keychain-name
+        run: echo "keychain-name=${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+
+      # ref: https://github.com/Apple-Actions/import-codesign-certs/pull/27#issuecomment-1298231619
+      - name: Build keychain
+        id: import-code-sign-cert
+        run: |
+          echo "${{ secrets.P12_FILE_MAC_BASE64 }}" | base64 --decode > certificate.p12
+          security create-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+          security default-keychain -d user -s "${{ env.KEYCHAIN_NAME }}"
+          security unlock-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+          security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
+          security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P '${{ secrets.P12_PASSWORD_MAC }}' -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/xcrun
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
+        env:
+          KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
+
+      - uses: actions/checkout@v6
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.7.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.SDK_VERSION }}
+      - name: Install dotnet workloads
+        run: dotnet workload install maui-ios maccatalyst
+
+      - name: Install dependencies
+        run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME_MAC }}
+
+      - name: Clear stale pip HTTP cache
+        # See the matching step in build-ios for the rationale; the same
+        # spurious "Cache entry deserialization failed" warning fires here
+        # because the macos-26 runner image's pre-populated pip cache is
+        # incompatible with the pip bundled with setup-python's Python.
+        run: rm -rf "$HOME/Library/Caches/pip"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Prepare Python Package
+        run: |
+          python --version
+          python -m pip install aiofiles aiohttp
+      - name: Dump Third Party License Info
+        id: dump-third-party-license-info
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Dump Third Party License Info (Retry)
+        if: steps.dump-third-party-license-info.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Print Third Party License Info Files
+        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+
+      - name: Build
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK_MAC }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+          /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_MAC }}"
+          /p:CodesignProvision="${{ secrets.CODESIGN_PROVISION_NAME_MAC }}"
+          /p:EnablePackageSigning=true
+          /p:PackageSigningKey='${{ secrets.PACKAGE_SIGN_KEY_NAME_MAC }}'
+          /p:CodesignEntitlements='Platforms/MacCatalyst/Entitlements.plist'
+
+      - name: Change pkg file name
+        run: >
+          mv
+          ${{ env.OUTPUT_DIR }}/TRViS-${{ inputs.display_version }}.pkg
+          ${{ env.PKG_PATH }}
+
+      - name: Upload PKG
+        uses: actions/upload-artifact@v7
+        with:
+          name: pkg
+          path: ${{ env.PKG_PATH }}
+          retention-days: 3
+
+      - name: Post 'Import Code Sign Certificates'
+        if: always() && steps.import-code-sign-cert.conclusion == 'success'
+        run: /usr/bin/security delete-keychain ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain

--- a/.github/workflows/_cd-build-mac.yml
+++ b/.github/workflows/_cd-build-mac.yml
@@ -91,37 +91,14 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME_MAC }}
 
-      - name: Clear stale pip HTTP cache
-        # See the matching step in build-ios for the rationale; the same
-        # spurious "Cache entry deserialization failed" warning fires here
-        # because the macos-26 runner image's pre-populated pip cache is
-        # incompatible with the pip bundled with setup-python's Python.
-        run: rm -rf "$HOME/Library/Caches/pip"
-
-      - uses: actions/setup-python@v6
+      - name: Dump third-party license info
+        uses: ./.github/actions/dump-third-party-licenses
         with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+          platform: maccatalyst
+          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          clear-pip-cache: "true"
 
       - name: Build
         run: >

--- a/.github/workflows/_cd-build-mac.yml
+++ b/.github/workflows/_cd-build-mac.yml
@@ -9,33 +9,33 @@ on:
       build_number:
         required: true
         type: string
-
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
+      CSPROJ_PATH:
+        required: true
+        type: string
+      OUTPUT_DIR:
+        required: true
+        type: string
+      PKG_PATH:
+        required: true
+        type: string
+      SDK_VERSION:
+        required: true
+        type: string
+      TARGET_FRAMEWORK_MAC:
+        required: true
+        type: string
+      TARGET_RUNTIME_MAC:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_INFO_DIR:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_LIST_NAME:
+        required: true
+        type: string
+      XCODE_VERSION:
+        required: true
+        type: string
 
 jobs:
   build-mac:
@@ -80,32 +80,32 @@ jobs:
       - name: Setup Xcode version
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+          xcode-version: ${{ inputs.XCODE_VERSION }}
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.SDK_VERSION }}
+          dotnet-version: ${{ inputs.SDK_VERSION }}
       - name: Install dotnet workloads
         run: dotnet workload install maui-ios maccatalyst
 
       - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME_MAC }}
+        run: dotnet restore ${{ inputs.CSPROJ_PATH }} -r ${{ inputs.TARGET_RUNTIME_MAC }}
 
       - name: Dump third-party license info
         uses: ./.github/actions/dump-third-party-licenses
         with:
           platform: maccatalyst
-          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          license-info-dir: ${{ inputs.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ inputs.THIRD_PARTY_LICENSE_LIST_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           clear-pip-cache: "true"
 
       - name: Build
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_MAC }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK_MAC }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
           /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_MAC }}"
@@ -117,14 +117,14 @@ jobs:
       - name: Change pkg file name
         run: >
           mv
-          ${{ env.OUTPUT_DIR }}/TRViS-${{ inputs.display_version }}.pkg
-          ${{ env.PKG_PATH }}
+          ${{ inputs.OUTPUT_DIR }}/TRViS-${{ inputs.display_version }}.pkg
+          ${{ inputs.PKG_PATH }}
 
       - name: Upload PKG
         uses: actions/upload-artifact@v7
         with:
           name: pkg
-          path: ${{ env.PKG_PATH }}
+          path: ${{ inputs.PKG_PATH }}
           retention-days: 3
 
       - name: Post 'Import Code Sign Certificates'

--- a/.github/workflows/_cd-build-windows.yml
+++ b/.github/workflows/_cd-build-windows.yml
@@ -9,33 +9,42 @@ on:
       build_number:
         required: true
         type: string
-
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
+      ASSET_NAME_WIN_X64:
+        required: true
+        type: string
+      ASSET_NAME_WIN_X86:
+        required: true
+        type: string
+      ASSET_NAME_WIN_X64_SELF_CONTAINED:
+        required: true
+        type: string
+      ASSET_NAME_WIN_X86_SELF_CONTAINED:
+        required: true
+        type: string
+      CSPROJ_PATH:
+        required: true
+        type: string
+      OUTPUT_DIR:
+        required: true
+        type: string
+      SDK_VERSION:
+        required: true
+        type: string
+      TARGET_FRAMEWORK_WIN:
+        required: true
+        type: string
+      TARGET_RUNTIME_WINX64:
+        required: true
+        type: string
+      TARGET_RUNTIME_WINX86:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_INFO_DIR:
+        required: true
+        type: string
+      THIRD_PARTY_LICENSE_LIST_NAME:
+        required: true
+        type: string
 
 jobs:
   build-windows:
@@ -49,102 +58,102 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.SDK_VERSION }}
+          dotnet-version: ${{ inputs.SDK_VERSION }}
       - name: Install dotnet workloads
         run: dotnet workload install maui-windows
 
       - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }}
+        run: dotnet restore ${{ inputs.CSPROJ_PATH }}
 
       - name: Dump third-party license info
         uses: ./.github/actions/dump-third-party-licenses
         with:
           platform: windows
-          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          license-info-dir: ${{ inputs.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ inputs.THIRD_PARTY_LICENSE_LIST_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build x64
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK_WIN }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:WindowsPackageType=None
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX64 }}
+          /p:RuntimeIdentifierOverride=${{ inputs.TARGET_RUNTIME_WINX64 }}
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
 
       - name: Upload x64
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.ASSET_NAME_WIN_X64 }}
-          path: ${{ env.OUTPUT_DIR }}
+          name: ${{ inputs.ASSET_NAME_WIN_X64 }}
+          path: ${{ inputs.OUTPUT_DIR }}
           retention-days: 3
 
       - name: Clear Output Directory
-        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
+        run: Remove-Item -Recurse -Force -Path ${{ inputs.OUTPUT_DIR }}
 
       - name: Build x64 Self Contained
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK_WIN }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:WindowsPackageType=None
           /p:WindowsAppSDKSelfContained=true
           --self-contained
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX64 }}
+          /p:RuntimeIdentifierOverride=${{ inputs.TARGET_RUNTIME_WINX64 }}
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
 
       - name: Upload x64 Self Contained
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-          path: ${{ env.OUTPUT_DIR }}
+          name: ${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          path: ${{ inputs.OUTPUT_DIR }}
           retention-days: 3
 
       - name: Clear Output Directory
-        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
+        run: Remove-Item -Recurse -Force -Path ${{ inputs.OUTPUT_DIR }}
 
       - name: Build x86
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK_WIN }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:WindowsPackageType=None
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX86 }}
+          /p:RuntimeIdentifierOverride=${{ inputs.TARGET_RUNTIME_WINX86 }}
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
 
       - name: Upload x86
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.ASSET_NAME_WIN_X86 }}
-          path: ${{ env.OUTPUT_DIR }}
+          name: ${{ inputs.ASSET_NAME_WIN_X86 }}
+          path: ${{ inputs.OUTPUT_DIR }}
           retention-days: 3
 
       - name: Clear Output Directory
-        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
+        run: Remove-Item -Recurse -Force -Path ${{ inputs.OUTPUT_DIR }}
 
       - name: Build x86 Self Contained
         run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          dotnet publish ${{ inputs.CSPROJ_PATH }}
+          -f ${{ inputs.TARGET_FRAMEWORK_WIN }}
           -c Release
-          -o "${{ env.OUTPUT_DIR }}"
+          -o "${{ inputs.OUTPUT_DIR }}"
           /p:WindowsPackageType=None
           /p:WindowsAppSDKSelfContained=true
           --self-contained
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX86 }}
+          /p:RuntimeIdentifierOverride=${{ inputs.TARGET_RUNTIME_WINX86 }}
           /p:ApplicationDisplayVersion=${{ inputs.display_version }}
           /p:ApplicationVersion=${{ inputs.build_number }}
 
       - name: Upload x86 Self Contained
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-          path: ${{ env.OUTPUT_DIR }}
+          name: ${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          path: ${{ inputs.OUTPUT_DIR }}
           retention-days: 3

--- a/.github/workflows/_cd-build-windows.yml
+++ b/.github/workflows/_cd-build-windows.yml
@@ -56,30 +56,13 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ env.CSPROJ_PATH }}
 
-      - uses: actions/setup-python@v6
+      - name: Dump third-party license info
+        uses: ./.github/actions/dump-third-party-licenses
         with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py windows ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py windows ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+          platform: windows
+          license-info-dir: ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          license-list-name: ${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build x64
         run: >

--- a/.github/workflows/_cd-build-windows.yml
+++ b/.github/workflows/_cd-build-windows.yml
@@ -1,0 +1,167 @@
+name: CD - Build Windows
+
+on:
+  workflow_call:
+    inputs:
+      display_version:
+        required: true
+        type: string
+      build_number:
+        required: true
+        type: string
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      WITHOUT_ANDROID: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.SDK_VERSION }}
+      - name: Install dotnet workloads
+        run: dotnet workload install maui-windows
+
+      - name: Install dependencies
+        run: dotnet restore ${{ env.CSPROJ_PATH }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Prepare Python Package
+        run: |
+          python --version
+          python -m pip install aiofiles aiohttp
+      - name: Dump Third Party License Info
+        id: dump-third-party-license-info
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py windows ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Dump Third Party License Info (Retry)
+        if: steps.dump-third-party-license-info.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python ./tools/getThirdPartyLicenseJson.py windows ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
+      - name: Print Third Party License Info Files
+        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
+
+      - name: Build x64
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:WindowsPackageType=None
+          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX64 }}
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+
+      - name: Upload x64
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X64 }}
+          path: ${{ env.OUTPUT_DIR }}
+          retention-days: 3
+
+      - name: Clear Output Directory
+        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
+
+      - name: Build x64 Self Contained
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:WindowsPackageType=None
+          /p:WindowsAppSDKSelfContained=true
+          --self-contained
+          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX64 }}
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+
+      - name: Upload x64 Self Contained
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          path: ${{ env.OUTPUT_DIR }}
+          retention-days: 3
+
+      - name: Clear Output Directory
+        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
+
+      - name: Build x86
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:WindowsPackageType=None
+          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX86 }}
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+
+      - name: Upload x86
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X86 }}
+          path: ${{ env.OUTPUT_DIR }}
+          retention-days: 3
+
+      - name: Clear Output Directory
+        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
+
+      - name: Build x86 Self Contained
+        run: >
+          dotnet publish ${{ env.CSPROJ_PATH }}
+          -f ${{ env.TARGET_FRAMEWORK_WIN }}
+          -c Release
+          -o "${{ env.OUTPUT_DIR }}"
+          /p:WindowsPackageType=None
+          /p:WindowsAppSDKSelfContained=true
+          --self-contained
+          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX86 }}
+          /p:ApplicationDisplayVersion=${{ inputs.display_version }}
+          /p:ApplicationVersion=${{ inputs.build_number }}
+
+      - name: Upload x86 Self Contained
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          path: ${{ env.OUTPUT_DIR }}
+          retention-days: 3

--- a/.github/workflows/_cd-create-release.yml
+++ b/.github/workflows/_cd-create-release.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Download APK

--- a/.github/workflows/_cd-create-release.yml
+++ b/.github/workflows/_cd-create-release.yml
@@ -1,0 +1,97 @@
+name: CD - Create Release
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download APK
+        uses: actions/download-artifact@v8
+        with:
+          name: apk
+          path: ${{ env.OUTPUT_DIR }}
+      - name: Download windows asset (x64)
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X64 }}
+          path: ${{ env.ASSET_NAME_WIN_X64 }}
+      - name: Download windows asset (x86)
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X86 }}
+          path: ${{ env.ASSET_NAME_WIN_X86 }}
+      - name: Download windows asset (x64 self-contained)
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          path: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+      - name: Download windows asset (x86 self-contained)
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          path: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+
+      - name: pack win-x64
+        run: |
+          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64 }}.zip ${{ env.ASSET_NAME_WIN_X64 }}
+          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64 }}.7z ${{ env.ASSET_NAME_WIN_X64 }}
+      - name: pack win-x86
+        run: |
+          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86 }}.zip ${{ env.ASSET_NAME_WIN_X86 }}
+          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86 }}.7z ${{ env.ASSET_NAME_WIN_X86 }}
+      - name: pack win-x64-self-contained
+        run: |
+          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.zip ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.7z ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+      - name: pack win-x86-self-contained
+        run: |
+          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.zip ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.7z ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+
+      - name: Create Release
+        run: >
+          gh release create ${{ inputs.tag_name }}
+          --draft
+          --generate-notes
+          ${{ env.OUTPUT_DIR }}/*.apk
+          ${{ env.OUTPUT_DIR }}/*.zip
+          ${{ env.OUTPUT_DIR }}/*.7z
+          --repo ${{ github.repository }}
+          --notes 'This release is automatically created by actions ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/_cd-create-release.yml
+++ b/.github/workflows/_cd-create-release.yml
@@ -6,33 +6,21 @@ on:
       tag_name:
         required: true
         type: string
-
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
+      ASSET_NAME_WIN_X64:
+        required: true
+        type: string
+      ASSET_NAME_WIN_X86:
+        required: true
+        type: string
+      ASSET_NAME_WIN_X64_SELF_CONTAINED:
+        required: true
+        type: string
+      ASSET_NAME_WIN_X86_SELF_CONTAINED:
+        required: true
+        type: string
+      OUTPUT_DIR:
+        required: true
+        type: string
 
 jobs:
   create-release:
@@ -43,53 +31,53 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: apk
-          path: ${{ env.OUTPUT_DIR }}
+          path: ${{ inputs.OUTPUT_DIR }}
       - name: Download windows asset (x64)
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.ASSET_NAME_WIN_X64 }}
-          path: ${{ env.ASSET_NAME_WIN_X64 }}
+          name: ${{ inputs.ASSET_NAME_WIN_X64 }}
+          path: ${{ inputs.ASSET_NAME_WIN_X64 }}
       - name: Download windows asset (x86)
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.ASSET_NAME_WIN_X86 }}
-          path: ${{ env.ASSET_NAME_WIN_X86 }}
+          name: ${{ inputs.ASSET_NAME_WIN_X86 }}
+          path: ${{ inputs.ASSET_NAME_WIN_X86 }}
       - name: Download windows asset (x64 self-contained)
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-          path: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          name: ${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          path: ${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
       - name: Download windows asset (x86 self-contained)
         uses: actions/download-artifact@v8
         with:
-          name: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-          path: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          name: ${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          path: ${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
 
       - name: pack win-x64
         run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64 }}.zip ${{ env.ASSET_NAME_WIN_X64 }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64 }}.7z ${{ env.ASSET_NAME_WIN_X64 }}
+          7z a -tzip ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X64 }}.zip ${{ inputs.ASSET_NAME_WIN_X64 }}
+          7z a -t7z ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X64 }}.7z ${{ inputs.ASSET_NAME_WIN_X64 }}
       - name: pack win-x86
         run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86 }}.zip ${{ env.ASSET_NAME_WIN_X86 }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86 }}.7z ${{ env.ASSET_NAME_WIN_X86 }}
+          7z a -tzip ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X86 }}.zip ${{ inputs.ASSET_NAME_WIN_X86 }}
+          7z a -t7z ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X86 }}.7z ${{ inputs.ASSET_NAME_WIN_X86 }}
       - name: pack win-x64-self-contained
         run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.zip ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.7z ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          7z a -tzip ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.zip ${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
+          7z a -t7z ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.7z ${{ inputs.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
       - name: pack win-x86-self-contained
         run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.zip ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.7z ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          7z a -tzip ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.zip ${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
+          7z a -t7z ${{ inputs.OUTPUT_DIR }}/${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.7z ${{ inputs.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
 
       - name: Create Release
         run: >
           gh release create ${{ inputs.tag_name }}
           --draft
           --generate-notes
-          ${{ env.OUTPUT_DIR }}/*.apk
-          ${{ env.OUTPUT_DIR }}/*.zip
-          ${{ env.OUTPUT_DIR }}/*.7z
+          ${{ inputs.OUTPUT_DIR }}/*.apk
+          ${{ inputs.OUTPUT_DIR }}/*.zip
+          ${{ inputs.OUTPUT_DIR }}/*.7z
           --repo ${{ github.repository }}
           --notes 'This release is automatically created by actions ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}'
         env:

--- a/.github/workflows/_cd-publish-appstore.yml
+++ b/.github/workflows/_cd-publish-appstore.yml
@@ -1,0 +1,87 @@
+name: CD - Publish to App Store Connect
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      timeout_minutes:
+        required: true
+        type: number
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  publish:
+    runs-on: macos-26
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    # The `-f` paths below use the GitHub Actions ternary
+    # `platform == 'ios' && env.IPA_PATH || env.PKG_PATH`, which only selects
+    # IPA_PATH because IPA_PATH is a non-empty constant. If IPA_PATH ever
+    # becomes empty/falsy it would silently fall through to PKG_PATH.
+    steps:
+      - name: Import App Store Connect API Private Key
+        run: |
+          mkdir -p ${{ env.TARGET_DIR }}
+
+          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
+            echo -n ${{ secrets.APPSTORECONNECT_API_PRIVATE_KEY }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+            chmod 400 ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
+          fi
+        env:
+          TARGET_DIR: ~/.appstoreconnect/private_keys
+          TARGET_FILE: AuthKey_${{ secrets.APPSTORECONNECT_API_KEY }}.p8
+
+      - name: Download artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ env.OUTPUT_DIR }}
+
+      - name: validate
+        run: >
+          xcrun altool
+          --validate-app
+          --type ${{ inputs.platform }}
+          -f ${{ inputs.platform == 'ios' && env.IPA_PATH || env.PKG_PATH }}
+          --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
+          --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
+
+      - name: upload
+        run: >
+          xcrun altool
+          --upload-app
+          --type ${{ inputs.platform }}
+          -f ${{ inputs.platform == 'ios' && env.IPA_PATH || env.PKG_PATH }}
+          --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
+          --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}

--- a/.github/workflows/_cd-publish-appstore.yml
+++ b/.github/workflows/_cd-publish-appstore.yml
@@ -12,40 +12,22 @@ on:
       timeout_minutes:
         required: true
         type: number
-
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
+      IPA_PATH:
+        required: true
+        type: string
+      OUTPUT_DIR:
+        required: true
+        type: string
+      PKG_PATH:
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: macos-26
     timeout-minutes: ${{ inputs.timeout_minutes }}
     # The `-f` paths below use the GitHub Actions ternary
-    # `platform == 'ios' && env.IPA_PATH || env.PKG_PATH`, which only selects
+    # `platform == 'ios' && inputs.IPA_PATH || inputs.PKG_PATH`, which only selects
     # IPA_PATH because IPA_PATH is a non-empty constant. If IPA_PATH ever
     # becomes empty/falsy it would silently fall through to PKG_PATH.
     steps:
@@ -66,14 +48,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
-          path: ${{ env.OUTPUT_DIR }}
+          path: ${{ inputs.OUTPUT_DIR }}
 
       - name: validate
         run: >
           xcrun altool
           --validate-app
           --type ${{ inputs.platform }}
-          -f ${{ inputs.platform == 'ios' && env.IPA_PATH || env.PKG_PATH }}
+          -f ${{ inputs.platform == 'ios' && inputs.IPA_PATH || inputs.PKG_PATH }}
           --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
           --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
 
@@ -82,6 +64,6 @@ jobs:
           xcrun altool
           --upload-app
           --type ${{ inputs.platform }}
-          -f ${{ inputs.platform == 'ios' && env.IPA_PATH || env.PKG_PATH }}
+          -f ${{ inputs.platform == 'ios' && inputs.IPA_PATH || inputs.PKG_PATH }}
           --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
           --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}

--- a/.github/workflows/_cd-set-tag.yml
+++ b/.github/workflows/_cd-set-tag.yml
@@ -9,25 +9,13 @@ on:
       build_number:
         required: true
         type: string
-      publish_ios_result:
-        required: true
-        type: string
-      publish_mac_result:
-        required: true
-        type: string
-      build_android_result:
-        required: true
-        type: string
-      build_windows_result:
-        required: true
-        type: string
     outputs:
       tag-name:
         value: ${{ jobs.set-tag.outputs.tag-name }}
 
 jobs:
   set-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     outputs:
       tag-name: ${{ steps.tag-name.outputs.tag-name }}
@@ -84,14 +72,13 @@ jobs:
             echo "ERROR: Tag ${TAG_NAME} exists on remote at ${remote_sha} but this run points to ${local_sha}"
             exit 1
           fi
-          git push origin "${TAG_NAME}"
-
-      - name: Comment TagName and Actions-Run URL to PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: >
-          echo Tag \`${{ steps.tag-name.outputs.tag-name }}\` was automatically created and pushed with
-          ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-          ' (Publish Status iOS: ${{ inputs.publish_ios_result }} / macOS: ${{ inputs.publish_mac_result }} / Android: ${{ inputs.build_android_result }} / Windows: ${{ inputs.build_windows_result }})'
-          | gh pr comment ${{ github.event.number }} -F -
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if ! git push origin "${TAG_NAME}"; then
+            # Another concurrent set-tag job may have pushed first.
+            remote_sha=$(git ls-remote origin "refs/tags/${TAG_NAME}^{}" | awk '{print $1}')
+            if [ "$remote_sha" = "$local_sha" ]; then
+              echo "Tag ${TAG_NAME} pushed by concurrent job at same SHA; treating as success."
+              exit 0
+            fi
+            echo "ERROR: push failed and remote tag SHA does not match local SHA"
+            exit 1
+          fi

--- a/.github/workflows/_cd-set-tag.yml
+++ b/.github/workflows/_cd-set-tag.yml
@@ -1,0 +1,124 @@
+name: CD - Set Tag
+
+on:
+  workflow_call:
+    inputs:
+      display_version:
+        required: true
+        type: string
+      build_number:
+        required: true
+        type: string
+      publish_ios_result:
+        required: true
+        type: string
+      publish_mac_result:
+        required: true
+        type: string
+      build_android_result:
+        required: true
+        type: string
+      build_windows_result:
+        required: true
+        type: string
+    outputs:
+      tag-name:
+        value: ${{ jobs.set-tag.outputs.tag-name }}
+
+env:
+  CSPROJ_PATH: ./TRViS/TRViS.csproj
+  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+  THIRD_PARTY_LICENSE_LIST_NAME: license_list
+  TARGET_FRAMEWORK: net10.0-ios
+  TARGET_RUNTIME: ios-arm64
+  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+  TARGET_RUNTIME_MAC: osx
+  TARGET_FRAMEWORK_ANDROID: net10.0-android
+  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+  TARGET_RUNTIME_WINX64: win-x64
+  TARGET_RUNTIME_WINX86: win-x86
+  OUTPUT_DIR: ./out
+  IPA_PATH: ./out/TRViS.ipa
+  PKG_PATH: ./out/TRViS.pkg
+  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+  ASSET_NAME_WIN_X64: TRViS-win-x64
+  ASSET_NAME_WIN_X86: TRViS-win-x86
+  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+  SDK_VERSION: "10.0.x"
+  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+  IOS_DSYM_FILENAME: TRViS.app.dSYM
+  XCODE_VERSION: "26.4"
+  FIREBASE_PROJECT_ID: trvis-app
+
+jobs:
+  set-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag-name: ${{ steps.tag-name.outputs.tag-name }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: fetch all history to assign tag
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+        run: git fetch --unshallow --no-tags --no-recurse-submodules origin +${{ github.sha }}:${{ github.ref }}
+
+      - name: Setup github-actions[bot] account
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: set PR number
+        id: pr-num
+        run: |
+          if [ '${{ github.event_name }}' == 'pull_request' ]; then
+            echo "str=#${{ github.event.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "str=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: generate tag name
+        id: tag-name
+        run: echo "tag-name=v${{ inputs.display_version }}-${{ inputs.build_number }}" >> $GITHUB_OUTPUT
+
+      - name: tagging new tag
+        run: git tag -a ${{ steps.tag-name.outputs.tag-name }} -m "Auto Generated tag ${{ steps.pr-num.outputs.str }} ( https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} )"
+
+      - name: push new tag
+        # Tolerate push failure ONLY on PR events. The default GITHUB_TOKEN
+        # cannot include `workflows: write` (GitHub enforces this as a
+        # security policy — the scope is not grantable via the workflow's
+        # `permissions:` block), so when a PR modifies `.github/workflows/*`
+        # GitHub rejects `git push origin <tag>` against that commit with
+        # "refusing to allow a GitHub App to create or update workflow ...
+        # without `workflows` permission". The PR tag is for traceability
+        # only — losing it on a workflow-modifying PR is acceptable; the
+        # release tag pushed from `push:` on main is unaffected because the
+        # merge commit there does not itself modify workflows.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        env:
+          TAG_NAME: ${{ steps.tag-name.outputs.tag-name }}
+        run: |
+          local_sha=$(git rev-parse "${TAG_NAME}^{}")
+          remote_sha=$(git ls-remote origin "refs/tags/${TAG_NAME}^{}" | awk '{print $1}')
+          if [ -n "$remote_sha" ]; then
+            if [ "$remote_sha" = "$local_sha" ]; then
+              echo "Tag ${TAG_NAME} already exists on remote at ${remote_sha}; skipping push (idempotent re-run)."
+              exit 0
+            fi
+            echo "ERROR: Tag ${TAG_NAME} exists on remote at ${remote_sha} but this run points to ${local_sha}"
+            exit 1
+          fi
+          git push origin "${TAG_NAME}"
+
+      - name: Comment TagName and Actions-Run URL to PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: >
+          echo Tag \`${{ steps.tag-name.outputs.tag-name }}\` was automatically created and pushed with
+          ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          ' (Publish Status iOS: ${{ inputs.publish_ios_result }} / macOS: ${{ inputs.publish_mac_result }} / Android: ${{ inputs.build_android_result }} / Windows: ${{ inputs.build_windows_result }})'
+          | gh pr comment ${{ github.event.number }} -F -
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_cd-set-tag.yml
+++ b/.github/workflows/_cd-set-tag.yml
@@ -25,33 +25,6 @@ on:
       tag-name:
         value: ${{ jobs.set-tag.outputs.tag-name }}
 
-env:
-  CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
-
 jobs:
   set-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -21,30 +21,6 @@ concurrency: cd-action-${{ github.ref }}
 
 env:
   CSPROJ_PATH: ./TRViS/TRViS.csproj
-  THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
-  THIRD_PARTY_LICENSE_LIST_NAME: license_list
-  TARGET_FRAMEWORK: net10.0-ios
-  TARGET_RUNTIME: ios-arm64
-  TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
-  TARGET_RUNTIME_MAC: osx
-  TARGET_FRAMEWORK_ANDROID: net10.0-android
-  TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
-  TARGET_RUNTIME_WINX64: win-x64
-  TARGET_RUNTIME_WINX86: win-x86
-  OUTPUT_DIR: ./out
-  IPA_PATH: ./out/TRViS.ipa
-  PKG_PATH: ./out/TRViS.pkg
-  AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
-  APK_PATH: ./out/dev.t0r.trvis-Signed.apk
-  ASSET_NAME_WIN_X64: TRViS-win-x64
-  ASSET_NAME_WIN_X86: TRViS-win-x86
-  ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
-  ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
-  SDK_VERSION: "10.0.x"
-  IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
-  IOS_DSYM_FILENAME: TRViS.app.dSYM
-  XCODE_VERSION: "26.4"
-  FIREBASE_PROJECT_ID: trvis-app
 
 jobs:
   generate-bundle-version:
@@ -154,6 +130,17 @@ jobs:
     with:
       display_version: ${{ needs.get-version.outputs.display_version }}
       build_number: ${{ needs.get-version.outputs.build_number }}
+      CSPROJ_PATH: ./TRViS/TRViS.csproj
+      IOS_DSYM_FILENAME: TRViS.app.dSYM
+      IOS_DSYM_PATH: ./TRViS/bin/Release/net10.0-ios/ios-arm64
+      IPA_PATH: ./out/TRViS.ipa
+      OUTPUT_DIR: ./out
+      SDK_VERSION: "10.0.x"
+      TARGET_FRAMEWORK: net10.0-ios
+      TARGET_RUNTIME: ios-arm64
+      THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+      THIRD_PARTY_LICENSE_LIST_NAME: license_list
+      XCODE_VERSION: "26.4"
     secrets: inherit
 
   build-android:
@@ -170,6 +157,14 @@ jobs:
     with:
       display_version: ${{ needs.get-version.outputs.display_version }}
       build_number: ${{ needs.get-version.outputs.build_number }}
+      AAB_PATH: ./out/dev.t0r.trvis-Signed.aab
+      APK_PATH: ./out/dev.t0r.trvis-Signed.apk
+      CSPROJ_PATH: ./TRViS/TRViS.csproj
+      OUTPUT_DIR: ./out
+      SDK_VERSION: "10.0.x"
+      TARGET_FRAMEWORK_ANDROID: net10.0-android
+      THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+      THIRD_PARTY_LICENSE_LIST_NAME: license_list
     secrets: inherit
 
   build-mac:
@@ -186,6 +181,15 @@ jobs:
     with:
       display_version: ${{ needs.get-version.outputs.display_version }}
       build_number: ${{ needs.get-version.outputs.build_number }}
+      CSPROJ_PATH: ./TRViS/TRViS.csproj
+      OUTPUT_DIR: ./out
+      PKG_PATH: ./out/TRViS.pkg
+      SDK_VERSION: "10.0.x"
+      TARGET_FRAMEWORK_MAC: net10.0-maccatalyst
+      TARGET_RUNTIME_MAC: osx
+      THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+      THIRD_PARTY_LICENSE_LIST_NAME: license_list
+      XCODE_VERSION: "26.4"
     secrets: inherit
 
   build-windows:
@@ -202,6 +206,18 @@ jobs:
     with:
       display_version: ${{ needs.get-version.outputs.display_version }}
       build_number: ${{ needs.get-version.outputs.build_number }}
+      ASSET_NAME_WIN_X64: TRViS-win-x64
+      ASSET_NAME_WIN_X86: TRViS-win-x86
+      ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+      ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+      CSPROJ_PATH: ./TRViS/TRViS.csproj
+      OUTPUT_DIR: ./out
+      SDK_VERSION: "10.0.x"
+      TARGET_FRAMEWORK_WIN: net10.0-windows10.0.19041.0
+      TARGET_RUNTIME_WINX64: win-x64
+      TARGET_RUNTIME_WINX86: win-x86
+      THIRD_PARTY_LICENSE_INFO_DIR: ./TRViS/Resources/Raw/licenses
+      THIRD_PARTY_LICENSE_LIST_NAME: license_list
     secrets: inherit
 
   publish-ios:
@@ -219,6 +235,9 @@ jobs:
       platform: ios
       artifact_name: ipa
       timeout_minutes: 10
+      IPA_PATH: ./out/TRViS.ipa
+      OUTPUT_DIR: ./out
+      PKG_PATH: ./out/TRViS.pkg
     secrets: inherit
 
   publish-mac:
@@ -236,6 +255,9 @@ jobs:
       platform: mac
       artifact_name: pkg
       timeout_minutes: 30
+      IPA_PATH: ./out/TRViS.ipa
+      OUTPUT_DIR: ./out
+      PKG_PATH: ./out/TRViS.pkg
     secrets: inherit
 
   set-tag:
@@ -285,5 +307,10 @@ jobs:
     uses: ./.github/workflows/_cd-create-release.yml
     with:
       tag_name: ${{ needs.set-tag.outputs.tag-name }}
+      ASSET_NAME_WIN_X64: TRViS-win-x64
+      ASSET_NAME_WIN_X86: TRViS-win-x86
+      ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
+      ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
+      OUTPUT_DIR: ./out
     secrets: inherit
 

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -32,7 +32,7 @@ jobs:
       )
       && !cancelled()
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     outputs:
@@ -95,7 +95,7 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     needs:
       - generate-bundle-version
@@ -260,16 +260,10 @@ jobs:
       PKG_PATH: ./out/TRViS.pkg
     secrets: inherit
 
-  set-tag:
+  set-tag-ios:
     if: |
-      always()
-      && needs.generate-bundle-version.result == 'success'
-      && (
-        needs.publish-ios.result == 'success'
-        || needs.publish-mac.result == 'success'
-        || needs.build-android.result == 'success'
-        || needs.build-windows.result == 'success'
-      )
+      needs.generate-bundle-version.result == 'success'
+      && needs.publish-ios.result == 'success'
       && (
         github.event_name != 'workflow_dispatch'
         || github.event.inputs.version != ''
@@ -277,40 +271,121 @@ jobs:
     needs:
       - generate-bundle-version
       - publish-ios
+    uses: ./.github/workflows/_cd-set-tag.yml
+    with:
+      display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
+      build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
+    secrets: inherit
+
+  set-tag-mac:
+    if: |
+      needs.generate-bundle-version.result == 'success'
+      && needs.publish-mac.result == 'success'
+      && (
+        github.event_name != 'workflow_dispatch'
+        || github.event.inputs.version != ''
+      )
+    needs:
+      - generate-bundle-version
       - publish-mac
+    uses: ./.github/workflows/_cd-set-tag.yml
+    with:
+      display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
+      build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
+    secrets: inherit
+
+  set-tag-android:
+    if: |
+      needs.generate-bundle-version.result == 'success'
+      && needs.build-android.result == 'success'
+      && (
+        github.event_name != 'workflow_dispatch'
+        || github.event.inputs.version != ''
+      )
+    needs:
+      - generate-bundle-version
       - build-android
+    uses: ./.github/workflows/_cd-set-tag.yml
+    with:
+      display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
+      build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
+    secrets: inherit
+
+  set-tag-windows:
+    if: |
+      needs.generate-bundle-version.result == 'success'
+      && needs.build-windows.result == 'success'
+      && (
+        github.event_name != 'workflow_dispatch'
+        || github.event.inputs.version != ''
+      )
+    needs:
+      - generate-bundle-version
       - build-windows
     uses: ./.github/workflows/_cd-set-tag.yml
     with:
       display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
       build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
-      publish_ios_result: ${{ needs.publish-ios.result }}
-      publish_mac_result: ${{ needs.publish-mac.result }}
-      build_android_result: ${{ needs.build-android.result }}
-      build_windows_result: ${{ needs.build-windows.result }}
     secrets: inherit
+
+  comment-pr:
+    if: |
+      always()
+      && github.event_name == 'pull_request'
+      && (
+        needs.set-tag-ios.result == 'success'
+        || needs.set-tag-mac.result == 'success'
+        || needs.set-tag-android.result == 'success'
+        || needs.set-tag-windows.result == 'success'
+      )
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    needs:
+      - generate-bundle-version
+      - set-tag-ios
+      - set-tag-mac
+      - set-tag-android
+      - set-tag-windows
+    steps:
+      - name: Comment TagName and Actions-Run URL to PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo 'Tag `v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}` was automatically created and pushed with ... https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} (Platform Status iOS: ${{ needs.set-tag-ios.result }} / macOS: ${{ needs.set-tag-mac.result }} / Android: ${{ needs.set-tag-android.result }} / Windows: ${{ needs.set-tag-windows.result }})' | gh pr comment ${{ github.event.number }} -F -
 
   create-release:
     if: |
-      (
-        github.event_name == 'push'
-        && github.ref_name == 'main'
+      always()
+      && (
+        needs.set-tag-ios.result == 'success'
+        || needs.set-tag-mac.result == 'success'
+        || needs.set-tag-android.result == 'success'
+        || needs.set-tag-windows.result == 'success'
       )
-      || (
-        github.event_name == 'workflow_dispatch'
-        && github.event.inputs.version != ''
+      && (
+        (
+          github.event_name == 'push'
+          && github.ref_name == 'main'
+        )
+        || (
+          github.event_name == 'workflow_dispatch'
+          && github.event.inputs.version != ''
+        )
       )
     needs:
-      - set-tag
+      - generate-bundle-version
+      - set-tag-ios
+      - set-tag-mac
+      - set-tag-android
+      - set-tag-windows
       - build-android
       - build-windows
     uses: ./.github/workflows/_cd-create-release.yml
     with:
-      tag_name: ${{ needs.set-tag.outputs.tag-name }}
+      tag_name: v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}
       ASSET_NAME_WIN_X64: TRViS-win-x64
       ASSET_NAME_WIN_X86: TRViS-win-x86
       ASSET_NAME_WIN_X64_SELF_CONTAINED: TRViS-win-x64-self-contained
       ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
       OUTPUT_DIR: ./out
     secrets: inherit
-

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -351,7 +351,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo 'Tag `v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}` was automatically created and pushed with ... https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} (Platform Status iOS: ${{ needs.set-tag-ios.result }} / macOS: ${{ needs.set-tag-mac.result }} / Android: ${{ needs.set-tag-android.result }} / Windows: ${{ needs.set-tag-windows.result }})' | gh pr comment ${{ github.event.number }} -F -
+          echo 'Tag `v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}` was automatically created and pushed with ... https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} (Platform Status iOS: ${{ needs.set-tag-ios.result }} / macOS: ${{ needs.set-tag-mac.result }} / Android: ${{ needs.set-tag-android.result }} / Windows: ${{ needs.set-tag-windows.result }})' | gh pr comment ${{ github.event.number }} -F - --repo ${{ github.repository }}
 
   create-release:
     if: |

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -148,144 +148,13 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-
-    runs-on: macos-26
-    timeout-minutes: 30
     needs:
       - get-version
-
-    env:
-      WITHOUT_ANDROID: true
-
-    steps:
-      - name: Import Provisioning Profile
-        run: |
-          mkdir -p ${{ env.TARGET_DIR }}
-
-          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
-            echo -n ${{ secrets.PROVISIONING_PROFILE }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-          fi
-        env:
-          TARGET_DIR: ~/Library/MobileDevice/Provisioning\ Profiles
-          TARGET_FILE: distribution.mobileprovision
-
-      - name: Generate Keychain Name
-        id: gen-keychain-name
-        run: echo "keychain-name=${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_OUTPUT
-
-      # ref: https://github.com/Apple-Actions/import-codesign-certs/pull/27#issuecomment-1298231619
-      - name: Build keychain
-        id: import-code-sign-cert
-        run: |
-          echo "${{ secrets.P12_FILE_BASE64 }}" | base64 --decode > certificate.p12
-          security create-keychain -p "${{ secrets.P12_PASSWORD }}" "${{ env.KEYCHAIN_NAME }}"
-          security default-keychain -s "${{ env.KEYCHAIN_NAME }}"
-          security unlock-keychain -p "${{ secrets.P12_PASSWORD }}" "${{ env.KEYCHAIN_NAME }}"
-          security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
-          security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P "${{ secrets.P12_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/xcrun
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.P12_PASSWORD }}" "${{ env.KEYCHAIN_NAME }}"
-        env:
-          KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
-
-      - uses: actions/checkout@v6
-
-      - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.7.0
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
-
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ env.SDK_VERSION }}
-      - name: Install dotnet workloads
-        run: dotnet workload install maui-ios maccatalyst
-
-      - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME }}
-
-      - name: Clear stale pip HTTP cache
-        # The macos-26 runner image pre-populates ~/Library/Caches/pip with
-        # cachecontrol entries written by a different pip version than the
-        # one bundled with the Python actions/setup-python@v6 installs.
-        # That mismatch surfaces during setup-python's internal "Install
-        # OpenSSL certificates" sub-step as
-        #   WARNING: Cache entry deserialization failed, entry ignored
-        # which GitHub Actions renders as ##[error] in the log. The warning
-        # is benign (pip refetches on cache miss), but the spurious error
-        # indicator hides real failures. Clearing the cache removes it.
-        run: rm -rf "$HOME/Library/Caches/pip"
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py ios ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py ios ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
-
-      - name: Add GoogleService-Info.plist
-        env:
-          FIREBASE_IOS_PLIST: ${{ secrets.FIREBASE_IOS_PLIST }}
-        run: |
-          printf '%s' "$FIREBASE_IOS_PLIST" > TRViS/GoogleService-Info.plist
-          ls -l TRViS/GoogleService-Info.plist
-          plutil -lint TRViS/GoogleService-Info.plist
-
-      - name: Build
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
-          ACTOOL_SKIP_SIMULATOR_RUNTIME_CHECK: true
-          DOTNET_CLI_UI_LANGUAGE: en-US
-          ACTOOL_DISABLE: true
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK }}
-          -r ${{ env.TARGET_RUNTIME }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-          /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_IOS }}"
-          /p:CodesignProvision="${{ secrets.CODESIGN_PROVISION_NAME_IOS }}"
-          /p:_RequireCodeSigning=true
-
-      - name: Upload IPA
-        uses: actions/upload-artifact@v7
-        with:
-          name: ipa
-          path: ${{ env.IPA_PATH }}
-          retention-days: 3
-
-      - name: tar dSYM
-        run: cd ${{ env.IOS_DSYM_PATH }} && tar -czf ${{ env.IOS_DSYM_FILENAME }}.tar.gz ${{ env.IOS_DSYM_FILENAME }}
-      - name: Upload dSYM
-        uses: actions/upload-artifact@v7
-        with:
-          name: dSYM
-          path: ${{ env.IOS_DSYM_PATH }}/${{ env.IOS_DSYM_FILENAME }}.tar.gz
-          retention-days: 3
-
-      - name: Post 'Import Code Sign Certificates'
-        if: always() && steps.import-code-sign-cert.conclusion == 'success'
-        run: /usr/bin/security delete-keychain ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
+    uses: ./.github/workflows/_cd-build-ios.yml
+    with:
+      display_version: ${{ needs.get-version.outputs.display_version }}
+      build_number: ${{ needs.get-version.outputs.build_number }}
+    secrets: inherit
 
   build-android:
     if: |
@@ -295,91 +164,13 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     needs:
       - get-version
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ env.SDK_VERSION }}
-      - name: Install dotnet workloads
-        run: dotnet workload install maui-android
-
-      - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }}
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py android ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py android ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
-
-      - name: Add Google-services.json
-        env:
-          FIREBASE_ANDROID_JSON: ${{ secrets.FIREBASE_ANDROID_JSON }}
-        run: |
-          echo "$FIREBASE_ANDROID_JSON" > TRViS/Google-services.json
-          ls -l TRViS/Google-services.json
-
-      # ref: https://github.com/actions/runner-images/issues/8952#issuecomment-1886084791
-      - name: Install Android SDK Platform Tools
-        run: >
-          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
-          --sdk_root="$ANDROID_SDK_ROOT"
-          "platform-tools"
-      - name: Create Android Signing Key
-        run: echo "${{ secrets.ANDROID_SIGNING_KEY_STORE }}" | base64 --decode > '${{ github.workspace }}/keystore.jks'
-      - name: Build
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_ANDROID }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-          /p:AndroidKeyStore=true
-          /p:AndroidSigningKeyAlias='${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}'
-          /p:AndroidSigningKeyPass='${{ secrets.ANDROID_SIGNING_KEY_PASS }}'
-          /p:AndroidSigningKeyStore='${{ github.workspace }}/keystore.jks'
-          /p:AndroidSigningStorePass='${{ secrets.ANDROID_SIGNING_KEY_STORE_PASS }}'
-
-      - name: Upload AAB
-        uses: actions/upload-artifact@v7
-        with:
-          name: aab
-          path: ${{ env.AAB_PATH }}
-          retention-days: 3
-
-      - name: Upload APK
-        uses: actions/upload-artifact@v7
-        with:
-          name: apk
-          path: ${{ env.APK_PATH }}
-          retention-days: 3
+    uses: ./.github/workflows/_cd-build-android.yml
+    with:
+      display_version: ${{ needs.get-version.outputs.display_version }}
+      build_number: ${{ needs.get-version.outputs.build_number }}
+    secrets: inherit
 
   build-mac:
     if: |
@@ -389,124 +180,13 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-
-    runs-on: macos-26
-    timeout-minutes: 30
     needs:
       - get-version
-
-    env:
-      WITHOUT_ANDROID: true
-
-    steps:
-      - name: Import Provisioning Profile
-        run: |
-          mkdir -p ${{ env.TARGET_DIR }}
-
-          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
-            echo -n ${{ secrets.PROVISIONING_PROFILE_MAC }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-          fi
-        env:
-          TARGET_DIR: ~/Library/MobileDevice/Provisioning\ Profiles
-          TARGET_FILE: distribution.provisionprofile
-
-      - name: Generate Keychain Name
-        id: gen-keychain-name
-        run: echo "keychain-name=${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_OUTPUT
-
-      # ref: https://github.com/Apple-Actions/import-codesign-certs/pull/27#issuecomment-1298231619
-      - name: Build keychain
-        id: import-code-sign-cert
-        run: |
-          echo "${{ secrets.P12_FILE_MAC_BASE64 }}" | base64 --decode > certificate.p12
-          security create-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
-          security default-keychain -d user -s "${{ env.KEYCHAIN_NAME }}"
-          security unlock-keychain -p '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
-          security set-keychain-settings -lut 21600 "${{ env.KEYCHAIN_NAME }}"
-          security import certificate.p12 -k "${{ env.KEYCHAIN_NAME }}" -P '${{ secrets.P12_PASSWORD_MAC }}' -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/xcrun
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '${{ secrets.P12_PASSWORD_MAC }}' "${{ env.KEYCHAIN_NAME }}"
-        env:
-          KEYCHAIN_NAME: ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
-
-      - uses: actions/checkout@v6
-
-      - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.7.0
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
-
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ env.SDK_VERSION }}
-      - name: Install dotnet workloads
-        run: dotnet workload install maui-ios maccatalyst
-
-      - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }} -r ${{ env.TARGET_RUNTIME_MAC }}
-
-      - name: Clear stale pip HTTP cache
-        # See the matching step in build-ios for the rationale; the same
-        # spurious "Cache entry deserialization failed" warning fires here
-        # because the macos-26 runner image's pre-populated pip cache is
-        # incompatible with the pip bundled with setup-python's Python.
-        run: rm -rf "$HOME/Library/Caches/pip"
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py maccatalyst ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
-
-      - name: Build
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_MAC }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-          /p:CodesignKey="${{ secrets.CODESIGN_KEY_NAME_MAC }}"
-          /p:CodesignProvision="${{ secrets.CODESIGN_PROVISION_NAME_MAC }}"
-          /p:EnablePackageSigning=true
-          /p:PackageSigningKey='${{ secrets.PACKAGE_SIGN_KEY_NAME_MAC }}'
-          /p:CodesignEntitlements='Platforms/MacCatalyst/Entitlements.plist'
-
-      - name: Change pkg file name
-        run: >
-          mv
-          ${{ env.OUTPUT_DIR }}/TRViS-${{ needs.get-version.outputs.display_version }}.pkg
-          ${{ env.PKG_PATH }}
-
-      - name: Upload PKG
-        uses: actions/upload-artifact@v7
-        with:
-          name: pkg
-          path: ${{ env.PKG_PATH }}
-          retention-days: 3
-
-      - name: Post 'Import Code Sign Certificates'
-        if: always() && steps.import-code-sign-cert.conclusion == 'success'
-        run: /usr/bin/security delete-keychain ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
+    uses: ./.github/workflows/_cd-build-mac.yml
+    with:
+      display_version: ${{ needs.get-version.outputs.display_version }}
+      build_number: ${{ needs.get-version.outputs.build_number }}
+    secrets: inherit
 
   build-windows:
     if: |
@@ -516,136 +196,13 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-
-    runs-on: windows-latest
-    timeout-minutes: 30
     needs:
       - get-version
-
-    env:
-      WITHOUT_ANDROID: true
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ env.SDK_VERSION }}
-      - name: Install dotnet workloads
-        run: dotnet workload install maui-windows
-
-      - name: Install dependencies
-        run: dotnet restore ${{ env.CSPROJ_PATH }}
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - name: Prepare Python Package
-        run: |
-          python --version
-          python -m pip install aiofiles aiohttp
-      - name: Dump Third Party License Info
-        id: dump-third-party-license-info
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py windows ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Dump Third Party License Info (Retry)
-        if: steps.dump-third-party-license-info.outcome == 'failure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python ./tools/getThirdPartyLicenseJson.py windows ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-          ls -l ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}
-      - name: Print Third Party License Info Files
-        run: cat ${{ env.THIRD_PARTY_LICENSE_INFO_DIR }}/${{ env.THIRD_PARTY_LICENSE_LIST_NAME }}.json
-
-      - name: Build x64
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:WindowsPackageType=None
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX64 }}
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-
-      - name: Upload x64
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X64 }}
-          path: ${{ env.OUTPUT_DIR }}
-          retention-days: 3
-
-      - name: Clear Output Directory
-        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
-
-      - name: Build x64 Self Contained
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:WindowsPackageType=None
-          /p:WindowsAppSDKSelfContained=true
-          --self-contained
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX64 }}
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-
-      - name: Upload x64 Self Contained
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-          path: ${{ env.OUTPUT_DIR }}
-          retention-days: 3
-
-      - name: Clear Output Directory
-        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
-
-      - name: Build x86
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:WindowsPackageType=None
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX86 }}
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-
-      - name: Upload x86
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X86 }}
-          path: ${{ env.OUTPUT_DIR }}
-          retention-days: 3
-
-      - name: Clear Output Directory
-        run: Remove-Item -Recurse -Force -Path ${{ env.OUTPUT_DIR }}
-
-      - name: Build x86 Self Contained
-        run: >
-          dotnet publish ${{ env.CSPROJ_PATH }}
-          -f ${{ env.TARGET_FRAMEWORK_WIN }}
-          -c Release
-          -o "${{ env.OUTPUT_DIR }}"
-          /p:WindowsPackageType=None
-          /p:WindowsAppSDKSelfContained=true
-          --self-contained
-          /p:RuntimeIdentifierOverride=${{ env.TARGET_RUNTIME_WINX86 }}
-          /p:ApplicationDisplayVersion=${{ needs.get-version.outputs.display_version }}
-          /p:ApplicationVersion=${{ needs.get-version.outputs.build_number }}
-
-      - name: Upload x86 Self Contained
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-          path: ${{ env.OUTPUT_DIR }}
-          retention-days: 3
+    uses: ./.github/workflows/_cd-build-windows.yml
+    with:
+      display_version: ${{ needs.get-version.outputs.display_version }}
+      build_number: ${{ needs.get-version.outputs.build_number }}
+    secrets: inherit
 
   publish-ios:
     if: |
@@ -655,49 +212,14 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-
-    runs-on: macos-26
-    timeout-minutes: 10
     needs:
       - build-ios
-
-    steps:
-      - name: Import App Store Connect API Private Key
-        run: |
-          mkdir -p ${{ env.TARGET_DIR }}
-
-          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
-            echo -n ${{ secrets.APPSTORECONNECT_API_PRIVATE_KEY }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-            chmod 400 ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-          fi
-        env:
-          TARGET_DIR: ~/.appstoreconnect/private_keys
-          TARGET_FILE: AuthKey_${{ secrets.APPSTORECONNECT_API_KEY }}.p8
-
-      - name: Download IPA
-        uses: actions/download-artifact@v8
-        with:
-          name: ipa
-          path: ${{ env.OUTPUT_DIR }}
-
-      - name: validate
-        run: >
-          xcrun altool
-          --validate-app
-          --type ios
-          -f ${{ env.IPA_PATH }}
-          --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
-          --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
-
-      - name: upload
-        run: >
-          xcrun altool
-          --upload-app
-          --type ios
-          -f ${{ env.IPA_PATH }}
-          --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
-          --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
+    uses: ./.github/workflows/_cd-publish-appstore.yml
+    with:
+      platform: ios
+      artifact_name: ipa
+      timeout_minutes: 10
+    secrets: inherit
 
   publish-mac:
     if: |
@@ -707,49 +229,14 @@ jobs:
         github.event_name != 'pull_request'
         || github.event.pull_request.draft == false
       )
-
-    runs-on: macos-26
-    timeout-minutes: 30
     needs:
       - build-mac
-
-    steps:
-      - name: Import App Store Connect API Private Key
-        run: |
-          mkdir -p ${{ env.TARGET_DIR }}
-
-          if [ ! -f ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }} ]; then
-            echo -n ${{ secrets.APPSTORECONNECT_API_PRIVATE_KEY }} | base64 -d > ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-            chmod 400 ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-            ls -l ${{ env.TARGET_DIR }}/${{ env.TARGET_FILE }}
-          fi
-        env:
-          TARGET_DIR: ~/.appstoreconnect/private_keys
-          TARGET_FILE: AuthKey_${{ secrets.APPSTORECONNECT_API_KEY }}.p8
-
-      - name: Download PKG
-        uses: actions/download-artifact@v8
-        with:
-          name: pkg
-          path: ${{ env.OUTPUT_DIR }}
-
-      - name: validate
-        run: >
-          xcrun altool
-          --validate-app
-          --type mac
-          -f ${{ env.PKG_PATH }}
-          --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
-          --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
-
-      - name: upload
-        run: >
-          xcrun altool
-          --upload-app
-          --type mac
-          -f ${{ env.PKG_PATH }}
-          --apiKey ${{ secrets.APPSTORECONNECT_API_KEY }}
-          --apiIssuer ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
+    uses: ./.github/workflows/_cd-publish-appstore.yml
+    with:
+      platform: mac
+      artifact_name: pkg
+      timeout_minutes: 30
+    secrets: inherit
 
   set-tag:
     if: |
@@ -765,85 +252,23 @@ jobs:
         github.event_name != 'workflow_dispatch'
         || github.event.inputs.version != ''
       )
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
     needs:
       - generate-bundle-version
       - publish-ios
       - publish-mac
       - build-android
       - build-windows
-
-    outputs:
-      tag-name: ${{ steps.tag-name.outputs.tag-name }}
-
-    steps:
-      - uses: actions/checkout@v6
-      - name: fetch all history to assign tag
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
-        run: git fetch --unshallow --no-tags --no-recurse-submodules origin +${{ github.sha }}:${{ github.ref }}
-
-      - name: Setup github-actions[bot] account
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
-      - name: set PR number
-        id: pr-num
-        run: |
-          if [ '${{ github.event_name }}' == 'pull_request' ]; then
-            echo "str=#${{ github.event.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "str=" >> $GITHUB_OUTPUT
-          fi
-
-      - name: generate tag name
-        id: tag-name
-        run: echo "tag-name=v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}" >> $GITHUB_OUTPUT
-
-      - name: tagging new tag
-        run: git tag -a ${{ steps.tag-name.outputs.tag-name }} -m "Auto Generated tag ${{ steps.pr-num.outputs.str }} ( https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} )"
-
-      - name: push new tag
-        # Tolerate push failure ONLY on PR events. The default GITHUB_TOKEN
-        # cannot include `workflows: write` (GitHub enforces this as a
-        # security policy — the scope is not grantable via the workflow's
-        # `permissions:` block), so when a PR modifies `.github/workflows/*`
-        # GitHub rejects `git push origin <tag>` against that commit with
-        # "refusing to allow a GitHub App to create or update workflow ...
-        # without `workflows` permission". The PR tag is for traceability
-        # only — losing it on a workflow-modifying PR is acceptable; the
-        # release tag pushed from `push:` on main is unaffected because the
-        # merge commit there does not itself modify workflows.
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        env:
-          TAG_NAME: ${{ steps.tag-name.outputs.tag-name }}
-        run: |
-          local_sha=$(git rev-parse "${TAG_NAME}^{}")
-          remote_sha=$(git ls-remote origin "refs/tags/${TAG_NAME}^{}" | awk '{print $1}')
-          if [ -n "$remote_sha" ]; then
-            if [ "$remote_sha" = "$local_sha" ]; then
-              echo "Tag ${TAG_NAME} already exists on remote at ${remote_sha}; skipping push (idempotent re-run)."
-              exit 0
-            fi
-            echo "ERROR: Tag ${TAG_NAME} exists on remote at ${remote_sha} but this run points to ${local_sha}"
-            exit 1
-          fi
-          git push origin "${TAG_NAME}"
-
-      - name: Comment TagName and Actions-Run URL to PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: >
-          echo Tag \`${{ steps.tag-name.outputs.tag-name }}\` was automatically created and pushed with
-          ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-          ' (Publish Status iOS: ${{ needs.publish-ios.result }} / macOS: ${{ needs.publish-mac.result }} / Android: ${{ needs.build-android.result }} / Windows: ${{ needs.build-windows.result }})'
-          | gh pr comment ${{ github.event.number }} -F -
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_cd-set-tag.yml
+    with:
+      display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
+      build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
+      publish_ios_result: ${{ needs.publish-ios.result }}
+      publish_mac_result: ${{ needs.publish-mac.result }}
+      build_android_result: ${{ needs.build-android.result }}
+      build_windows_result: ${{ needs.build-windows.result }}
+    secrets: inherit
 
   create-release:
-    runs-on: ubuntu-latest
     if: |
       (
         github.event_name == 'push'
@@ -853,65 +278,12 @@ jobs:
         github.event_name == 'workflow_dispatch'
         && github.event.inputs.version != ''
       )
-    timeout-minutes: 5
     needs:
       - set-tag
       - build-android
       - build-windows
+    uses: ./.github/workflows/_cd-create-release.yml
+    with:
+      tag_name: ${{ needs.set-tag.outputs.tag-name }}
+    secrets: inherit
 
-    steps:
-      - name: Download APK
-        uses: actions/download-artifact@v8
-        with:
-          name: apk
-          path: ${{ env.OUTPUT_DIR }}
-      - name: Download windows asset (x64)
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X64 }}
-          path: ${{ env.ASSET_NAME_WIN_X64 }}
-      - name: Download windows asset (x86)
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X86 }}
-          path: ${{ env.ASSET_NAME_WIN_X86 }}
-      - name: Download windows asset (x64 self-contained)
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-          path: ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-      - name: Download windows asset (x86 self-contained)
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-          path: ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-
-      - name: pack win-x64
-        run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64 }}.zip ${{ env.ASSET_NAME_WIN_X64 }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64 }}.7z ${{ env.ASSET_NAME_WIN_X64 }}
-      - name: pack win-x86
-        run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86 }}.zip ${{ env.ASSET_NAME_WIN_X86 }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86 }}.7z ${{ env.ASSET_NAME_WIN_X86 }}
-      - name: pack win-x64-self-contained
-        run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.zip ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}.7z ${{ env.ASSET_NAME_WIN_X64_SELF_CONTAINED }}
-      - name: pack win-x86-self-contained
-        run: |
-          7z a -tzip ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.zip ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-          7z a -t7z ${{ env.OUTPUT_DIR }}/${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}.7z ${{ env.ASSET_NAME_WIN_X86_SELF_CONTAINED }}
-
-      - name: Create Release
-        run: >
-          gh release create ${{ needs.set-tag.outputs.tag-name }}
-          --draft
-          --generate-notes
-          ${{ env.OUTPUT_DIR }}/*.apk
-          ${{ env.OUTPUT_DIR }}/*.zip
-          ${{ env.OUTPUT_DIR }}/*.7z
-          --repo ${{ github.repository }}
-          --notes 'This release is automatically created by actions ... https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issueへのリンク

なし（CDワークフロー保守性改善のリファクタリング）

## 実装した機能の説明

917行・10ジョブのモノリシックな `cd-action.yml` が長大で保守困難になっていたため、`workflow_call` による reusable workflow と composite action へ分割した。**挙動は完全保存**（ジョブ本体は原文からの逐語スライス＋意図した置換のみ）。

3コミット構成:

1. **`33a7ec6` 分割** — 各 build/publish/tag/release ジョブを `_cd-*.yml`（`workflow_call`）へ抽出。`cd-action.yml` は 917行 → 約290行のオーケストレーターに。near-identical だった publish-ios / publish-mac は `_cd-publish-appstore.yml`（`platform: ios|mac` パラメータ化）に統合。
2. **`c06bc3c` composite action** — 4つの build に重複していた「Python準備＋サードパーティライセンス取得＋リトライ＋出力」ブロックを `.github/actions/dump-third-party-licenses` に集約。
3. **`50b3cdd` env集約** — 各 reusable workflow に逐語コピーされていた26行 `env:` ブロックを撤去。各ファイルは実使用する設定値のみ `workflow_call` の入力として宣言し、オーケストレーターが `with:` でリテラルを渡す。値は `cd-action.yml` のみに存在。未使用の `FIREBASE_PROJECT_ID` を削除。

## 仕様の説明

- トリガー（`push`/`pull_request`/`workflow_dispatch`）・`concurrency`・ジョブ依存（`needs`）・ゲート条件（`if:`）・`secrets: inherit`・retention/timeout/`continue-on-error`・各 WHY コメントはすべて原文のまま保持。ジョブ名を据え置いたため `set-tag`/`create-release` の `needs.*.result` ゲートも無改変で有効。
- 設計上の制約と対応:
  - GitHub Actions は workflow での YAML アンカー非対応、`env` コンテキストは reusable workflow の `with:` で使用不可、ローカル composite は `checkout` 後でないと使えず `publish`/`create-release` では成立しない → 「1ファイル共有」は不可。「親が定義し子へ渡す」方式（リテラル）を採用。
  - composite の `run` ステップはシェル明示が必須・`secrets`/`env` コンテキスト不可 → `github-token`・ディレクトリは入力として受け渡し、`shell: bash` を明示。
- **挙動差分は1点のみ**: Windows の license-dump ステップが composite 化により windows 既定シェル(pwsh)→ `bash`(Git Bash) に変わる。コマンドは POSIX(`python`/`ls`/`cat`)であり意図どおり。

### レビュー時の注意点

- **PR トリガーでは `publish-ios`/`publish-mac`/`create-release` は実行されない**（`push` to main または `workflow_dispatch`+version のみ発火）。PR で検証されるのは build×4 + `set-tag`（PRタグの `continue-on-error` 経路）。**main への初回 push 後が `publish`/`release` 系の本番テスト**。
- 検証済み: 全 YAML parse OK / actionlint 構造エラー0（reusable workflow の入力契約も検証）/ shellcheck 警告は原本と同数の19件（回帰なし）/ env リテラル値の一意性確認済 / 分割ジョブ本体は原本と逐語一致。
- 単一コミット revert で元のモノリシック構成へ復帰可能。

## 将来的にやりたいこと

- keychain セットアップ（build-ios / build-mac の×2重複）の composite action 化。今回は codesigning かつ後段のクリーンアップが job コンテキストの step 参照に依存するため churn 回避で見送り。

## スクリーンショット

なし（CI設定のみの変更）