### PR TITLE
WebSocket切断時にHome画面で切断表示＋再接続ボタンを出す (#261)

### DIFF
--- a/TRViS.LocationService.Tests/NetworkSyncConnectionLostWatcherTests.cs
+++ b/TRViS.LocationService.Tests/NetworkSyncConnectionLostWatcherTests.cs
@@ -1,0 +1,120 @@
+using NUnit.Framework;
+
+using TRViS.NetworkSyncService;
+
+namespace TRViS.LocationService.Tests;
+
+// NetworkSyncConnectionLostWatcher の単体テスト (#261)。
+// 既存の FakeNetworkSyncService (NetworkSyncServiceBase サブクラス、
+// RaiseConnectionClosed / RaiseConnectionFailed を公開) を流用する。
+[TestFixture]
+public class NetworkSyncConnectionLostWatcherTests
+{
+	[Test]
+	public void Ctor_NullCallback_Throws()
+	{
+		Assert.Throws<ArgumentNullException>(() => new NetworkSyncConnectionLostWatcher(null!));
+	}
+
+	[Test]
+	public void ConnectionClosed_OnWatchedService_InvokesCallbackOnce()
+	{
+		int count = 0;
+		var watcher = new NetworkSyncConnectionLostWatcher(() => count++);
+		var svc = new FakeNetworkSyncService();
+		watcher.Watch(svc);
+
+		svc.RaiseConnectionClosed();
+
+		Assert.That(count, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void ConnectionFailed_OnWatchedService_InvokesCallbackOnce()
+	{
+		int count = 0;
+		var watcher = new NetworkSyncConnectionLostWatcher(() => count++);
+		var svc = new FakeNetworkSyncService();
+		watcher.Watch(svc);
+
+		svc.RaiseConnectionFailed();
+
+		Assert.That(count, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void Rewatch_DifferentService_OldServiceNoLongerInvokesCallback_NewOneDoes()
+	{
+		int count = 0;
+		var watcher = new NetworkSyncConnectionLostWatcher(() => count++);
+		var oldSvc = new FakeNetworkSyncService();
+		var newSvc = new FakeNetworkSyncService();
+
+		watcher.Watch(oldSvc);
+		watcher.Watch(newSvc);
+
+		// 旧サービス (再接続で差し替えられた側) のイベントはコールバックを発火しない。
+		oldSvc.RaiseConnectionClosed();
+		Assert.That(count, Is.EqualTo(0), "stale service must not trigger the callback");
+
+		// 新サービスのイベントは発火する。
+		newSvc.RaiseConnectionClosed();
+		Assert.That(count, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void Clear_ThenFormerlyWatchedServiceRaises_DoesNotInvokeCallback()
+	{
+		int count = 0;
+		var watcher = new NetworkSyncConnectionLostWatcher(() => count++);
+		var svc = new FakeNetworkSyncService();
+
+		watcher.Watch(svc);
+		watcher.Clear();
+
+		svc.RaiseConnectionClosed();
+		svc.RaiseConnectionFailed();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(count, Is.EqualTo(0));
+			Assert.That(watcher.Watched, Is.Null);
+		});
+	}
+
+	// 再接続スワップ後に旧サービスが遅延イベントを出しても banner を再点灯させない、
+	// かつ watcher は常に最新サービスを追従する、という統合的な振る舞いの確認。
+	[Test]
+	public void AfterSwap_OnlyLatestServiceDrivesCallback()
+	{
+		int count = 0;
+		var watcher = new NetworkSyncConnectionLostWatcher(() => count++);
+		var a = new FakeNetworkSyncService();
+		var b = new FakeNetworkSyncService();
+
+		watcher.Watch(a);
+		watcher.Watch(b);
+
+		a.RaiseConnectionFailed();   // 旧 (A) -> 無視
+		Assert.That(count, Is.EqualTo(0));
+
+		b.RaiseConnectionFailed();   // 最新 (B) -> 発火
+		Assert.That(count, Is.EqualTo(1));
+		Assert.That(watcher.Watched, Is.SameAs(b));
+	}
+
+	[Test]
+	public void Rewatch_SameService_DoesNotDoubleSubscribe()
+	{
+		int count = 0;
+		var watcher = new NetworkSyncConnectionLostWatcher(() => count++);
+		var svc = new FakeNetworkSyncService();
+
+		watcher.Watch(svc);
+		watcher.Watch(svc); // 同一インスタンスの再 Watch は no-op であるべき
+
+		svc.RaiseConnectionClosed();
+
+		Assert.That(count, Is.EqualTo(1), "re-watching the same service must not double-subscribe");
+	}
+}

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -1362,6 +1362,48 @@ public class WebSocketIntegrationTests
 		}
 	}
 
+	// #261: 切断時 LocationService は GPS へフォールバックして
+	// WebSocketNetworkSyncService を Dispose するが、AppViewModel.Loader は
+	// その (Dispose 済み) サービスのまま据え置き、Home 画面は「サーバー未接続 +
+	// 再接続ボタン」を出しつつキャッシュ済みデータの閲覧/「開く」を継続できる。
+	// この UX が成立する前提 = Dispose 後も ILoader のキャッシュ読み出しが
+	// 生き続けること、を回帰テストで固定する。
+	[Test]
+	public async Task CachedLoaderData_RemainsReadableAfterDispose()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var timetableTask = WaitForEventAsync<TimetableData>(
+				h => service.TimetableUpdated += h,
+				h => service.TimetableUpdated -= h
+			);
+			await _control.BroadcastTimetableAsync(TestData.AllScopeJson);
+			await timetableTask;
+
+			// 切断時の LocationService.SetLonLatLocationService() 相当。
+			service.Dispose();
+
+			var loader = (ILoader)service;
+			Assert.Multiple(() =>
+			{
+				var workGroups = loader.GetWorkGroupList();
+				Assert.That(workGroups, Has.Count.EqualTo(1));
+				Assert.That(workGroups[0].Id, Is.EqualTo(TestData.WorkGroupId));
+
+				Assert.That(loader.GetWorkList(TestData.WorkGroupId), Has.Count.EqualTo(1));
+				Assert.That(loader.GetTrainDataList(TestData.WorkId), Has.Count.EqualTo(2));
+				Assert.That(loader.GetTrainData(TestData.TrainId), Is.Not.Null);
+			});
+		}
+		finally
+		{
+			service.Dispose();
+		}
+	}
+
 	// ================================================================
 	// 再接続
 	// ================================================================

--- a/TRViS.NetworkSyncService/NetworkSyncConnectionLostWatcher.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncConnectionLostWatcher.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace TRViS.NetworkSyncService;
+
+/// <summary>
+/// 1 つの <see cref="NetworkSyncServiceBase"/> の接続断 (
+/// <see cref="NetworkSyncServiceBase.ConnectionClosed"/> /
+/// <see cref="NetworkSyncServiceBase.ConnectionFailed"/>) を監視し、
+/// 「現在監視しているサービス」が接続を失ったときだけコールバックを呼ぶ。
+///
+/// <para>
+/// 別サービスを <see cref="Watch"/> し直すと旧サービスのハンドラを必ず外すため、
+/// 再接続で差し替えられた旧インスタンスの遅延イベントがコールバックを
+/// 再発火させることはない (#261)。AppViewModel 側はこのコールバックで
+/// UI スレッドへマーシャリングして観測対象プロパティを更新する想定で、
+/// このクラス自体は MAUI 非依存・同期で単体テスト可能。
+/// </para>
+/// </summary>
+public sealed class NetworkSyncConnectionLostWatcher
+{
+	private readonly Action _onConnectionLost;
+	private NetworkSyncServiceBase? _watched;
+
+	public NetworkSyncConnectionLostWatcher(Action onConnectionLost)
+	{
+		ArgumentNullException.ThrowIfNull(onConnectionLost);
+		_onConnectionLost = onConnectionLost;
+	}
+
+	/// <summary>現在監視中のサービス。未監視なら null。</summary>
+	public NetworkSyncServiceBase? Watched => _watched;
+
+	/// <summary>
+	/// <paramref name="service"/> の接続断監視を開始する。既に別サービスを
+	/// 監視していた場合はそのハンドラを先に外す。同一インスタンスの再 Watch は
+	/// 二重購読しないよう no-op。
+	/// </summary>
+	public void Watch(NetworkSyncServiceBase service)
+	{
+		ArgumentNullException.ThrowIfNull(service);
+		if (ReferenceEquals(_watched, service))
+			return;
+		Detach();
+		_watched = service;
+		service.ConnectionClosed += OnConnectionLost;
+		service.ConnectionFailed += OnConnectionLost;
+	}
+
+	/// <summary>監視を解除する。以後どのサービスのイベントでもコールバックは呼ばれない。</summary>
+	public void Clear() => Detach();
+
+	private void Detach()
+	{
+		if (_watched is null)
+			return;
+		_watched.ConnectionClosed -= OnConnectionLost;
+		_watched.ConnectionFailed -= OnConnectionLost;
+		_watched = null;
+	}
+
+	private void OnConnectionLost(object? sender, EventArgs e)
+	{
+		// 既に差し替え/解除済みのサービスからの遅延イベントは無視する。
+		if (!ReferenceEquals(sender, _watched))
+			return;
+		_onConnectionLost();
+	}
+}

--- a/TRViS.UITests/AutomationIds.cs
+++ b/TRViS.UITests/AutomationIds.cs
@@ -66,6 +66,9 @@ public static class AutomationIds
 		public const string WorkChip = "StartHome.WorkChip";
 		public const string OpenButton = "StartHome.OpenButton";
 		public const string DisconnectButton = "StartHome.DisconnectButton";
+		// Shown in the LoaderInfoCard only when a WebSocket loader's connection
+		// dropped (#261). Tapping it re-runs the last WebSocket connect.
+		public const string ReconnectButton = "StartHome.ReconnectButton";
 
 		// UI_TEST-only seed seams.
 		public const string TestSeedButton = "StartHome.TestSeedButton";
@@ -114,6 +117,10 @@ public static class AutomationIds
 		// default a prior LoadSample leaves the page in Home mode and the
 		// LoadDemo button hidden behind the loader-info card.
 		public const string TestClearLoaderButton = "StartHome.TestClearLoaderButton";
+		// Sets a non-connected WebSocketNetworkSyncService as AppViewModel.Loader
+		// and flips IsServerConnectionLost=true, putting Home into the #261
+		// "サーバー未接続 + 再接続" state WITHOUT a real WebSocket server.
+		public const string TestSimulateWebSocketDisconnectButton = "StartHome.TestSimulateWebSocketDisconnectButton";
 
 		// Direct invoker for OnSelectFileClicked. Bypasses the styled
 		// SelectFileButton because Appium UIAutomator2's ACTION_CLICK against

--- a/TRViS.UITests/Pages/StartHomePageObject.cs
+++ b/TRViS.UITests/Pages/StartHomePageObject.cs
@@ -40,6 +40,16 @@ public class StartHomePageObject : PageObject
 	public AppiumElement OpenButton => FindByAutomationId(AutomationIds.StartHome.OpenButton);
 	public AppiumElement DisconnectButton => FindByAutomationId(AutomationIds.StartHome.DisconnectButton);
 
+	// Home mode — loader/connection status (#261).
+	public AppiumElement LoaderInfoTitle => FindByAutomationId(AutomationIds.StartHome.LoaderInfoTitle);
+	// Visible only while a WebSocket loader's connection is lost. Use
+	// WaitForElement: it flips visible asynchronously after IsServerConnectionLost.
+	public AppiumElement ReconnectButton => WaitForElement(AutomationIds.StartHome.ReconnectButton);
+
+	/// <summary>True once the #261 reconnect button is on screen (disconnected state).</summary>
+	public bool IsReconnectButtonVisible(double timeoutSeconds = 8)
+		=> PollDisplayed(AutomationIds.StartHome.ReconnectButton, timeoutSeconds);
+
 	/// <summary>
 	/// Returns true when the WorkGroupChip is currently visible (i.e. a tentative
 	/// WorkGroup has been selected). Returns false on any lookup error so callers
@@ -71,6 +81,7 @@ public class StartHomePageObject : PageObject
 	public AppiumElement TestSetupBrowseFallbackButton => FindByAutomationId(AutomationIds.StartHome.TestSetupBrowseFallbackButton);
 	public AppiumElement TestSeedNextTrainSelectionButton => FindByAutomationId(AutomationIds.StartHome.TestSeedNextTrainSelectionButton);
 	public AppiumElement TestClearLoaderButton => FindByAutomationId(AutomationIds.StartHome.TestClearLoaderButton);
+	public AppiumElement TestSimulateWebSocketDisconnectButton => FindByAutomationId(AutomationIds.StartHome.TestSimulateWebSocketDisconnectButton);
 
 	public bool IsDisplayed()
 	{
@@ -314,6 +325,14 @@ public class StartHomePageObject : PageObject
 	/// from "no loader" regardless of where the previous test left things.
 	/// </summary>
 	public void ClearLoaderForTesting() => TestClearLoaderButton.Click();
+
+	/// <summary>
+	/// Taps the UI_TEST-only seam that sets a non-connected
+	/// WebSocketNetworkSyncService loader and flips IsServerConnectionLost=true,
+	/// driving Home into the #261 "サーバー未接続 + 再接続" state without a real
+	/// WebSocket server.
+	/// </summary>
+	public void SimulateWebSocketDisconnectForTesting() => TestSimulateWebSocketDisconnectButton.Click();
 
 	/// <summary>
 	/// Filename written by <see cref="SeedSqliteForTesting"/>. Mirrors the

--- a/TRViS.UITests/Tests/WebSocketReconnectTests.cs
+++ b/TRViS.UITests/Tests/WebSocketReconnectTests.cs
@@ -88,11 +88,16 @@ public class WebSocketReconnectTests : BaseUITest
 
 		_startHomePage.ReconnectButton.Click();
 
-		// State preserved: still disconnected, button still there, app alive.
+		// State preserved after the tap: still disconnected, button still
+		// available, and the Home action row is intact — i.e. we did NOT
+		// navigate to DTAC or crash. NOTE: StartHome.Title is the Start-mode
+		// header element and is intentionally absent from the Home-mode
+		// accessibility tree, so IsDisplayed()/Title cannot be the liveness
+		// probe here — assert on Home-mode elements instead.
 		Assert.That(_startHomePage.IsReconnectButtonVisible(), Is.True,
 			"再接続 must remain available when reconnection cannot proceed.");
 		Assert.That(_startHomePage.LoaderInfoTitle.Text, Does.Contain("サーバー未接続"));
-		Assert.That(_startHomePage.IsDisplayed(), Is.True,
-			"the page must still be alive after the 再接続 tap.");
+		Assert.That(_startHomePage.DisconnectButton.Displayed, Is.True,
+			"the Home page must still be intact (no crash / no navigation) after the 再接続 tap.");
 	}
 }

