### PR TITLE
fix(app): #273 AnchorPopover を廃しページ内オーバーレイへ置換

### DIFF
--- a/TRViS.UITests/AutomationIds.cs
+++ b/TRViS.UITests/AutomationIds.cs
@@ -197,6 +197,30 @@ public static class AutomationIds
 		// Use string.Format: TimetableRowStationNamePattern.Replace("{0}", rowIndex.ToString())
 		public const string TimetableRowStationNamePattern = "TimetableRow.{0}.StationName";
 		public const string TimetableRowInfoRowPattern = "TimetableRow.{0}.InfoRow";
+
+		// In-page popup overlay (replaced TR.Maui.AnchorPopover, #273). The
+		// scrim spans the page and dismisses on tap-outside; the two popup
+		// roots are the QuickSwitch (WorkGroup/Work switcher, opened from the
+		// AppBar title) and SelectMarker (marker colour/text picker, opened
+		// from the timetable MarkerButton) ContentViews.
+		public const string PopupScrim = "DTAC.PopupScrim";
+		public const string QuickSwitchPopup = "DTAC.QuickSwitchPopup";
+		// QuickSwitch tab buttons (TabButtonSmall = plain TapGestureRecognizer,
+		// no CollectionView): tapping one is a robust "descendant input routes
+		// through the overlay's absorber Border" probe on every platform.
+		public const string QuickSwitchPopupWorkTab = "DTAC.QuickSwitchPopup.WorkTab";
+		public const string SelectMarkerPopup = "DTAC.SelectMarkerPopup";
+		public const string SelectMarkerPopupCloseButton = "DTAC.SelectMarkerPopup.CloseButton";
+
+		// UI_TEST-only seams (bottom-left strip, below the title/time seams).
+		// The real anchors are MAUI custom controls that WinUI surfaces as
+		// non-control Panes Appium can't reliably tap, and #266 established
+		// that real-gesture popover E2E is fragile cross-platform — these
+		// invoke the exact production show/dismiss path so the Windows
+		// ToPlatform-crash regression stays covered on every platform.
+		public const string TestOpenQuickSwitchButton = "DTAC.TestOpenQuickSwitchButton";
+		public const string TestOpenMarkerPopupButton = "DTAC.TestOpenMarkerPopupButton";
+		public const string TestDismissPopupButton = "DTAC.TestDismissPopupButton";
 	}
 
 	/// <summary>

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -372,4 +372,130 @@ public class DTACViewHostPageObject : PageObject
 		}
 		return false;
 	}
+
+	// ---------- In-page popups (replaced TR.Maui.AnchorPopover, #273) ----------
+	//
+	// Open/dismiss go through UI_TEST seams that run the exact production
+	// ShowQuickSwitchPopupAsync / ShowSelectMarkerPopupAsync / DismissAsync
+	// path — the real anchors (AppBar title Label, timetable MarkerButton
+	// Border) are MAUI custom controls WinUI exposes as non-control Panes
+	// Appium can't reliably tap, and #266 found real-gesture popover E2E
+	// fragile cross-platform. Presence is probed by the popup root's
+	// AutomationId on iOS/Android/macOS and by the rendered visible text on
+	// Windows (where ContentView AutomationId surfaces as a non-control Pane),
+	// mirroring FindCustomControl's dual strategy.
+
+	public void OpenQuickSwitchPopupViaSeam()
+		=> FindByAutomationId(AutomationIds.DTAC.TestOpenQuickSwitchButton).Click();
+
+	public void OpenSelectMarkerPopupViaSeam()
+		=> FindByAutomationId(AutomationIds.DTAC.TestOpenMarkerPopupButton).Click();
+
+	public void DismissPopupViaSeam()
+		=> FindByAutomationId(AutomationIds.DTAC.TestDismissPopupButton).Click();
+
+	/// <summary>
+	/// Taps SelectMarkerPopup's real "Close" button (the production dismiss
+	/// affordance — exercised in addition to the seam so the popup's own
+	/// IPagePopupHost.DismissAsync wiring is covered end to end).
+	/// </summary>
+	public void TapSelectMarkerPopupClose()
+	{
+		if (IsWindows)
+			WaitForElementByVisibleText(TimeSpan.FromSeconds(15), "Close").Click();
+		else
+			FindByAutomationId(AutomationIds.DTAC.SelectMarkerPopupCloseButton).Click();
+	}
+
+	/// <summary>
+	/// Taps QuickSwitchPopup's "Work" tab — a plain TapGestureRecognizer on a
+	/// TabButtonSmall (no CollectionView, so not subject to this codebase's
+	/// documented iOS CollectionView-row-tap flakiness). Doubles as the
+	/// regression probe for the overlay's absorber Border: if the absorber
+	/// swallowed descendant input the tap would do nothing; if it failed to
+	/// stop bubbling, the tap would reach the scrim and dismiss the popup.
+	/// </summary>
+	public void TapQuickSwitchWorkTab()
+	{
+		if (IsWindows)
+			WaitForElementByVisibleText(TimeSpan.FromSeconds(15), "Work").Click();
+		else
+			FindByAutomationId(AutomationIds.DTAC.QuickSwitchPopupWorkTab).Click();
+	}
+
+	public bool IsQuickSwitchPopupShown(double timeoutSeconds = 5)
+		=> IsPopupPresent(AutomationIds.DTAC.QuickSwitchPopup, timeoutSeconds, "WorkGroup", "Work");
+
+	public bool IsQuickSwitchPopupGone(double timeoutSeconds = 5)
+		=> IsPopupGone(AutomationIds.DTAC.QuickSwitchPopup, timeoutSeconds, "WorkGroup", "Work");
+
+	public bool IsSelectMarkerPopupShown(double timeoutSeconds = 5)
+		=> IsPopupPresent(AutomationIds.DTAC.SelectMarkerPopup, timeoutSeconds, "Close");
+
+	public bool IsSelectMarkerPopupGone(double timeoutSeconds = 5)
+		=> IsPopupGone(AutomationIds.DTAC.SelectMarkerPopup, timeoutSeconds, "Close");
+
+	private bool IsPopupPresent(string automationId, double timeoutSeconds, params string[] windowsTextCandidates)
+	{
+		var prevWait = TimeSpan.FromSeconds(10);
+		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+		try
+		{
+			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+			while (DateTime.UtcNow < deadline)
+			{
+				if (TryFindVisiblePopup(automationId, windowsTextCandidates))
+					return true;
+				Thread.Sleep(150);
+			}
+			return false;
+		}
+		finally
+		{
+			Driver.Manage().Timeouts().ImplicitWait = prevWait;
+		}
+	}
+
+	private bool IsPopupGone(string automationId, double timeoutSeconds, params string[] windowsTextCandidates)
+	{
+		var prevWait = TimeSpan.FromSeconds(10);
+		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+		try
+		{
+			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+			while (DateTime.UtcNow < deadline)
+			{
+				if (!TryFindVisiblePopup(automationId, windowsTextCandidates))
+					return true;
+				Thread.Sleep(150);
+			}
+			return false;
+		}
+		finally
+		{
+			Driver.Manage().Timeouts().ImplicitWait = prevWait;
+		}
+	}
+
+	private bool TryFindVisiblePopup(string automationId, string[] windowsTextCandidates)
+	{
+		if (IsWindows && windowsTextCandidates.Length > 0)
+		{
+			string predicate = string.Join(" or ",
+				windowsTextCandidates.Select(t => $"@Name='{t}'"));
+			try
+			{
+				var els = Driver.FindElements(By.XPath($"//*[{predicate}]"));
+				return els.Count > 0 && IsElementUserVisible((AppiumElement)els[0]);
+			}
+			catch { return false; }
+		}
+
+		try
+		{
+			var els = Driver.FindElements(AutomationIdLocator(automationId));
+			return els.Count > 0 && IsElementUserVisible((AppiumElement)els[0]);
+		}
+		catch { return false; }
+	}
 }

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -445,22 +445,33 @@ public class DTACViewHostPageObject : PageObject
 	// every platform surfaces somewhere, the most robust cross-platform
 	// "it is on screen" signal.
 	public bool IsQuickSwitchPopupShown(double timeoutSeconds = 5)
-		=> IsPopupPresent(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds, "WorkGroup", "Work");
+		=> IsPopupPresent(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds,
+			new[] { "WorkGroup", "Work" }, useTextOnWindows: true);
 
 	public bool IsQuickSwitchPopupGone(double timeoutSeconds = 5)
-		=> IsPopupGone(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds, "WorkGroup", "Work");
+		=> IsPopupGone(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds,
+			new[] { "WorkGroup", "Work" }, useTextOnWindows: true);
 
 	// Probe the Close *Button* AutomationId with NO text candidate: a plain
 	// Button resolves by AccessibilityId / By.Id on every platform (cf.
 	// ConnectServer.CloseButton), and a "Close" text probe would collide with
 	// the WinUI title-bar Close button (run 25983087525 closed the whole app).
