### PR TITLE
デフォルトの選択を電車時刻表に変更

### DIFF
--- a/TRViS/MyAppCustomizables/SettingFileBase.cs
+++ b/TRViS/MyAppCustomizables/SettingFileBase.cs
@@ -65,7 +65,7 @@ public partial class SettingFileStructure
 	/// <summary>
 	/// 横型時刻表ボタンに表示するラベル
 	/// </summary>
-	public HorizontalTimetableButtonLabel HorizontalTimetableButtonLabel { get; set; } = HorizontalTimetableButtonLabel.Horizontal;
+	public HorizontalTimetableButtonLabel HorizontalTimetableButtonLabel { get; set; } = HorizontalTimetableButtonLabel.Train;
 
 	/// <summary>
 	/// PDF 表示に使用する pdf.js のバージョンと描画方式

--- a/TRViS/RootPages/EasterEggPage.xaml.cs
+++ b/TRViS/RootPages/EasterEggPage.xaml.cs
@@ -211,7 +211,7 @@ public partial class EasterEggPage : ContentPage
 			0 => HorizontalTimetableButtonLabel.Horizontal,
 			1 => HorizontalTimetableButtonLabel.Train,
 			2 => HorizontalTimetableButtonLabel.ETrain,
-			_ => HorizontalTimetableButtonLabel.Horizontal
+			_ => HorizontalTimetableButtonLabel.Train
 		};
 
 		logger.Info("HorizontalTimetableButtonLabel changed to {0}", newLabel);
@@ -228,7 +228,7 @@ public partial class EasterEggPage : ContentPage
 				HorizontalTimetableButtonLabel.Horizontal => 0,
 				HorizontalTimetableButtonLabel.Train => 1,
 				HorizontalTimetableButtonLabel.ETrain => 2,
-				_ => 0
+				_ => 1
 			};
 		}
 		finally

--- a/TRViS/ViewModels/EasterEggPageViewModel.cs
+++ b/TRViS/ViewModels/EasterEggPageViewModel.cs
@@ -52,7 +52,7 @@ public partial class EasterEggPageViewModel : ObservableObject
 	public partial bool KeepScreenOnWhenRunning { get; set; } = false;
 
 	[ObservableProperty]
-	public partial HorizontalTimetableButtonLabel HorizontalTimetableButtonLabel { get; set; } = HorizontalTimetableButtonLabel.Horizontal;
+	public partial HorizontalTimetableButtonLabel HorizontalTimetableButtonLabel { get; set; } = HorizontalTimetableButtonLabel.Train;
 
 	[ObservableProperty]
 	public partial PdfJsRenderEngine PdfJsRenderEngine { get; set; } = PdfJsRenderEngine.V2Svg;


### PR DESCRIPTION
## Issueへのリンク

## 実装した機能の説明

デフォルトの横型時刻表ボタンのラベルを「電車」に変更した。

## 仕様の説明

アプリ起動時に表示される横型時刻表ボタンのラベルが「電車」として設定される。

## 将来的にやりたいこと

## スクリーンショット