--- a/TRViS.UITests/Tests/WebSocketReconnectTests.cs
+++ b/TRViS.UITests/Tests/WebSocketReconnectTests.cs
@@ -1,0 +1,98 @@
+using TRViS.UITests.Pages;
+
+namespace TRViS.UITests.Tests;
+
+/// <summary>
+/// E2E for #261: when a WebSocket loader's connection drops, Home must stop
+/// showing "サーバー接続中" and instead show "サーバー未接続" plus a 再接続 button.
+///
+/// The disconnected state is reached through the UI_TEST-only
+/// <c>StartHome.TestSimulateWebSocketDisconnectButton</c> seam (sets a
+/// non-connected WebSocketNetworkSyncService loader + IsServerConnectionLost),
+/// so the test needs no real WebSocket server and stays deterministic on CI.
+/// </summary>
+[TestFixture]
+[Infrastructure.RetryAllTests(2)] // see AppLaunchTests for rationale
+public class WebSocketReconnectTests : BaseUITest
+{
+	// Share one Appium session across the fixture (iOS only); see
+	// BaseUITest.ShareSessionAcrossTestsInFixture. Mirrors StartHomeTests.
+	protected override bool ShareSessionAcrossTestsInFixture => true;
+
+	private StartHomePageObject _startHomePage = null!;
+
+	[SetUp]
+	public override void SetUp()
+	{
+		base.SetUp();
+
+		_startHomePage = new StartHomePageObject(Driver);
+
+		// Cross-fixture shared session: a prior fixture may have left a modal
+		// open. Close the SelectFile dialog if it carried over.
+		var dialog = new SelectFileDialogPageObject(Driver);
+		if (dialog.PollDisplayed(AutomationIds.SelectFile.Title, timeoutSeconds: 1))
+		{
+			dialog.Close();
+			Thread.Sleep(300);
+		}
+
+		if (!_startHomePage.PollDisplayed(AutomationIds.StartHome.Title, timeoutSeconds: 3))
+		{
+			new AppShellPage(Driver).NavigateToHome();
+			_startHomePage = new StartHomePageObject(Driver);
+		}
+
+		// Each test starts from "no loader": clearing the loader resets
+		// IsServerConnectionLost=false (AppViewModel.OnLoaderChanged) so the
+		// disconnected state from a prior test in this shared session is gone.
+		_startHomePage.ClearLoaderForTesting();
+		_startHomePage.AcceptPrivacyPolicyIfNeeded();
+
+		Assert.That(_startHomePage.IsDisplayed(), Is.True,
+			"StartHomePage should be displayed after recovery.");
+	}
+
+	[Test]
+	public void WebSocketDisconnect_ShowsServerNotConnectedTitleAndReconnectButton()
+	{
+		_startHomePage.SimulateWebSocketDisconnectForTesting();
+
+		Assert.That(_startHomePage.IsReconnectButtonVisible(), Is.True,
+			"再接続 button must appear once the WebSocket connection is lost.");
+
+		Assert.That(_startHomePage.LoaderInfoTitle.Text, Does.Contain("サーバー未接続"),
+			"LoaderInfoCard title must switch from \"サーバー接続中\" to \"サーバー未接続\" "
+			+ "so the disconnect is visible (#261).");
+
+		// 開く / 閉じる stay reachable: cached data is still browsable while
+		// disconnected (the WS loader's caches survive Dispose).
+		Assert.Multiple(() =>
+		{
+			Assert.That(_startHomePage.OpenButton.Displayed, Is.True);
+			Assert.That(_startHomePage.DisconnectButton.Displayed, Is.True);
+		});
+	}
+
+	/// <summary>
+	/// The seam stores no reconnect target, so 再接続 → ReconnectWebSocketAsync
+	/// returns false without touching the network. Tapping it must not crash and
+	/// must leave the disconnected UI intact (so the user can retry / 閉じる).
+	/// </summary>
+	[Test]
+	public void ReconnectTap_WithoutStoredTarget_KeepsDisconnectedStateAndDoesNotCrash()
+	{
+		_startHomePage.SimulateWebSocketDisconnectForTesting();
+		Assert.That(_startHomePage.IsReconnectButtonVisible(), Is.True,
+			"precondition: disconnected state must be shown before tapping 再接続.");
+
+		_startHomePage.ReconnectButton.Click();
+
+		// State preserved: still disconnected, button still there, app alive.
+		Assert.That(_startHomePage.IsReconnectButtonVisible(), Is.True,
+			"再接続 must remain available when reconnection cannot proceed.");
+		Assert.That(_startHomePage.LoaderInfoTitle.Text, Does.Contain("サーバー未接続"));
+		Assert.That(_startHomePage.IsDisplayed(), Is.True,
+			"the page must still be alive after the 再接続 tap.");
+	}
+}