+	// "Close" text fallback on non-Windows only: a plain Button's AutomationId
+	// is as unreliable on Android as the QuickSwitch Grid was (run 25983883205
+	// — Close-button-AutomationId-only failed there while QuickSwitch's text
+	// probe passed via the same overlay, so the popup *does* render). On
+	// Windows the AutomationId resolves fine (24/24 green on e0ab887) and a
+	// "Close" text probe must NOT be used — it matches the WinUI title-bar
+	// Close button (run 25983087525 closed the whole app).
 	public bool IsSelectMarkerPopupShown(double timeoutSeconds = 5)
-		=> IsPopupPresent(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds);
+		=> IsPopupPresent(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds,
+			new[] { "Close" }, useTextOnWindows: false);
 
 	public bool IsSelectMarkerPopupGone(double timeoutSeconds = 5)
-		=> IsPopupGone(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds);
+		=> IsPopupGone(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds,
+			new[] { "Close" }, useTextOnWindows: false);
 
-	private bool IsPopupPresent(string automationId, double timeoutSeconds, params string[] textCandidates)
+	private bool IsPopupPresent(string automationId, double timeoutSeconds, string[] textCandidates, bool useTextOnWindows = true)
 	{
 		var prevWait = TimeSpan.FromSeconds(10);
 		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
@@ -469,7 +480,7 @@ public class DTACViewHostPageObject : PageObject
 			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
 			while (DateTime.UtcNow < deadline)
 			{
-				if (TryFindVisiblePopup(automationId, textCandidates))
+				if (TryFindVisiblePopup(automationId, textCandidates, useTextOnWindows))
 					return true;
 				Thread.Sleep(150);
 			}
@@ -481,7 +492,7 @@ public class DTACViewHostPageObject : PageObject
 		}
 	}
 
-	private bool IsPopupGone(string automationId, double timeoutSeconds, params string[] textCandidates)
+	private bool IsPopupGone(string automationId, double timeoutSeconds, string[] textCandidates, bool useTextOnWindows = true)
 	{
 		var prevWait = TimeSpan.FromSeconds(10);
 		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
@@ -490,7 +501,7 @@ public class DTACViewHostPageObject : PageObject
 			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
 			while (DateTime.UtcNow < deadline)
 			{
-				if (!TryFindVisiblePopup(automationId, textCandidates))
+				if (!TryFindVisiblePopup(automationId, textCandidates, useTextOnWindows))
 					return true;
 				Thread.Sleep(150);
 			}
@@ -502,12 +513,13 @@ public class DTACViewHostPageObject : PageObject
 		}
 	}
 
-	// Try the AutomationId first, then fall back to the rendered text on EVERY
-	// platform. Appium+MAUI element addressing for non-Button custom controls
-	// is unreliable platform-by-platform (the reason FindCustomControl exists);
-	// the popup's visible label text is the most robust cross-platform "it is
-	// on screen" signal, so probe it everywhere — not just Windows.
-	private bool TryFindVisiblePopup(string automationId, string[] textCandidates)
+	// Try the AutomationId first, then fall back to the rendered text. Appium+
+	// MAUI element addressing for non-Button custom controls is unreliable
+	// platform-by-platform (the reason FindCustomControl exists); the popup's
+	// visible label text is the most robust cross-platform "it is on screen"
+	// signal. <paramref name="useTextOnWindows"/> is false when the text would
+	// collide with a WinUI chrome element (e.g. "Close" == title-bar button).
+	private bool TryFindVisiblePopup(string automationId, string[] textCandidates, bool useTextOnWindows = true)
 	{
 		try
 		{
@@ -519,6 +531,8 @@ public class DTACViewHostPageObject : PageObject
 
 		if (textCandidates.Length == 0)
 			return false;
+		if (IsWindows && !useTextOnWindows)
+			return false; // text would match WinUI chrome (e.g. caption Close)
 
 		// Per-platform Appium exposes visible text under different attributes:
 		// Android=text/content-desc, iOS+macOS=label/name/value, Windows=Name.
@@ -561,12 +575,51 @@ public class DTACViewHostPageObject : PageObject
 		try
 		{
 			string src = Driver.PageSource ?? "(null PageSource)";
-			const int max = 16000;
-			return src.Length <= max ? src : src.Substring(0, max) + "\n…(truncated)";
+
+			// Android's PageSource is ~1 MB of deeply-nested, attribute-heavy
+			// XML; head-truncating just shows the Shell scaffold. Instead report
+			// which markers are present (does the overlay/popup exist at all?)
+			// plus a window around the first popup-related node.
+			string[] markers =
+			{
+				"DTAC.PopupScrim", "DTAC.QuickSwitchPopup", "DTAC.SelectMarkerPopup",
+				"WorkGroup", "Work", "Close", "DTAC.MenuButton", "不明なエラー",
+			};
+			var sb = new System.Text.StringBuilder();
+			sb.Append("PageSource length=").Append(src.Length).Append("; markers: ");
+			foreach (var m in markers)
+				sb.Append(m).Append('=').Append(CountOccurrences(src, m)).Append("  ");
+			sb.AppendLine();
+
+			int anchor = new[] { "Scrim", "Popup", "Close" }
+				.Select(t => src.IndexOf(t, StringComparison.Ordinal))
+				.Where(i => i >= 0)
+				.DefaultIfEmpty(-1)
+				.Min();
+			if (anchor >= 0)
+			{
+				int start = Math.Max(0, anchor - 2000);
+				int len = Math.Min(12000, src.Length - start);
+				sb.Append("…window@").Append(start).Append(":\n")
+				  .Append(src, start, len).Append("\n…(window end)");
+			}
+			else
+			{
+				sb.Append("(no Scrim/Popup/Close token anywhere — first 8000 chars)\n")
+				  .Append(src.Substring(0, Math.Min(8000, src.Length)));
+			}
+			return sb.ToString();
 		}
 		catch (Exception ex)
 		{
 			return $"(PageSource unavailable: {ex.GetType().Name}: {ex.Message})";
 		}
+	}
+
+	private static int CountOccurrences(string haystack, string needle)
+	{
+		int n = 0, i = 0;
+		while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { n++; i += needle.Length; }
+		return n;
 	}
 }

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -385,14 +385,37 @@ public class DTACViewHostPageObject : PageObject
 	// Windows (where ContentView AutomationId surfaces as a non-control Pane),
 	// mirroring FindCustomControl's dual strategy.
 
-	public void OpenQuickSwitchPopupViaSeam()
-		=> WaitForElement(AutomationIds.DTAC.TestOpenQuickSwitchButton).Click();
-
-	public void OpenSelectMarkerPopupViaSeam()
-		=> WaitForElement(AutomationIds.DTAC.TestOpenMarkerPopupButton).Click();
-
 	public void DismissPopupViaSeam()
 		=> WaitForElement(AutomationIds.DTAC.TestDismissPopupButton).Click();
+
+	// Appium↔MAUI Button click dispatch is intermittently dropped on Android
+	// (this codebase already works around the same for the SelectFile seam):
+	// a single seam click occasionally no-ops, so the overlay never opens —
+	// run 25984214790's diagnostic showed DTAC.PopupScrim=0, 不明なエラー=0
+	// (no crash, the open just didn't take), while the identical path passed
+	// on run 25983883205. Re-click + re-poll a few times. ShowOverlayPopupAsync
+	// is re-entrant, so an extra click while already shown is harmless. Returns
+	// true once the popup is detected, false if every attempt failed.
+	public bool OpenQuickSwitchPopupReliably(int attempts = 4, double perAttemptSeconds = 8)
+		=> RetrySeam(AutomationIds.DTAC.TestOpenQuickSwitchButton, IsQuickSwitchPopupShown, attempts, perAttemptSeconds);
+
+	public bool OpenSelectMarkerPopupReliably(int attempts = 4, double perAttemptSeconds = 8)
+		=> RetrySeam(AutomationIds.DTAC.TestOpenMarkerPopupButton, IsSelectMarkerPopupShown, attempts, perAttemptSeconds);
+
+	public bool DismissQuickSwitchReliably(int attempts = 4, double perAttemptSeconds = 6)
+		=> RetrySeam(AutomationIds.DTAC.TestDismissPopupButton, IsQuickSwitchPopupGone, attempts, perAttemptSeconds);
+
+	private bool RetrySeam(string seamAutomationId, Func<double, bool> condition, int attempts, double perAttemptSeconds)
+	{
+		for (int i = 0; i < attempts; i++)
+		{
+			try { WaitForElement(seamAutomationId).Click(); }
+			catch { /* seam not hit this attempt — re-poll then retry */ }
+			if (condition(perAttemptSeconds))
+				return true;
+		}
+		return false;
+	}
 
 	/// <summary>
 	/// Best-effort popup dismissal for fixture TearDown: the overlay is a
