### PR TITLE
fix(app): #219 Reset 時に Firebase 設定のメモリ↔ディスクを同期

### DIFF
--- a/TRViS/RootPages/FirebaseSettingPage.xaml.cs
+++ b/TRViS/RootPages/FirebaseSettingPage.xaml.cs
@@ -24,7 +24,8 @@ public partial class FirebaseSettingPage : ContentPage
 		logger.Trace("Executing...");
 		FirebaseSettingViewModel.CopyFrom(InstanceManager.FirebaseSettingViewModel);
 		FirebaseSettingViewModel.IsEnabled = false;
-		FirebaseSettingViewModel.SaveAndApplySettings(true);
+		InstanceManager.FirebaseSettingViewModel.CopyFrom(FirebaseSettingViewModel);
+		InstanceManager.FirebaseSettingViewModel.SaveAndApplySettings(true);
 		logger.Trace("Executed");
 	}
 

--- a/TRViS/RootPages/PrivacyPolicyDialog.xaml.cs
+++ b/TRViS/RootPages/PrivacyPolicyDialog.xaml.cs
@@ -130,7 +130,8 @@ public partial class PrivacyPolicyDialog : ContentPage
 		logger.Trace("Reset clicked");
 		FirebaseSettingViewModel.CopyFrom(InstanceManager.FirebaseSettingViewModel);
 		FirebaseSettingViewModel.IsEnabled = false;
-		FirebaseSettingViewModel.SaveAndApplySettings(true);
+		InstanceManager.FirebaseSettingViewModel.CopyFrom(FirebaseSettingViewModel);
+		InstanceManager.FirebaseSettingViewModel.SaveAndApplySettings(true);
 	}
 
 	private async void OnSaveButtonClicked(object? sender, EventArgs e)


### PR DESCRIPTION
## 概要

Fixes #219

`FirebaseSettingPage.OnResetButtonClicked` および `PrivacyPolicyDialog.OnResetButtonClicked` は working copy をディスクに永続化するだけで、共有メモリインスタンス `InstanceManager.FirebaseSettingViewModel` を更新していなかった。

このため Reset 後に以下のズレが発生していた:

- ディスク: `IsEnabled=false` で永続化済み
- メモリ (`InstanceManager.FirebaseSettingViewModel`): リセット前の値のまま

共有インスタンスを直接参照するコード（`AppShell.xaml.cs:23,35` 等）は次回起動まで古い状態を見続け、Reset 直後の挙動が不整合になる。

## 変更内容

issue 提案の **(b)** を採用し、Save ハンドラと同じパターンに揃えた（両ページとも 1 行追加）:

```csharp
FirebaseSettingViewModel.CopyFrom(InstanceManager.FirebaseSettingViewModel);
FirebaseSettingViewModel.IsEnabled = false;
InstanceManager.FirebaseSettingViewModel.CopyFrom(FirebaseSettingViewModel);  // ← 追加: メモリ同期
InstanceManager.FirebaseSettingViewModel.SaveAndApplySettings(true);
```

- `TRViS/RootPages/FirebaseSettingPage.xaml.cs`
- `TRViS/RootPages/PrivacyPolicyDialog.xaml.cs`

working copy のラウンドトリップは意図的で、Save と同様にダイアログのスイッチ表示を反映させてから永続化する。

## レビュアー向けメモ

- `SaveAndApplySettings(` の全呼び出し箇所を確認済み。同じアンチパターンはこの 2 つの Reset ハンドラのみで、Save 側 (`FirebaseSettingPage.xaml.cs:41`, `PrivacyPolicyDialog.xaml.cs:145`) は既に正しくメモリ同期している。`AppShell.xaml.cs:38` は `(false)`（apply のみ・永続化なし）で問題なし。
- 新規テストなし: page code-behind + static `InstanceManager` + MAUI `Preferences` に実用的なテストシームがなく、Appium もメモリ/ディスクの乖離を検査できない。本修正は既に出荷済みの Save パスの構造的ミラーである点が検証根拠。
- issue 文中の「`AppShell.IsEnabledChanged` を購読しているフライアウト」について、production には `FirebaseSettingViewModel.IsEnabledChanged +=` の購読者は存在しない。バグは購読経由ではなく共有インスタンスの直接 read を通じて顕在化する（イベント機構自体は存在するが現状 production 購読者なし）。
- issue は「本ブランチ起源ではなく既存問題」として別 PR を希望していたため、単独 PR とした。

## 検証

- maccatalyst ビルド成功（0 warning / 0 error）

🤖 Generated with [Claude Code](https://claude.com/claude-code)