--- a/TRViS/RootPages/HomeGridView.xaml
+++ b/TRViS/RootPages/HomeGridView.xaml
@@ -33,7 +33,7 @@
 		<Border.StrokeShape>
 			<RoundRectangle CornerRadius="8"/>
 		</Border.StrokeShape>
-		<Grid ColumnDefinitions="Auto,*"
+		<Grid ColumnDefinitions="Auto,*,Auto"
 					ColumnSpacing="10">
 			<Label
 				x:Name="LoaderInfoGlyphLabel"
@@ -81,6 +81,22 @@
 					IsVisible="False"
 					Text=""/>
 			</VerticalStackLayout>
+			<!-- 再接続ボタン: WebSocket 接続が切断されたときだけ表示する (#261)。
+			     既存の 閉じる/開く 行 (HomeButtonsRow) は親 StartHomePage が
+			     reparent するため触らず、自己完結するこのカード内に置く。 -->
+			<Button
+				x:Name="ReconnectButton"
+				AutomationId="StartHome.ReconnectButton"
+				Grid.Column="2"
+				Text="再接続"
+				FontSize="13"
+				FontAttributes="Bold"
+				HeightRequest="36"
+				Padding="14,0"
+				CornerRadius="8"
+				VerticalOptions="Center"
+				IsVisible="False"
+				Clicked="OnReconnectClicked"/>
 		</Grid>
 	</Border>
 

--- a/TRViS/RootPages/HomeGridView.xaml.cs
+++ b/TRViS/RootPages/HomeGridView.xaml.cs
@@ -105,6 +105,11 @@ public partial class HomeGridView : Grid
 				UpdateDiagramInfoLabels();
 				break;
 
+			case nameof(AppViewModel.IsServerConnectionLost):
+				// 切断 / 再接続成功で状態が変わった -> ステータス行と再接続ボタンを更新。
+				UpdateLoaderInfoLabels();
+				break;
+
 			case nameof(AppViewModel.WorkGroupList):
 				// WorkGroupList changes can come from a Refresh() (websocket) which
 				// may also reset committed AppViewModel selections. Rebuild the items;
@@ -155,8 +160,15 @@ public partial class HomeGridView : Grid
 			LoaderInfoTitleLabel.Text = "読み込み済みデータ";
 			LoaderInfoDetailLabel.Text = "";
 			LoaderInfoGlyphLabel.Text = MaterialIcons.Description;
+			ReconnectButton.IsVisible = false;
 			return;
 		}