@@ -408,19 +431,25 @@ public class DTACViewHostPageObject : PageObject
 
 	/// <summary>
 	/// Taps SelectMarkerPopup's real "Close" button (the production dismiss
-	/// affordance — exercised in addition to the seam so the popup's own
-	/// IPagePopupHost.DismissAsync wiring is covered end to end).
-	///
-	/// Resolved by AutomationId on every platform: it is a plain MAUI Button,
-	/// which WinUI surfaces with a reachable AccessibilityId (same as
-	/// ConnectServer.CloseButton). A Windows visible-text fallback must NOT be
-	/// used here — "Close" also matches the WinUI window title-bar Close (X)
-	/// button, and clicking that closes the whole app (run 25983087525:
-	/// it killed the Appium session and cascaded NoSuchWindowException into
-	/// every later test).
+	/// path: OnCloseButtonClicked -> IPagePopupHost.DismissAsync) and confirms
+	/// the popup is gone, retrying for the same Android Appium click-drop reason
+	/// as the seams. The Close button is a plain MAUI Button resolved by
+	/// AutomationId on every platform (WinUI exposes a reachable
+	/// AccessibilityId, like ConnectServer.CloseButton); a "Close" visible-text
+	/// lookup must NOT be used — it matches the WinUI title-bar Close (X)
+	/// button, which closed the whole app in run 25983087525.
 	/// </summary>
-	public void TapSelectMarkerPopupClose()
-		=> WaitForElement(AutomationIds.DTAC.SelectMarkerPopupCloseButton).Click();
+	public bool DismissSelectMarkerViaCloseReliably(int attempts = 4, double perAttemptSeconds = 6)
+	{
+		for (int i = 0; i < attempts; i++)
+		{
+			try { WaitForElement(AutomationIds.DTAC.SelectMarkerPopupCloseButton).Click(); }
+			catch { /* button gone (already dismissed) or not hit — re-check */ }
+			if (IsSelectMarkerPopupGone(perAttemptSeconds))
+				return true;
+		}
+		return false;
+	}
 
 	/// <summary>
 	/// Taps QuickSwitchPopup's "Work" tab — a plain TapGestureRecognizer on a

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -386,26 +386,41 @@ public class DTACViewHostPageObject : PageObject
 	// mirroring FindCustomControl's dual strategy.
 
 	public void OpenQuickSwitchPopupViaSeam()
-		=> FindByAutomationId(AutomationIds.DTAC.TestOpenQuickSwitchButton).Click();
+		=> WaitForElement(AutomationIds.DTAC.TestOpenQuickSwitchButton).Click();
 
 	public void OpenSelectMarkerPopupViaSeam()
-		=> FindByAutomationId(AutomationIds.DTAC.TestOpenMarkerPopupButton).Click();
+		=> WaitForElement(AutomationIds.DTAC.TestOpenMarkerPopupButton).Click();
 
 	public void DismissPopupViaSeam()
-		=> FindByAutomationId(AutomationIds.DTAC.TestDismissPopupButton).Click();
+		=> WaitForElement(AutomationIds.DTAC.TestDismissPopupButton).Click();
+
+	/// <summary>
+	/// Best-effort popup dismissal for fixture TearDown: the overlay is a
+	/// full-screen modal scrim, so a popup left open by a failed assertion
+	/// blocks the flyout/menu and wedges every later test in a shared session
+	/// (run 25983087525: one QuickSwitch failure cascaded into ~8 unrelated
+	/// failures). Swallows everything — never throws out of TearDown.
+	/// </summary>
+	public void TryDismissAnyPopup()
+	{
+		try { DismissPopupViaSeam(); } catch { /* not on DTAC / no popup */ }
+	}
 
 	/// <summary>
 	/// Taps SelectMarkerPopup's real "Close" button (the production dismiss
 	/// affordance — exercised in addition to the seam so the popup's own
 	/// IPagePopupHost.DismissAsync wiring is covered end to end).
+	///
+	/// Resolved by AutomationId on every platform: it is a plain MAUI Button,
+	/// which WinUI surfaces with a reachable AccessibilityId (same as
+	/// ConnectServer.CloseButton). A Windows visible-text fallback must NOT be
+	/// used here — "Close" also matches the WinUI window title-bar Close (X)
+	/// button, and clicking that closes the whole app (run 25983087525:
+	/// it killed the Appium session and cascaded NoSuchWindowException into
+	/// every later test).
 	/// </summary>
 	public void TapSelectMarkerPopupClose()
-	{
-		if (IsWindows)
-			WaitForElementByVisibleText(TimeSpan.FromSeconds(15), "Close").Click();
-		else
-			FindByAutomationId(AutomationIds.DTAC.SelectMarkerPopupCloseButton).Click();
-	}
+		=> WaitForElement(AutomationIds.DTAC.SelectMarkerPopupCloseButton).Click();
 
 	/// <summary>
 	/// Taps QuickSwitchPopup's "Work" tab — a plain TapGestureRecognizer on a
@@ -423,17 +438,28 @@ public class DTACViewHostPageObject : PageObject
 			FindByAutomationId(AutomationIds.DTAC.QuickSwitchPopupWorkTab).Click();
 	}
 
+	// Key off the WorkTab (a TabButtonSmall = Grid custom control), NOT the
+	// popup root ContentView: MAUI does not create a native view for a plain
+	// ContentView, so its AutomationId is absent from the Android tree
+	// (run 25983087525 — QuickSwitch "not shown" though it had rendered).
+	// Grid AutomationId resolves via By.Id on Android / AccessibilityId on
+	// iOS+macOS (cf. NextTrainButton); Windows surfaces it as a Pane, so the
+	// rendered tab-label text ("WorkGroup"/"Work") is the Windows fallback.
 	public bool IsQuickSwitchPopupShown(double timeoutSeconds = 5)
-		=> IsPopupPresent(AutomationIds.DTAC.QuickSwitchPopup, timeoutSeconds, "WorkGroup", "Work");
+		=> IsPopupPresent(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds, "WorkGroup", "Work");
 
 	public bool IsQuickSwitchPopupGone(double timeoutSeconds = 5)
-		=> IsPopupGone(AutomationIds.DTAC.QuickSwitchPopup, timeoutSeconds, "WorkGroup", "Work");
+		=> IsPopupGone(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds, "WorkGroup", "Work");
 
+	// Probe the Close *Button* (not the popup root ContentView, which WinUI
+	// surfaces as a non-control Pane) and pass NO Windows text candidate: a
+	// plain Button resolves by AccessibilityId on every platform, and "Close"
+	// as a Name probe collides with the WinUI title-bar Close button.
 	public bool IsSelectMarkerPopupShown(double timeoutSeconds = 5)
-		=> IsPopupPresent(AutomationIds.DTAC.SelectMarkerPopup, timeoutSeconds, "Close");
+		=> IsPopupPresent(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds);
 
 	public bool IsSelectMarkerPopupGone(double timeoutSeconds = 5)
-		=> IsPopupGone(AutomationIds.DTAC.SelectMarkerPopup, timeoutSeconds, "Close");
+		=> IsPopupGone(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds);
 
 	private bool IsPopupPresent(string automationId, double timeoutSeconds, params string[] windowsTextCandidates)
 	{

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -438,30 +438,29 @@ public class DTACViewHostPageObject : PageObject
 			FindByAutomationId(AutomationIds.DTAC.QuickSwitchPopupWorkTab).Click();
 	}
 
-	// Key off the WorkTab (a TabButtonSmall = Grid custom control), NOT the
-	// popup root ContentView: MAUI does not create a native view for a plain
-	// ContentView, so its AutomationId is absent from the Android tree
-	// (run 25983087525 — QuickSwitch "not shown" though it had rendered).
-	// Grid AutomationId resolves via By.Id on Android / AccessibilityId on
-	// iOS+macOS (cf. NextTrainButton); Windows surfaces it as a Pane, so the
-	// rendered tab-label text ("WorkGroup"/"Work") is the Windows fallback.
+	// Probe the WorkTab AutomationId, then the rendered tab labels
+	// "WorkGroup"/"Work" on every platform. The popup root is a ContentView
+	// (MAUI creates no native view for it, so its AutomationId is absent from
+	// the Android tree — run 25983087525); the tab labels are real text that
+	// every platform surfaces somewhere, the most robust cross-platform
+	// "it is on screen" signal.
 	public bool IsQuickSwitchPopupShown(double timeoutSeconds = 5)
 		=> IsPopupPresent(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds, "WorkGroup", "Work");
 
 	public bool IsQuickSwitchPopupGone(double timeoutSeconds = 5)
 		=> IsPopupGone(AutomationIds.DTAC.QuickSwitchPopupWorkTab, timeoutSeconds, "WorkGroup", "Work");
 
