### PR TITLE
fix(net): Android/iOS/Mac で cleartext (http/ws) 接続が OS にブロックされる問題を修正

### DIFF
--- a/TRViS/Platforms/Android/AndroidManifest.xml
+++ b/TRViS/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<!-- usesCleartextTraffic: NetworkSyncService の接続先はユーザーが任意入力する URL
+	     (典型例: LAN 上のシミュレータ/ゲームの http://192.168.x.x や ws://...)。
+	     TLS 証明書を持たない LAN ホストが大半のため、Android 9+ がデフォルトで
+	     ブロックする cleartext (非 TLS) 通信を許可する。接続先が固定ドメインでは
+	     ないため network-security-config によるドメインスコープ化は機能しない。 -->
+	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:usesCleartextTraffic="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/TRViS/Platforms/MacCatalyst/Info.plist
+++ b/TRViS/Platforms/MacCatalyst/Info.plist
@@ -40,6 +40,19 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Check whether you are near a station or not.</string>
+	<!-- App Transport Security: NetworkSyncService の接続先はユーザーが任意入力する
+	     URL (LAN 上のシミュレータ/ゲームの http:// や ws:// が典型)。TLS を張れない
+	     LAN ホストへ繋ぐため、ATS のデフォルト cleartext ブロックを解除する。
+	     ClientWebSocket も内部で NSURLSession を使うため ATS の対象。 -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<!-- macOS もローカルネットワークアクセスの許可ダイアログ対象。説明文字列が
+	     無いとダイアログを出せず接続が黙って失敗するため必須。 -->
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>ローカルネットワーク上の運転シミュレータ等のサーバーと連携するために使用します。</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (c) 2023 Tetsu Otter</string>
 	<key>LSApplicationCategoryType</key>

--- a/TRViS/Platforms/iOS/Info.plist
+++ b/TRViS/Platforms/iOS/Info.plist
@@ -47,5 +47,19 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Check whether you are near a station or not.</string>
+	<!-- App Transport Security: NetworkSyncService の接続先はユーザーが任意入力する
+	     URL (LAN 上のシミュレータ/ゲームの http:// や ws:// が典型)。TLS を張れない
+	     LAN ホストへ繋ぐため、ATS のデフォルト cleartext ブロックを解除する。
+	     ClientWebSocket も内部で NSURLSession を使うため ATS の対象。 -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<!-- iOS 14+ はローカルネットワーク上のホストへ初回アクセスする際に許可
+	     ダイアログを表示する。この説明文字列が無いとダイアログを出せず接続が
+	     黙って失敗するため必須。 -->
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>ローカルネットワーク上の運転シミュレータ等のサーバーと連携するために使用します。</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 背景・報告内容

「Android で HTTP/WebSocket 接続をしようとすると権限エラーで弾かれる」という報告について調査。**報告は事実**でした（ただし正確には INTERNET ランタイム権限ではなく、Android 9+ の cleartext 通信ブロック）。

## 原因

- [AndroidManifest.xml](../blob/main/TRViS/Platforms/Android/AndroidManifest.xml) には `INTERNET` / `ACCESS_NETWORK_STATE` が宣言済みで、**ランタイムのネットワーク権限は問題なし**。
- `usesCleartextTraffic` も network-security-config も未設定だった。ターゲットは `net10.0-android`（target SDK 28+）のため、**非 TLS の `http://` / `ws://` 通信が OS によりデフォルトでブロック**される。
- `ConnectServerDialog` はユーザー入力 URL（NetworkSyncService の典型例＝LAN 上のシミュレータ/ゲームの `http://192.168.x.x` / `ws://...`、TLS 証明書なし）をそのまま接続するため確実に踏む。
- 例外メッセージ `Cleartext HTTP traffic to … not permitted` の "not permitted" が「権限エラー」として認識されていた。

## 追加で見つかった不足（iOS / Mac でも同じ罠）

報告は Android のみだったが、**iOS / Mac Catalyst も同一問題**を抱えていた:

1. **App Transport Security 未設定** — Apple は iOS 9+ で cleartext HTTP をデフォルト遮断。`ClientWebSocket` も内部で `NSURLSession` を使うため ATS の対象。
2. **`NSLocalNetworkUsageDescription` 欠落** — iOS 14+ / 近年の macOS は LAN ホスト初回アクセス時に許可ダイアログを出すが、この説明文字列が無いとダイアログを表示できず接続が黙って失敗する（ATS を通しても繋がらない第二の罠）。

Windows は `runFullTrust` capability のため AppContainer のネットワーク制約を受けず、追加不要。

## 変更内容

| ファイル | 変更 |
|---|---|
| `TRViS/Platforms/Android/AndroidManifest.xml` | `<application>` に `android:usesCleartextTraffic="true"` |
| `TRViS/Platforms/iOS/Info.plist` | `NSAppTransportSecurity`(`NSAllowsArbitraryLoads=true`) + `NSLocalNetworkUsageDescription` |
| `TRViS/Platforms/MacCatalyst/Info.plist` | 同上 |

接続先が固定ドメインでなくユーザー任意入力（LAN IP 含む）のため、ドメインスコープの network-security-config / ATS 例外は機能せず、用途上 blanket 許可が妥当（理由は各ファイルにコメント記載）。

## 検証

- `plutil -lint` で iOS / MacCatalyst の Info.plist が OK であることを確認。
- AndroidManifest.xml は属性追加のみで整形式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)