+
+		// #261: a WebSocket loader whose connection dropped must not keep showing
+		// "サーバー接続中". Cached WorkGroup/Work/Train data is still readable from
+		// the (LocationService-disposed) service, so the picker stays usable and
+		// 開く still works — only the status line + 再接続 button change.
+		bool wsConnectionLost = loader is WebSocketNetworkSyncService && viewModel.IsServerConnectionLost;
 
 		// Title = loader type, glyph = matching Material Icon, detail = source label
 		// (file name, URL) set atomically with the loader via AppViewModel.SetLoader.
@@ -165,12 +177,14 @@ public partial class HomeGridView : Grid
 			SampleDataLoader => ("デモデータ", MaterialIcons.Science),
 			LoaderJson => ("JSON ファイル", MaterialIcons.Description),
 			LoaderSQL => ("SQLite ファイル", MaterialIcons.Storage),
+			WebSocketNetworkSyncService when wsConnectionLost => ("サーバー未接続", MaterialIcons.WifiOff),
 			WebSocketNetworkSyncService => ("サーバー接続中", MaterialIcons.Wifi),
 			_ => (loader.GetType().Name, MaterialIcons.Description),
 		};
 		LoaderInfoTitleLabel.Text = title;
 		LoaderInfoGlyphLabel.Text = glyph;
 		LoaderInfoDetailLabel.Text = viewModel.LoaderSourceLabel ?? string.Empty;