-	// Probe the Close *Button* (not the popup root ContentView, which WinUI
-	// surfaces as a non-control Pane) and pass NO Windows text candidate: a
-	// plain Button resolves by AccessibilityId on every platform, and "Close"
-	// as a Name probe collides with the WinUI title-bar Close button.
+	// Probe the Close *Button* AutomationId with NO text candidate: a plain
+	// Button resolves by AccessibilityId / By.Id on every platform (cf.
+	// ConnectServer.CloseButton), and a "Close" text probe would collide with
+	// the WinUI title-bar Close button (run 25983087525 closed the whole app).
 	public bool IsSelectMarkerPopupShown(double timeoutSeconds = 5)
 		=> IsPopupPresent(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds);
 
 	public bool IsSelectMarkerPopupGone(double timeoutSeconds = 5)
 		=> IsPopupGone(AutomationIds.DTAC.SelectMarkerPopupCloseButton, timeoutSeconds);
 
-	private bool IsPopupPresent(string automationId, double timeoutSeconds, params string[] windowsTextCandidates)
+	private bool IsPopupPresent(string automationId, double timeoutSeconds, params string[] textCandidates)
 	{
 		var prevWait = TimeSpan.FromSeconds(10);
 		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
@@ -470,7 +469,7 @@ public class DTACViewHostPageObject : PageObject
 			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
 			while (DateTime.UtcNow < deadline)
 			{
-				if (TryFindVisiblePopup(automationId, windowsTextCandidates))
+				if (TryFindVisiblePopup(automationId, textCandidates))
 					return true;
 				Thread.Sleep(150);
 			}
@@ -482,7 +481,7 @@ public class DTACViewHostPageObject : PageObject
 		}
 	}
 
-	private bool IsPopupGone(string automationId, double timeoutSeconds, params string[] windowsTextCandidates)
+	private bool IsPopupGone(string automationId, double timeoutSeconds, params string[] textCandidates)
 	{
 		var prevWait = TimeSpan.FromSeconds(10);
 		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
@@ -491,7 +490,7 @@ public class DTACViewHostPageObject : PageObject
 			Driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
 			while (DateTime.UtcNow < deadline)
 			{
-				if (!TryFindVisiblePopup(automationId, windowsTextCandidates))
+				if (!TryFindVisiblePopup(automationId, textCandidates))
 					return true;
 				Thread.Sleep(150);
 			}
@@ -503,25 +502,71 @@ public class DTACViewHostPageObject : PageObject
 		}
 	}
 
-	private bool TryFindVisiblePopup(string automationId, string[] windowsTextCandidates)
+	// Try the AutomationId first, then fall back to the rendered text on EVERY
+	// platform. Appium+MAUI element addressing for non-Button custom controls
+	// is unreliable platform-by-platform (the reason FindCustomControl exists);
+	// the popup's visible label text is the most robust cross-platform "it is
+	// on screen" signal, so probe it everywhere — not just Windows.
+	private bool TryFindVisiblePopup(string automationId, string[] textCandidates)
 	{
-		if (IsWindows && windowsTextCandidates.Length > 0)
-		{
-			string predicate = string.Join(" or ",
-				windowsTextCandidates.Select(t => $"@Name='{t}'"));
-			try
-			{
-				var els = Driver.FindElements(By.XPath($"//*[{predicate}]"));
-				return els.Count > 0 && IsElementUserVisible((AppiumElement)els[0]);
-			}
-			catch { return false; }
-		}
-
 		try
 		{
 			var els = Driver.FindElements(AutomationIdLocator(automationId));
+			if (els.Count > 0 && IsElementUserVisible((AppiumElement)els[0]))
+				return true;
+		}
+		catch { /* fall through to text probe */ }
+
+		if (textCandidates.Length == 0)
+			return false;
+
+		// Per-platform Appium exposes visible text under different attributes:
+		// Android=text/content-desc, iOS+macOS=label/name/value, Windows=Name.
+		string predicate = string.Join(" or ", textCandidates.SelectMany(t => new[]
+		{
+			$"@text={XPathLiteral(t)}",
+			$"@content-desc={XPathLiteral(t)}",
+			$"@label={XPathLiteral(t)}",
+			$"@name={XPathLiteral(t)}",
+			$"@value={XPathLiteral(t)}",
+			$"@Name={XPathLiteral(t)}",
+		}));
+		try
+		{
+			var els = Driver.FindElements(By.XPath($"//*[{predicate}]"));
 			return els.Count > 0 && IsElementUserVisible((AppiumElement)els[0]);
 		}
 		catch { return false; }
+	}
+
+	// XPath 1.0 has no escape for quotes; wrap in the other quote, or build a
+	// concat() when the literal contains both. Popup labels are simple ASCII,
+	// but keep this correct so a future label can't silently break the probe.
+	private static string XPathLiteral(string s)
+	{
+		if (!s.Contains('\'')) return $"'{s}'";
+		if (!s.Contains('"')) return $"\"{s}\"";
+		return "concat('" + s.Replace("'", "',\"'\",'") + "')";
+	}
+
+	/// <summary>
+	/// Best-effort Appium tree dump for failure diagnostics. Written to the
+	/// test's stdout (NUnit surfaces it as "Standard Output Messages" in the
+	/// CI log) so a "popup not shown" failure shows whether the scrim / popup
+	/// content is actually in the platform tree — same approach the flyout
+	/// helper uses. Truncated so it doesn't flood the log.
+	/// </summary>
+	public string CaptureTreeForDiagnostics()
+	{
+		try
+		{
+			string src = Driver.PageSource ?? "(null PageSource)";
+			const int max = 16000;
+			return src.Length <= max ? src : src.Substring(0, max) + "\n…(truncated)";
+		}
+		catch (Exception ex)
+		{
+			return $"(PageSource unavailable: {ex.GetType().Name}: {ex.Message})";
+		}
 	}
 }

--- a/TRViS.UITests/Tests/DTACPopupTests.cs
+++ b/TRViS.UITests/Tests/DTACPopupTests.cs
@@ -102,8 +102,11 @@ public class DTACPopupTests : BaseUITest
 	{
 		var dtac = OpenDTAC();
 
-		dtac.OpenQuickSwitchPopupViaSeam();
-		AssertPopupShown(dtac.IsQuickSwitchPopupShown(), dtac, "QuickSwitchPopup",
+		// Retry the open seam: Android intermittently drops the Appium Button
+		// click so the overlay never opens (run 25984214790 diagnostic:
+		// PopupScrim=0, 不明なエラー=0 — no crash, the click just didn't take;
+		// the identical path passed on run 25983883205).
+		AssertPopupShown(dtac.OpenQuickSwitchPopupReliably(), dtac, "QuickSwitchPopup",
 			"QuickSwitchPopup must appear after the open seam fires. On Windows the "
 			+ "old AnchorPopover.ShowAsync threw MissingMethodException here and "
 			+ "crashed the app into the fatal error modal (#273).");
@@ -126,9 +129,9 @@ public class DTACPopupTests : BaseUITest
 
 		// Dismiss via the seam (DismissAsync) — tap-outside on the scrim isn't
 		// reliably reproducible cross-platform; the regression is the crash, not
-		// the gesture (#266 rationale).
-		dtac.DismissPopupViaSeam();
-		Assert.That(dtac.IsQuickSwitchPopupGone(), Is.True,
+		// the gesture (#266 rationale). Retried for the same Android click-drop
+		// reason as the open.
+		Assert.That(dtac.DismissQuickSwitchReliably(), Is.True,
 			"QuickSwitchPopup must be gone after DismissAsync.");
 		Assert.That(dtac.IsDisplayed(), Is.True,
 			"DTAC must remain displayed (no crash) after dismissing the popup.");
@@ -139,8 +142,8 @@ public class DTACPopupTests : BaseUITest
 	{
 		var dtac = OpenDTAC();
 
-		dtac.OpenSelectMarkerPopupViaSeam();
-		AssertPopupShown(dtac.IsSelectMarkerPopupShown(), dtac, "SelectMarkerPopup",
+		// Retry the open seam (same Android click-drop reason as QuickSwitch).
+		AssertPopupShown(dtac.OpenSelectMarkerPopupReliably(), dtac, "SelectMarkerPopup",
 			"SelectMarkerPopup must appear after the open seam fires. On Windows the "
 			+ "old AnchorPopover.ShowAsync threw MissingMethodException here and "
 			+ "crashed the app into the fatal error modal (#273).");
@@ -149,9 +152,8 @@ public class DTACPopupTests : BaseUITest
 
 		// Dismiss via the popup's own "Close" button — exercises
 		// SelectMarkerPopup.OnCloseButtonClicked -> IPagePopupHost.DismissAsync,
-		// the real production interaction.
-		dtac.TapSelectMarkerPopupClose();
-		Assert.That(dtac.IsSelectMarkerPopupGone(), Is.True,
+		// the real production interaction (retried for Android click-drop).
+		Assert.That(dtac.DismissSelectMarkerViaCloseReliably(), Is.True,
 			"SelectMarkerPopup must be gone after tapping its Close button.");
 		Assert.That(dtac.IsDisplayed(), Is.True,
 			"DTAC must remain displayed (no crash) after dismissing the popup.");

--- a/TRViS.UITests/Tests/DTACPopupTests.cs
+++ b/TRViS.UITests/Tests/DTACPopupTests.cs
@@ -82,13 +82,28 @@ public class DTACPopupTests : BaseUITest
 		return dtac;
 	}
 
+	/// <summary>
+	/// Asserts a popup is shown, and on failure dumps the Appium tree to the
+	/// test's stdout (NUnit "Standard Output Messages" in the CI log) so a
+	/// "not shown" failure reveals whether the scrim / popup content is
+	/// actually in the platform tree — same diagnostic approach the flyout
+	/// helper uses.
+	/// </summary>
+	private static void AssertPopupShown(bool shown, DTACViewHostPageObject dtac, string label, string message)
+	{
+		if (!shown)
+			TestContext.Out.WriteLine(
+				$"[diag] {label} not shown — Appium tree follows:\n{dtac.CaptureTreeForDiagnostics()}");
+		Assert.That(shown, Is.True, message);
+	}
+
 	[Test]
 	public void QuickSwitchPopup_OpensAndDismisses_WithoutCrashing()
 	{
 		var dtac = OpenDTAC();
 
 		dtac.OpenQuickSwitchPopupViaSeam();
-		Assert.That(dtac.IsQuickSwitchPopupShown(), Is.True,
+		AssertPopupShown(dtac.IsQuickSwitchPopupShown(), dtac, "QuickSwitchPopup",
 			"QuickSwitchPopup must appear after the open seam fires. On Windows the "
 			+ "old AnchorPopover.ShowAsync threw MissingMethodException here and "
 			+ "crashed the app into the fatal error modal (#273).");
@@ -102,7 +117,7 @@ public class DTACPopupTests : BaseUITest
 		// absorber stops the tap bubbling to the dismiss scrim: the popup must
 		// still be shown and the app still alive afterwards.
 		dtac.TapQuickSwitchWorkTab();
-		Assert.That(dtac.IsQuickSwitchPopupShown(2), Is.True,
+		AssertPopupShown(dtac.IsQuickSwitchPopupShown(2), dtac, "QuickSwitchPopup (after Work-tab tap)",
 			"Tapping the Work tab inside the popup must not dismiss it (the "
 			+ "absorber Border must stop inner taps reaching the scrim) and must "
 			+ "not crash the app.");
@@ -125,7 +140,7 @@ public class DTACPopupTests : BaseUITest
 		var dtac = OpenDTAC();
 
 		dtac.OpenSelectMarkerPopupViaSeam();
-		Assert.That(dtac.IsSelectMarkerPopupShown(), Is.True,
+		AssertPopupShown(dtac.IsSelectMarkerPopupShown(), dtac, "SelectMarkerPopup",
 			"SelectMarkerPopup must appear after the open seam fires. On Windows the "
 			+ "old AnchorPopover.ShowAsync threw MissingMethodException here and "
 			+ "crashed the app into the fatal error modal (#273).");

--- a/TRViS.UITests/Tests/DTACPopupTests.cs
+++ b/TRViS.UITests/Tests/DTACPopupTests.cs
@@ -1,0 +1,121 @@
+using TRViS.UITests.Pages;
+
+namespace TRViS.UITests.Tests;
+
+/// <summary>
+/// Regression coverage for #273: the two remaining TR.Maui.AnchorPopover
+/// popups (QuickSwitchPopup, opened from the AppBar title; SelectMarkerPopup,
+/// opened from the timetable MarkerButton). AnchorPopover 1.0.0.2 is built
+/// against MAUI 9 and on the project's MAUI 10 Windows target its ShowAsync
+/// throws MissingMethodException for ElementExtensions.ToPlatform, crashing
+/// the app into the fatal "不明なエラー" modal (ui-test-windows on #273; #266
+/// retired its own AnchorPopover usage for the identical reason). The popups
+/// are now in-page overlays owned by ViewHost, so opening and dismissing them
+/// must work on every platform without crashing.
+///
+/// Open/dismiss run through UI_TEST seams that invoke the exact production
+/// show/dismiss path (ShowQuickSwitchPopupAsync / ShowSelectMarkerPopupAsync /
+/// DismissAsync) — the real anchors are MAUI custom controls WinUI surfaces as
+/// non-control Panes Appium can't reliably tap, and #266 established that
+/// real-gesture popover E2E is fragile cross-platform. SelectMarkerPopup's
+/// real "Close" button is also exercised so its IPagePopupHost.DismissAsync
+/// wiring is covered end to end.
+/// </summary>
+[TestFixture]
+[Infrastructure.RetryAllTests(2)] // see AppLaunchTests for rationale
+public class DTACPopupTests : BaseUITest
+{
+	private StartHomePageObject _startHomePage = null!;
+
+	protected override bool ShareSessionAcrossTestsInFixture => true;
+
+	[SetUp]
+	public override void SetUp()
+	{
+		base.SetUp();
+
+		_startHomePage = new StartHomePageObject(Driver);
+
+		// Idempotent reset to StartHome with no loader (mirrors
+		// DTACTimetableTests) — no-ops on the first test of the fixture.
+		if (!_startHomePage.PollDisplayed(AutomationIds.StartHome.Title, timeoutSeconds: 3))
+		{
+			new AppShellPage(Driver).NavigateToHome();
+			_startHomePage = new StartHomePageObject(Driver);
+		}
+		_startHomePage.ClearLoaderForTesting();
+		_startHomePage.AcceptPrivacyPolicyIfNeeded();
+	}
+
+	private DTACViewHostPageObject OpenDTAC()
+	{
+		Assert.That(_startHomePage.IsDisplayed(), Is.True,
+			"StartHome should be displayed at fixture entry.");
+		_startHomePage.LoadSample();
+		_startHomePage.WaitForElement(AutomationIds.StartHome.WorkGroupList);
+		var dtac = _startHomePage.AutoOpenForTesting();
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC view should be displayed after AutoOpenForTesting.");
+		return dtac;
+	}
+
+	[Test]
+	public void QuickSwitchPopup_OpensAndDismisses_WithoutCrashing()
+	{
+		var dtac = OpenDTAC();
+
+		dtac.OpenQuickSwitchPopupViaSeam();
+		Assert.That(dtac.IsQuickSwitchPopupShown(), Is.True,
+			"QuickSwitchPopup must appear after the open seam fires. On Windows the "
+			+ "old AnchorPopover.ShowAsync threw MissingMethodException here and "
+			+ "crashed the app into the fatal error modal (#273).");
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC must still be alive (no fatal-error modal) while the popup is open.");
+
+		// Tap a control *inside* the popup (the "Work" tab — a plain
+		// TapGestureRecognizer, not a fragile CollectionView row). This proves
+		// descendant input routes through the overlay's absorber Border on
+		// every platform (the WinUI-3 gesture-routing risk), and that the
+		// absorber stops the tap bubbling to the dismiss scrim: the popup must
+		// still be shown and the app still alive afterwards.
+		dtac.TapQuickSwitchWorkTab();
+		Assert.That(dtac.IsQuickSwitchPopupShown(2), Is.True,
+			"Tapping the Work tab inside the popup must not dismiss it (the "
+			+ "absorber Border must stop inner taps reaching the scrim) and must "
+			+ "not crash the app.");
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC must still be alive after interacting inside the popup.");
+
+		// Dismiss via the seam (DismissAsync) — tap-outside on the scrim isn't
+		// reliably reproducible cross-platform; the regression is the crash, not
+		// the gesture (#266 rationale).
+		dtac.DismissPopupViaSeam();
+		Assert.That(dtac.IsQuickSwitchPopupGone(), Is.True,
+			"QuickSwitchPopup must be gone after DismissAsync.");
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC must remain displayed (no crash) after dismissing the popup.");
+	}
+
+	[Test]
+	public void SelectMarkerPopup_OpensAndDismisses_WithoutCrashing()
+	{
+		var dtac = OpenDTAC();
+
+		dtac.OpenSelectMarkerPopupViaSeam();
+		Assert.That(dtac.IsSelectMarkerPopupShown(), Is.True,
+			"SelectMarkerPopup must appear after the open seam fires. On Windows the "
+			+ "old AnchorPopover.ShowAsync threw MissingMethodException here and "
+			+ "crashed the app into the fatal error modal (#273).");
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC must still be alive (no fatal-error modal) while the popup is open.");
+
+		// Dismiss via the popup's own "Close" button — exercises
+		// SelectMarkerPopup.OnCloseButtonClicked -> IPagePopupHost.DismissAsync,
+		// the real production interaction.
+		dtac.TapSelectMarkerPopupClose();
+		Assert.That(dtac.IsSelectMarkerPopupGone(), Is.True,
+			"SelectMarkerPopup must be gone after tapping its Close button.");
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC must remain displayed (no crash) after dismissing the popup.");
+	}
+}

--- a/TRViS.UITests/Tests/DTACPopupTests.cs
+++ b/TRViS.UITests/Tests/DTACPopupTests.cs
@@ -34,6 +34,11 @@ public class DTACPopupTests : BaseUITest
 	{
 		base.SetUp();
 
+		// Belt-and-suspenders: if a prior test left the modal scrim up it
+		// blocks NavigateToHome's flyout. Dismiss before recovering state.
+		try { new DTACViewHostPageObject(Driver).TryDismissAnyPopup(); }
+		catch { /* fresh session / not on DTAC — nothing to dismiss */ }
+
 		_startHomePage = new StartHomePageObject(Driver);
 
 		// Idempotent reset to StartHome with no loader (mirrors
@@ -45,6 +50,24 @@ public class DTACPopupTests : BaseUITest
 		}
 		_startHomePage.ClearLoaderForTesting();
 		_startHomePage.AcceptPrivacyPolicyIfNeeded();
+	}
+
+	/// <summary>
+	/// Runs before BaseUITest's teardown (NUnit runs derived TearDown first).
+	/// The overlay is a full-screen modal scrim; a popup left open by a failed
+	/// assertion would block the flyout and wedge every subsequent test in
+	/// this shared session (and, since the app process persists across
+	/// fixtures, later fixtures too). Best-effort, never throws.
+	/// </summary>
+	[TearDown]
+	public void DismissPopupAfterTest()
+	{
+		// Wrap the whole thing: if the Appium session died during the test
+		// (e.g. a window-close cascade), even constructing the page object or
+		// touching Driver can throw — and a throwing TearDown is reported by
+		// NUnit as a failure, manufacturing one that wouldn't otherwise exist.
+		try { new DTACViewHostPageObject(Driver).TryDismissAnyPopup(); }
+		catch { /* driver/session dead — nothing to clean up */ }
 	}
 
 	private DTACViewHostPageObject OpenDTAC()

--- a/TRViS/DTAC/IPagePopupHost.cs
+++ b/TRViS/DTAC/IPagePopupHost.cs
@@ -1,0 +1,19 @@
+namespace TRViS.DTAC;
+
+/// <summary>
+/// In-app replacement for <c>TR.Maui.AnchorPopover.IAnchorPopover</c>'s dismiss
+/// handle. The AnchorPopover package (built against MAUI 9) is binary-incompatible
+/// with the project's MAUI 10 on Windows — calling its <c>ShowAsync</c> throws
+/// <c>MissingMethodException</c> for <c>ElementExtensions.ToPlatform</c> and
+/// crashes the app (#266 retired its own usage for the same reason; #273 covers
+/// the two remaining ones: QuickSwitchPopup and SelectMarkerPopup).
+///
+/// Popups are now rendered as an in-page overlay owned by <see cref="ViewHost"/>,
+/// which implements this interface so popup content can request its own dismissal
+/// (e.g. SelectMarkerPopup's Close button) without referencing the page type.
+/// </summary>
+public interface IPagePopupHost
+{
+	/// <summary>Dismisses the currently displayed in-page popup.</summary>
+	Task DismissAsync();
+}

--- a/TRViS/DTAC/PageParts/QuickSwitchPopup.xaml
+++ b/TRViS/DTAC/PageParts/QuickSwitchPopup.xaml
@@ -5,7 +5,8 @@
 	xmlns:local="clr-namespace:TRViS.DTAC.PageParts"
 	xmlns:models="clr-namespace:TRViS.IO.Models;assembly=TRViS.IO.ILoader"
 	xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
-	x:Class="TRViS.DTAC.QuickSwitchPopup">
+	x:Class="TRViS.DTAC.QuickSwitchPopup"
+	AutomationId="DTAC.QuickSwitchPopup">
 	<Grid
 		Padding="8">
 		<Grid.RowDefinitions>
@@ -25,11 +26,13 @@
 
 			<local:TabButtonSmall
 				x:Name="WorkGroupTabButton"
+				AutomationId="DTAC.QuickSwitchPopup.WorkGroupTab"
 				Grid.Column="0"
 				ButtonText="WorkGroup"/>
 
 			<local:TabButtonSmall
 				x:Name="WorkTabButton"
+				AutomationId="DTAC.QuickSwitchPopup.WorkTab"
 				Grid.Column="2"
 				ButtonText="Work"/>
 		</Grid>

--- a/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/MarkerButton.xaml.cs
@@ -1,6 +1,5 @@
 using TRViS.Services;
 using TRViS.ViewModels;
-using TR.Maui.AnchorPopover;
 using TRViS.Utils;
 
 namespace TRViS.DTAC;
@@ -33,20 +32,17 @@ public partial class MarkerButton : Border
 
 			MarkerSettings.IsToggled = true;
 
-			SelectMarkerPopup popup = new(MarkerSettings);
-			var popover = AnchorPopover.Create();
-			popup.SetPopover(popover);
-
-			var options = new PopoverOptions
+			// TR.Maui.AnchorPopover crashes on Windows MAUI 10 (#273); the
+			// popup is now an in-page overlay owned by the hosting ViewHost.
+			ViewHost? host = ViewHost.GetHostFor(this);
+			if (host is null)
 			{
-				PreferredWidth = 240,
-				PreferredHeight = 360,
-				DismissOnTapOutside = true
-			};
+				logger.Warn("MarkerButton: hosting ViewHost not found — cannot show SelectMarkerPopup");
+				return;
+			}
 
-			logger.Info("Showing SelectMarkerPopup");
-			await popover.ShowAsync(popup, this, options);
-			logger.Trace("SelectMarkerPopup Shown");
+			await host.ShowSelectMarkerPopupAsync();
+			logger.Trace("SelectMarkerPopup dismissed");
 		}
 		catch (Exception ex)
 		{

--- a/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml
+++ b/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml
@@ -5,7 +5,8 @@
 	xmlns:local="clr-namespace:TRViS.DTAC"
 	xmlns:vm="clr-namespace:TRViS.ViewModels"
 	x:Class="TRViS.DTAC.SelectMarkerPopup"
-	x:DataType="vm:DTACMarkerViewModel">
+	x:DataType="vm:DTACMarkerViewModel"
+	AutomationId="DTAC.SelectMarkerPopup">
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto"/>
@@ -16,6 +17,7 @@
 			Grid.Row="0"
 			Margin="0,8,8,0"
 			Text="Close"
+			AutomationId="DTAC.SelectMarkerPopup.CloseButton"
 			HorizontalOptions="End"
 			Clicked="OnCloseButtonClicked"/>
 		<HorizontalStackLayout

--- a/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml.cs
+++ b/TRViS/DTAC/TimetableParts/SelectMarkerPopup.xaml.cs
@@ -1,13 +1,12 @@
 using TRViS.Services;
 using TRViS.ViewModels;
-using TR.Maui.AnchorPopover;
 
 namespace TRViS.DTAC;
 
 public partial class SelectMarkerPopup : ContentView
 {
 	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
-	private IAnchorPopover? _popover;
+	private IPagePopupHost? _host;
 
 	public SelectMarkerPopup() : this(Adapters.PresenterFactory.GetRawMarkerViewModel()) { }
 
@@ -28,16 +27,16 @@ public partial class SelectMarkerPopup : ContentView
 	{
 		logger.Trace("Closing...");
 
-		if (_popover != null)
+		if (_host != null)
 		{
-			await _popover.DismissAsync();
+			await _host.DismissAsync();
 		}
 
 		logger.Trace("Closed");
 	}
 
-	internal void SetPopover(IAnchorPopover popover)
+	internal void SetPopupHost(IPagePopupHost host)
 	{
-		_popover = popover;
+		_host = host;
 	}
 }

--- a/TRViS/DTAC/ViewHost.xaml
+++ b/TRViS/DTAC/ViewHost.xaml
@@ -69,5 +69,39 @@
 			<local:VerticalStylePage
 				x:Name="VerticalStylePageView"/>
 		</local:WithRemarksView>
+
+		<!--
+			In-page popup overlay (replaces TR.Maui.AnchorPopover, #273).
+			Last child of MainGrid + RowSpan=3 => covers the whole page at the
+			highest z-order (same overlay convention the UI_TEST seams use).
+			Hidden until ShowOverlayPopupAsync; the scrim dismisses on tap when
+			the request allows it, the inner Border swallows taps so taps on the
+			popup content don't dismiss it.
+		-->
+		<Grid
+			x:Name="PopupScrim"
+			Grid.Row="0"
+			Grid.RowSpan="3"
+			IsVisible="False"
+			AutomationId="DTAC.PopupScrim"
+			BackgroundColor="#80000000">
+			<Grid.GestureRecognizers>
+				<TapGestureRecognizer Tapped="PopupScrim_Tapped"/>
+			</Grid.GestureRecognizers>
+
+			<Border
+				x:Name="PopupContainer"
+				HorizontalOptions="Center"
+				VerticalOptions="Center"
+				Padding="0"
+				StrokeThickness="0"
+				StrokeShape="RoundRectangle 12">
+				<Border.GestureRecognizers>
+					<!-- absorb taps so they don't reach the dismiss scrim -->
+					<TapGestureRecognizer Tapped="PopupContainer_Tapped"/>
+				</Border.GestureRecognizers>
+				<ContentView x:Name="PopupContentHost"/>
+			</Border>
+		</Grid>
 	</Grid>
 </ContentPage>

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -1,7 +1,5 @@
 using System.ComponentModel;
 
-using TR.Maui.AnchorPopover;
-
 using TRViS.DTAC.Adapters;
 using TRViS.DTAC.Logic.Abstractions;
 using TRViS.DTAC.Logic.Presenter;
@@ -13,7 +11,7 @@ using TRViS.ViewModels;
 
 namespace TRViS.DTAC;
 
-public partial class ViewHost : ContentPage
+public partial class ViewHost : ContentPage, IPagePopupHost
 {
 	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
 
@@ -93,6 +91,7 @@ public partial class ViewHost : ContentPage
 		AddTestStateSeams();
 		ApplyTestStateSeams(_presenter.CurrentState);
 		AddTestIsInfoRowTransitionSeam();
+		AddTestPopupSeams();
 #endif
 
 		logger.Trace("Created");
@@ -363,6 +362,10 @@ public partial class ViewHost : ContentPage
 	protected override void OnDisappearing()
 	{
 		base.OnDisappearing();
+		// ViewHost is a cached ShellContent reused across navigations; drop any
+		// open popup so a stale overlay / dangling awaiter doesn't survive into
+		// the next visit.
+		DismissOverlayPopup();
 		if (DeviceInfo.Current.Idiom == DeviceIdiom.Phone)
 			InstanceManager.OrientationService.SetOrientation(AppDisplayOrientation.All);
 		InstanceManager.ScreenWakeLockService.DisableWakeLock();
@@ -388,19 +391,7 @@ public partial class ViewHost : ContentPage
 		try
 		{
 			logger.Info("TitleLabel tapped - showing QuickSwitchPopup");
-
-			QuickSwitchPopup popup = new();
-			var popover = AnchorPopover.Create();
-
-			var options = new PopoverOptions
-			{
-				PreferredWidth = 280,
-				PreferredHeight = 400,
-				DismissOnTapOutside = true
-			};
-
-			await popover.ShowAsync(popup, AppBarView, options);
-			logger.Trace("QuickSwitchPopup shown");
+			await ShowQuickSwitchPopupAsync();
 		}
 		catch (Exception ex)
 		{
@@ -408,4 +399,193 @@ public partial class ViewHost : ContentPage
 			await Util.ExitWithAlertAsync(ex);
 		}
 	}
+
+	// ---------- In-page popup overlay (replaces TR.Maui.AnchorPopover, #273) ----------
+	//
+	// TR.Maui.AnchorPopover 1.0.0.2 is built against MAUI 9; on the project's
+	// MAUI 10 Windows target IAnchorPopover.ShowAsync throws
+	// MissingMethodException for ElementExtensions.ToPlatform and crashes the
+	// app (#266 retired its own usage for the same reason — these two,
+	// QuickSwitchPopup and SelectMarkerPopup, were the remaining ones, #273).
+	// The replacement renders the popup content in an overlay that spans the
+	// page (PopupScrim/PopupContainer in ViewHost.xaml), which works on every
+	// platform with no third-party dependency.
+
+	private TaskCompletionSource<bool>? _popupTcs;
+	private bool _popupDismissOnTapOutside = true;
+
+	/// <summary>
+	/// Shows <paramref name="content"/> centered in the in-page overlay. The
+	/// returned task completes when the popup is dismissed (scrim tap, the
+	/// content's own close affordance, or navigation away). Drop-in replacement
+	/// for the old IAnchorPopover.ShowAsync semantics ("await until closed").
+	/// </summary>
+	public Task ShowOverlayPopupAsync(View content, double preferredWidth, double preferredHeight, bool dismissOnTapOutside)
+	{
+		if (!MainThread.IsMainThread)
+			return MainThread.InvokeOnMainThreadAsync(() => ShowOverlayPopupAsync(content, preferredWidth, preferredHeight, dismissOnTapOutside));
+
+		// Replace any popup already on screen — complete its awaiter first so
+		// a caller blocked on the previous ShowOverlayPopupAsync unblocks.
+		if (_popupTcs is { } prev && !prev.Task.IsCompleted)
+		{
+			_popupTcs = null;
+			prev.TrySetResult(true);
+		}
+
+		_popupDismissOnTapOutside = dismissOnTapOutside;
+		PopupContainer.WidthRequest = preferredWidth;
+		PopupContainer.HeightRequest = preferredHeight;
+		PopupContentHost.Content = content;
+		PopupScrim.IsVisible = true;
+
+		var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		_popupTcs = tcs;
+		return tcs.Task;
+	}
+
+	/// <summary>Dismisses the current in-page popup (<see cref="IPagePopupHost"/>).</summary>
+	public Task DismissAsync()
+	{
+		if (!MainThread.IsMainThread)
+			return MainThread.InvokeOnMainThreadAsync(DismissOverlayPopup);
+		DismissOverlayPopup();
+		return Task.CompletedTask;
+	}
+
+	private void DismissOverlayPopup()
+	{
+		if (!PopupScrim.IsVisible && _popupTcs is null)
+			return;
+
+		PopupScrim.IsVisible = false;
+		PopupContentHost.Content = null;
+		// -1 == "unset" so a later popup with no explicit size auto-measures.
+		PopupContainer.WidthRequest = -1;
+		PopupContainer.HeightRequest = -1;
+
+		var tcs = _popupTcs;
+		_popupTcs = null;
+		tcs?.TrySetResult(true);
+	}
+
+	void PopupScrim_Tapped(object? sender, TappedEventArgs e)
+	{
+		if (_popupDismissOnTapOutside)
+		{
+			logger.Trace("Popup scrim tapped -> dismiss");
+			DismissOverlayPopup();
+		}
+	}
+
+	// Absorb taps on the popup content so they don't bubble to the dismiss
+	// scrim's TapGestureRecognizer (no-op by design).
+	void PopupContainer_Tapped(object? sender, TappedEventArgs e) { }
+
+	private async Task ShowQuickSwitchPopupAsync()
+	{
+		logger.Info("Showing QuickSwitchPopup");
+		QuickSwitchPopup popup = new();
+		await ShowOverlayPopupAsync(popup, preferredWidth: 280, preferredHeight: 400, dismissOnTapOutside: true);
+		logger.Trace("QuickSwitchPopup dismissed");
+	}
+
+	/// <summary>
+	/// Builds and shows SelectMarkerPopup in the overlay. Centralized here (not
+	/// in MarkerButton) so the overlay is owned by the page and the UI_TEST
+	/// seam exercises the exact production path. SelectMarkerPopup binds to the
+	/// singleton DTACMarkerViewModel, so this is equivalent to MarkerButton's
+	/// previous <c>new SelectMarkerPopup(MarkerSettings)</c>.
+	/// </summary>
+	internal async Task ShowSelectMarkerPopupAsync()
+	{
+		logger.Info("Showing SelectMarkerPopup");
+		SelectMarkerPopup popup = new();
+		popup.SetPopupHost(this);
+		await ShowOverlayPopupAsync(popup, preferredWidth: 240, preferredHeight: 360, dismissOnTapOutside: true);
+		logger.Trace("SelectMarkerPopup dismissed");
+	}
+
+	/// <summary>
+	/// Resolves the ViewHost hosting <paramref name="element"/> so descendant
+	/// controls (e.g. MarkerButton) can present the in-page popup overlay
+	/// without referencing the page directly. Walks the visual-tree parent
+	/// chain, then falls back to the current Shell page (ViewHost is a cached
+	/// ShellContent, so it is the Shell's CurrentPage whenever its descendants
+	/// are interactive).
+	/// </summary>
+	public static ViewHost? GetHostFor(Element? element)
+	{
+		for (Element? e = element; e is not null; e = e.Parent)
+		{
+			if (e is ViewHost host)
+				return host;
+		}
+		return Shell.Current?.CurrentPage as ViewHost;
+	}
+
+#if UI_TEST
+	// UI_TEST-only seams: open each popup via the exact production code path
+	// (ShowQuickSwitchPopupAsync / ShowSelectMarkerPopupAsync) and a dismiss
+	// invoker. Real anchors (the AppBar title Label, the timetable MarkerButton
+	// Border) are MAUI custom controls that WinUI surfaces as non-control Panes
+	// Appium's AccessibilityId search can't reliably tap, and #266 established
+	// that real-gesture popover E2E is fragile cross-platform — these seams keep
+	// the regression test (the Windows ToPlatform crash) robust while still
+	// running the production show/dismiss code on every platform. Stacked above
+	// the existing bottom-left seam strip (offsets 0/28/56).
+	private const string AutomationIdValueForTestOpenQuickSwitch = "DTAC.TestOpenQuickSwitchButton";
+	private const string AutomationIdValueForTestOpenMarkerPopup = "DTAC.TestOpenMarkerPopupButton";
+	private const string AutomationIdValueForTestDismissPopup = "DTAC.TestDismissPopupButton";
+
+	private void AddTestPopupSeams()
+	{
+		MainGrid.Children.Add(BuildPopupSeamButton(
+			AutomationIdValueForTestOpenQuickSwitch, bottomMarginPx: 84, TestOpenQuickSwitchButton_Clicked));
+		MainGrid.Children.Add(BuildPopupSeamButton(
+			AutomationIdValueForTestOpenMarkerPopup, bottomMarginPx: 112, TestOpenMarkerPopupButton_Clicked));
+		MainGrid.Children.Add(BuildPopupSeamButton(
+			AutomationIdValueForTestDismissPopup, bottomMarginPx: 140, TestDismissPopupButton_Clicked));
+	}
+
+	private static Button BuildPopupSeamButton(string automationId, double bottomMarginPx, EventHandler clicked)
+	{
+		var seam = new Button
+		{
+			AutomationId = automationId,
+			HorizontalOptions = LayoutOptions.Start,
+			VerticalOptions = LayoutOptions.End,
+			WidthRequest = 24,
+			HeightRequest = 24,
+			BackgroundColor = Colors.Transparent,
+			BorderColor = Colors.Transparent,
+			Padding = 0,
+			Margin = new Thickness(0, 0, 0, bottomMarginPx),
+		};
+		seam.Clicked += clicked;
+		Grid.SetRow(seam, 2);
+		return seam;
+	}
+
+	async void TestOpenQuickSwitchButton_Clicked(object? sender, EventArgs e)
+	{
+		logger.Info("TestOpenQuickSwitchButton clicked: showing QuickSwitchPopup");
+		try { await ShowQuickSwitchPopupAsync(); }
+		catch (Exception ex) { logger.Error(ex, "TestOpenQuickSwitchButton failed"); }
+	}
+
+	async void TestOpenMarkerPopupButton_Clicked(object? sender, EventArgs e)
+	{
+		logger.Info("TestOpenMarkerPopupButton clicked: showing SelectMarkerPopup");
+		try { await ShowSelectMarkerPopupAsync(); }
+		catch (Exception ex) { logger.Error(ex, "TestOpenMarkerPopupButton failed"); }
+	}
+
+	async void TestDismissPopupButton_Clicked(object? sender, EventArgs e)
+	{
+		logger.Info("TestDismissPopupButton clicked: dismissing in-page popup");
+		try { await DismissAsync(); }
+		catch (Exception ex) { logger.Error(ex, "TestDismissPopupButton failed"); }
+	}
+#endif
 }

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -82,9 +82,6 @@
 			PrivateAssets="all"
 			ExcludeAssets="runtime" />
 		<PackageReference
-			Include="TR.Maui.AnchorPopover"
-			Version="1.0.0.2" />
-		<PackageReference
 			Include="NLog"
 			Version="6.0.3" />
 		<PackageReference


### PR DESCRIPTION
## 概要

`TR.Maui.AnchorPopover` 1.0.0.2 は **net9.0 / Microsoft.Maui.Controls 9.0.0** 向けビルドのみで、本プロジェクトの **net10.0 / MAUI 10.0.41** とバイナリ非互換です。`Microsoft.Maui.Platform.ElementExtensions.ToPlatform` のシグネチャが MAUI 9→10 で変わったため、Windows で `IAnchorPopover.ShowAsync` が

```
System.MissingMethodException: Method not found: 'System.Object Microsoft.Maui.Platform.ElementExtensions.ToPlatform(Microsoft.Maui.IElement, Microsoft.Maui.IMauiContext)'.
```

を投げ、「不明なエラーが発生しました。アプリを終了します。」モーダルでアプリが落ちます(PR #273 の `ui-test-windows` で検出。Android は通過、Windows のみ failure)。

NuGet に MAUI 10 ビルドは存在せず、#266 が**同一原因**で同パッケージの自前利用を確認ダイアログへ退避済みでした。残っていたのが本 PR で扱う `QuickSwitchPopup`(AppBar タイトルタップ)と `SelectMarkerPopup`(時刻表マーカー色選択)の 2 箇所です。

## 対応

#266 の方針(AnchorPopover を退役させ、サードパーティ依存を増やさずクロスプラットフォーム安全な UI へ)に倣い、**ページ内オーバーレイ**へ置換しました。

- **`IPagePopupHost`** — `IAnchorPopover` の dismiss ハンドルを置換する小さなインターフェース。
- **`ViewHost.xaml`** — `MainGrid` の最後の子(`RowSpan=3`・最前面、既存 UI_TEST シームと同じオーバーレイ規約)に scrim + container オーバーレイを追加。
- **`ViewHost.xaml.cs`** — `ShowOverlayPopupAsync`/`DismissAsync`、scrim タップで閉じる、内側タップ吸収、再入・`OnDisappearing` クリーンアップを実装。両 Popup をページが所有し、`static GetHostFor()` で `MarkerButton` から到達。
- **`MarkerButton` / `SelectMarkerPopup`** を AnchorPopover から切り離し。
- 全利用が消えたため **`TRViS.csproj` の `TR.Maui.AnchorPopover` PackageReference を削除**し、#266 の退役を完了。

iOS / Android / macOS はコア MAUI(`Grid`/`Border`/`ContentView`/`TapGestureRecognizer`)のみ使用で挙動不変です。

## E2E

`QuickSwitchPopup` / `SelectMarkerPopup` の open→dismiss を **UI_TEST シーム**(本番の `ShowQuickSwitchPopupAsync` / `ShowSelectMarkerPopupAsync` / `DismissAsync` 経路を直接起動)で検証。実アンカーは WinUI が非操作 Pane で公開し Appium で安定して叩けず、#266 が実ジェスチャ popover E2E はクロスプラットフォームで脆いと結論済みのためシーム駆動としています。

- 両テスト: 「クラッシュせず開く + 閉じる + DTAC 生存」を表明(= #273 の Windows リグレッションそのもの)。
- `SelectMarkerPopup`: 実 **Close** ボタンで閉じ、`OnCloseButtonClicked → IPagePopupHost.DismissAsync` 配線を端から端まで通す。
- `QuickSwitchPopup`: さらにポップ内の **Work タブ**を叩き、descendant 入力が absorber Border を通ること・内側タップが scrim へ漏れて誤 dismiss しないことを確認。タブは素の `TapGestureRecognizer`(CollectionView 行ではない)で、本リポジトリが明文化している iOS の CollectionView 行タップ脆弱性を踏みません。

## 検証

- ✅ `net10.0-maccatalyst` クリーン再ビルド(CI と同じ `DISABLE_FIREBASE;UI_TEST` defines)— 0 error / 0 warning。MAUI ソースジェネレータが新規 XAML 名/ハンドラを認識。
- ✅ 本番 defines(`UI_TEST` 無し)ビルド — シーム記号が本番経路へ漏れていないことを確認。
- ✅ `TRViS.UITests` 再ビルド — 0 error / 0 warning。
- ⚠️ **`net10.0-windows` ビルド + `ui-test-windows` Appium は CI のみで検証可能**。Windows TFM は Windows ホストでのみ追加されるため macOS の MSBuild からは不可視(#266 と同じ制約)。実リグレッション確認はこのジョブで行われます。

## レビュアー向けメモ

1. Windows ランタイム検証は CI の `ui-test-windows` 依存(上記)。
2. **意図的な UX 変更**: 旧パッケージはアンカー近傍に浮かせていたが、置換後はページを暗くする中央 scrim モーダル(#266 が許容したクロスプラットフォーム信頼性とのトレードオフと同様)。なお `QuickSwitchPopup` は従来通り選択しても自動で閉じないため、Work 選択後もユーザーが閉じるまで暗いままになります。希望があれば `WorkListView_SelectionChanged` に `host.DismissAsync()` を足して選択即クローズにする磨き込みを本ブランチへ追加可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)