+		ReconnectButton.IsVisible = wsConnectionLost;
 	}
 
 	/// <summary>
@@ -573,6 +587,35 @@ public partial class HomeGridView : Grid
 		viewModel.Loader = null;
 		loader.Dispose();
 		// Loader change triggers OnViewModelPropertyChanged -> animate back to Start mode.
+	}
+
+	async void OnReconnectClicked(object sender, EventArgs e)
+	{
+		logger.Info("Reconnect clicked");
+		if (viewModel.Loader is not WebSocketNetworkSyncService)
+			return;
+
+		ReconnectButton.IsEnabled = false;
+		ReconnectButton.Text = "再接続中...";
+		try
+		{
+			// HandleWebSocketAppLinkAsync (via ReconnectWebSocketAsync) owns user
+			// feedback: on success it resets IsServerConnectionLost (-> this button
+			// hides via the PropertyChanged path) and shows its own "Success!"
+			// alert; on failure it shows its own connection-error alert and the
+			// banner stays so the user can retry.
+			await viewModel.ReconnectWebSocketAsync(CancellationToken.None);
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "OnReconnectClicked failed");
+			InstanceManager.CrashlyticsWrapper.Log(ex, "HomeGridView.OnReconnectClicked");
+		}
+		finally
+		{
+			ReconnectButton.Text = "再接続";
+			ReconnectButton.IsEnabled = true;
+		}
 	}
 
 	// ----- Navigation -----

--- a/TRViS/RootPages/StartHomePage.xaml.cs
+++ b/TRViS/RootPages/StartHomePage.xaml.cs
@@ -222,6 +222,7 @@ public partial class StartHomePage : ContentPage
 
 #if UI_TEST
 		AddTestOpenSelectFileDialogSeam();
+		AddTestSimulateWebSocketDisconnectSeam();
 #endif
 
 		logger.Trace("Created");
@@ -1132,6 +1133,59 @@ public partial class StartHomePage : ContentPage
 	// Mirrors AutomationIds.StartHome.TestOpenSelectFileDialogButton in the
 	// test project. Inlined here to avoid a project reference.
 	private const string AutomationIdValueForTestOpenSelectFileDialog = "StartHome.TestOpenSelectFileDialogButton";
+
+	// Mirrors AutomationIds.StartHome.TestSimulateWebSocketDisconnectButton.
+	private const string AutomationIdValueForTestSimulateWsDisconnect = "StartHome.TestSimulateWebSocketDisconnectButton";
+
+	// UI_TEST-only seam: same standalone-code-behind pattern as
+	// AddTestOpenSelectFileDialogSeam (kept out of TestSeamHost's 12-row Grid
+	// for the documented iPhone layout-row-growth reason). Margin y = 312 sits
+	// directly below the SelectFile seam (which occupies y=[288,312]), keeping
+	// the seam column contiguous in the top-left corner.
+	private void AddTestSimulateWebSocketDisconnectSeam()
+	{
+		var seam = new Button
+		{
+			AutomationId = AutomationIdValueForTestSimulateWsDisconnect,
+			HorizontalOptions = LayoutOptions.Start,
+			VerticalOptions = LayoutOptions.Start,
+			WidthRequest = 24,
+			HeightRequest = 24,
+			Margin = new Thickness(0, 312, 0, 0),
+			BackgroundColor = Colors.Transparent,
+			BorderColor = Colors.Transparent,
+			Padding = 0,
+		};
+		seam.Clicked += TestSimulateWebSocketDisconnectButton_Clicked;
+		Grid.SetRow(seam, 0);
+		RootGrid.Children.Add(seam);
+	}
+
+	// Drives Home into the #261 "サーバー未接続 + 再接続" state without a real
+	// server: a WebSocketNetworkSyncService constructed but never connected is a
+	// valid (empty) ILoader, so SetLoader flips the page to Home mode showing
+	// "サーバー接続中", then IsServerConnectionLost=true swaps it to the
+	// disconnected status + reveals the 再接続 button. No _lastWebSocketAppLinkInfo
+	// is stored, so a subsequent 再接続 tap is a deterministic no-op
+	// (ReconnectWebSocketAsync returns false) — keeps the test network-free.
+	void TestSimulateWebSocketDisconnectButton_Clicked(object? sender, EventArgs e)
+	{
+		logger.Info("TestSimulateWebSocketDisconnectButton clicked: simulating WS connection-lost state");
+		try
+		{
+			var service = new WebSocketNetworkSyncService(
+				new Uri("ws://uitest.invalid/"),
+				new System.Net.WebSockets.ClientWebSocket());
+			var previous = viewModel.Loader;
+			viewModel.SetLoader(service, "ws://uitest.invalid/");
+			previous?.Dispose();
+			viewModel.IsServerConnectionLost = true;
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "TestSimulateWebSocketDisconnectButton failed");
+		}
+	}
 
 	static void AddSeamButton(Grid host, int row, string automationId, EventHandler clicked)
 	{

--- a/TRViS/Utils/MaterialIcons.cs
+++ b/TRViS/Utils/MaterialIcons.cs
@@ -64,6 +64,9 @@ internal static class MaterialIcons
 	/// <summary>wifi — network sync / WebSocket-loaded data.</summary>
 	public const string Wifi = "\uE63E";
 
+	/// <summary>wifi_off \u2014 server sync connection lost (disconnected state).</summary>
+	public const string WifiOff = "\uE648";
+
 	// E8xx — content / files
 	/// <summary>code — file with code/text content (used for .json files).</summary>
 	public const string Code = "\uE86F";

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -24,6 +24,66 @@ public partial class AppViewModel
 	private readonly List<string> _ExternalResourceUrlHistory;
 	public IReadOnlyList<string> ExternalResourceUrlHistory => _ExternalResourceUrlHistory;
 
+	// --- WebSocket connection-lost tracking / reconnect (#261) ---
+	// Captured at the last successful WebSocket connect so the Home screen's
+	// 再接続 button can re-run the exact same connect. The AppLinkInfo is kept
+	// (not just LoaderSourceLabel) because AppLinkInfo.FromAppLink rejects a raw
+	// ws:// string (it requires host == "app"), so the display label alone is
+	// not reconnectable.
+	private AppLinkInfo? _lastWebSocketAppLinkInfo;
+	private string? _lastWebSocketOriginalAppLink;
+	// Watches the active WS service for ConnectionClosed / ConnectionFailed and
+	// detaches the old one on reconnect. The subscribe/resubscribe/sender-guard
+	// logic is extracted here so it can be unit-tested without MAUI; the only
+	// MAUI-bound part (MainThread marshaling + observable set) stays in the
+	// MarkServerConnectionLost callback below.
+	private NetworkSyncConnectionLostWatcher? _wsConnectionLostWatcherField;
+	private NetworkSyncConnectionLostWatcher WsConnectionLostWatcher
+		=> _wsConnectionLostWatcherField ??= new NetworkSyncConnectionLostWatcher(MarkServerConnectionLost);
+
+	/// <summary>
+	/// 切断イベント監視を解除し、再接続情報を破棄する。WebSocket 以外 / null の
+	/// ローダーに切り替わったとき (<see cref="OnLoaderChanged"/>) に呼ばれる。
+	/// </summary>
+	internal void ClearWebSocketConnectionTracking()
+	{
+		WsConnectionLostWatcher.Clear();
+		_lastWebSocketAppLinkInfo = null;
+		_lastWebSocketOriginalAppLink = null;
+	}
+
+	// ConnectionClosed / ConnectionFailed は WebSocket の受信ループスレッドから
+	// 発火する。ここでは Loader を差し替えず (切断後もキャッシュ済みデータを
+	// Home 画面に出し続けたいため。LocationService 側が GPS へフォールバックして
+	// サービスを Dispose 済みでもキャッシュは読める)、フラグだけ立てる。
+	// 観測対象プロパティの set は HomeGridView のラベル / 表示更新を駆動するので
+	// UI スレッドへマーシャリングする。
+	private void MarkServerConnectionLost()
+	{
+		logger.Info("WebSocket connection lost -> IsServerConnectionLost = true");
+		if (MainThread.IsMainThread)
+			IsServerConnectionLost = true;
+		else
+			MainThread.BeginInvokeOnMainThread(() => IsServerConnectionLost = true);
+	}
+
+	/// <summary>
+	/// 直近に成功した WebSocket 接続と同じ接続先へ再接続する。Home 画面の
+	/// 再接続ボタンから呼ばれる。再接続情報が無い場合は何もせず false を返す。
+	/// </summary>
+	public Task<bool> ReconnectWebSocketAsync(CancellationToken token)
+	{
+		AppLinkInfo? info = _lastWebSocketAppLinkInfo;
+		if (info is null)
+		{
+			logger.Warn("ReconnectWebSocketAsync: no stored WebSocket AppLink to reconnect with");
+			return Task.FromResult(false);
+		}
+		logger.Info("ReconnectWebSocketAsync: reconnecting to {0}", info.ResourceUri);
+		// addToHistory: false — a reconnect is not a new user-initiated entry.
+		return HandleWebSocketAppLinkAsync(info, _lastWebSocketOriginalAppLink, addToHistory: false, token);
+	}
+
 	public Task<bool> HandleAppLinkUriAsync(string uri, CancellationToken token)
 		=> HandleAppLinkUriAsync(uri, addToHistory: true, token);
 
@@ -280,6 +340,14 @@ public partial class AppViewModel
 			};
 
 			WebSocketNetworkSyncService service = await openFile.OpenWebSocketAppLinkAsync(appLinkInfo, token);
+
+			// Remember how to reconnect, watch this service for disconnects, and
+			// clear any prior "connection lost" banner — we now have a fresh live
+			// connection. Subscribe before SetLoader so an immediate drop is caught.
+			_lastWebSocketAppLinkInfo = appLinkInfo;
+			_lastWebSocketOriginalAppLink = originalAppLink;
+			WsConnectionLostWatcher.Watch(service);
+			IsServerConnectionLost = false;
 
 			ILoader? lastLoader = this.Loader;
 			this.SetLoader(service, originalAppLink ?? appLinkInfo.ResourceUri?.ToString());

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -45,6 +45,17 @@ public partial class AppViewModel : ObservableObject
 	public partial DiagramInfo? CurrentDiagramInfo { get; set; }
 
 	/// <summary>
+	/// 現在の <see cref="WebSocketNetworkSyncService"/> ローダーがサーバーとの接続を
+	/// 失っているか。接続断時に Home 画面が「サーバー接続中」のまま表示され続ける問題
+	/// (#261) を解消するため、Home 画面はこの値を購読して切断表示と再接続ボタンを出す。
+	/// 切断後もキャッシュ済みデータは <see cref="Loader"/> から読めるため Loader 自体は
+	/// 置き換えない。WebSocket 以外のローダーに切り替わった時点で false に戻る
+	/// (<see cref="OnLoaderChanged"/>)。
+	/// </summary>
+	[ObservableProperty]
+	public partial bool IsServerConnectionLost { get; set; }
+
+	/// <summary>
 	/// Raised after a server-driven load (HTTP / WebSocket TRViS.LocalServers
 	/// integration) has set the loader and committed a WorkGroup selection, to
 	/// request that the UI jump straight to the timetable instead of leaving the
@@ -208,6 +219,16 @@ public partial class AppViewModel : ObservableObject
 		CurrentDiagramInfo = null;
 		if (value is null)
 			LoaderSourceLabel = null;
+
+		// WebSocket 以外 (ファイル等) / null に切り替わったら、切断状態と再接続情報は
+		// 無意味なのでクリアする。WebSocket → WebSocket の再接続では value も
+		// WebSocketNetworkSyncService なので保持される (再接続成功時の false リセットは
+		// HandleWebSocketAppLinkAsync 側で行う)。
+		if (value is not WebSocketNetworkSyncService)
+		{
+			IsServerConnectionLost = false;
+			ClearWebSocketConnectionTracking();
+		}
 	}
 
 	void OnTimetableUpdated(object? sender, TimetableData timetableData)


### PR DESCRIPTION
Closes #261

## 背景 / 問題

WebSocket接続が切断されても `AppViewModel.Loader` がWSサービスのまま据え置かれ、Home画面が「サーバー接続中」のまま固まって切断が分かりづらかった。再接続手段も無かった。

原因: `WebSocketNetworkSyncService` が接続断で `ConnectionClosed` を発火 → `LocationService` がアラート表示＋GPSフォールバックして**サービスを Dispose** するが、`AppViewModel.Loader` は更新されないため `HomeGridView` が「サーバー接続中」を出し続ける。

## 変更点

- `AppViewModel.IsServerConnectionLost` (observable) を追加。WSの `ConnectionClosed` / `ConnectionFailed` を購読し、切断時に Home を **「サーバー未接続」+ `wifi_off` アイコン + 再接続ボタン** に切り替える。
- 切断後も WSサービスのキャッシュは読めるため **Loader は据え置き** → ピッカー閲覧／「開く」は継続可能。WS以外/ null ローダーに切り替わったら状態は自動クリア。
- 購読/再購読/解除/stale-sender ガードのロジックを `NetworkSyncConnectionLostWatcher`（MAUI非依存）に切り出し、単体テスト可能化。MAUI依存部（MainThreadマーシャリング＋observable set）のみ ViewModel 側に残置。
- 再接続は直近に成功した接続を再実行（`AppLinkInfo` を保持。`FromAppLink` は生 `ws://` を弾くため表示ラベルではなく `AppLinkInfo` を保持）。
- `LocationService` の GPSフォールバック／アラート挙動は**変更なし**（ファイル+別WSの構成への影響を避けるため、本Issueスコープ外）。

## テスト

- **Unit** (`TRViS.LocationService.Tests`, CIの test.yml): `NetworkSyncConnectionLostWatcher` 7ケース（closed/failed発火、再購読で旧サービス無効化、Clear、swap後は最新のみ、同一再Watchの二重購読防止）。`39/39` green。
- **Integration** (`WebSocketIntegrationTests`): `Dispose` 後も `ILoader` キャッシュが読めること（切断中もデータ閲覧可能という前提の回帰固定）。
- **E2E** (`TRViS.UITests`, ui-test.yml): UI_TESTシーム経由でサーバー不要に切断状態を再現し、「サーバー未接続」表示＋再接続ボタン表示／タップ後の状態維持を検証（2テスト）。

ローカル検証: MAUIアプリ（通常 / `DISABLE_FIREBASE;UI_TEST` 両方）0 warning / 0 error。

## レビュアー向けメモ

- 再接続成功時は既存のWS接続UXと同じく自動でDTAC（時刻表）へ遷移する（`HandleWebSocketAppLinkAsync` 再利用）。Homeへ戻って再接続したユーザーはそのままDTACへ移動する挙動。意図的だが要確認ポイント。
- 構造上MAUI依存でユニットテスト不可の範囲: `MarkServerConnectionLost`/MainThreadマーシャリング、`ReconnectWebSocketAsync` のnull早期return、HomeGridViewのUI配線（→ E2Eでカバー）。
- Appium E2E はローカル実行不可のため CI(ui-test.yml) で実行される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)