### PR TITLE
ci(cd): job単位concurrency+queue:maxで予約後にロックを即解放し待ち時間を短縮

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -372,7 +372,7 @@ jobs:
       - publish-ios
       - publish-mac
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cd-create-release

--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
   pull_request:
     types:
       - opened
@@ -17,13 +17,19 @@ on:
         required: false
         type: string
 
-concurrency: cd-action-${{ github.ref }}
-
 env:
   CSPROJ_PATH: ./TRViS/TRViS.csproj
 
 jobs:
   generate-bundle-version:
+    # Critical section: read existing tags -> allocate next build number -> push the tag.
+    # Job-level concurrency keeps the lock only for THIS job (~minutes), so the rest of
+    # the pipeline (build/publish/release) runs lock-free and the next run's reservation
+    # can start as soon as this job finishes. queue: max lets up to 100 runs stack FIFO
+    # (queue: max is incompatible with cancel-in-progress: true, so it is omitted).
+    concurrency:
+      group: cd-action-${{ github.ref }}
+      queue: max
     if: |
       !startsWith(github.ref, 'refs/tags/v')
       && (
@@ -33,11 +39,12 @@ jobs:
       && !cancelled()
 
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    timeout-minutes: 8
 
     outputs:
       display_version: ${{ steps.set_display_version.outputs.disp-version }}
       build_number: ${{ steps.build_number.outputs.version }}
+      tag_name: ${{ steps.set-tag.outputs.tag-name }}
 
     steps:
       - uses: actions/checkout@v6
@@ -86,6 +93,17 @@ jobs:
 
       - name: print new version number
         run: echo "VersionNumber ... ${{ steps.set_display_version.outputs.disp-version }}-${{ steps.build_number.outputs.version }}"
+
+      # Reserve the version by pushing the tag here, inside the serialized job, so the
+      # build number allocation and the tag push are atomic across concurrent runs.
+      # On total build/publish failure the tag is removed later by the cleanup-tag job.
+      - name: Reserve & push tag
+        id: set-tag
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.version != '' }}
+        uses: ./.github/actions/cd-set-tag
+        with:
+          display_version: ${{ steps.set_display_version.outputs.disp-version }}
+          build_number: ${{ steps.build_number.outputs.version }}
 
   get-version:
     if: |
@@ -309,119 +327,33 @@ jobs:
           APPSTORECONNECT_API_KEY: ${{ secrets.APPSTORECONNECT_API_KEY }}
           APPSTORECONNECT_ISSUER_ID: ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
 
-  set-tag-ios:
-    if: |
-      needs.generate-bundle-version.result == 'success'
-      && needs.publish-ios.result == 'success'
-      && (
-        github.event_name != 'workflow_dispatch'
-        || github.event.inputs.version != ''
-      )
-    needs:
-      - generate-bundle-version
-      - publish-ios
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cd-set-tag
-        with:
-          display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
-          build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
-
-  set-tag-mac:
-    if: |
-      needs.generate-bundle-version.result == 'success'
-      && needs.publish-mac.result == 'success'
-      && (
-        github.event_name != 'workflow_dispatch'
-        || github.event.inputs.version != ''
-      )
-    needs:
-      - generate-bundle-version
-      - publish-mac
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cd-set-tag
-        with:
-          display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
-          build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
-
-  set-tag-android:
-    if: |
-      needs.generate-bundle-version.result == 'success'
-      && needs.build-android.result == 'success'
-      && (
-        github.event_name != 'workflow_dispatch'
-        || github.event.inputs.version != ''
-      )
-    needs:
-      - generate-bundle-version
-      - build-android
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cd-set-tag
-        with:
-          display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
-          build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
-
-  set-tag-windows:
-    if: |
-      needs.generate-bundle-version.result == 'success'
-      && needs.build-windows.result == 'success'
-      && (
-        github.event_name != 'workflow_dispatch'
-        || github.event.inputs.version != ''
-      )
-    needs:
-      - generate-bundle-version
-      - build-windows
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cd-set-tag
-        with:
-          display_version: ${{ needs.generate-bundle-version.outputs.display_version }}
-          build_number: ${{ needs.generate-bundle-version.outputs.build_number }}
-
   comment-pr:
+    # The tag name is fixed the moment generate-bundle-version finishes, so the PR
+    # comment no longer waits for the (now removed) per-platform set-tag jobs.
     if: |
       always()
       && github.event_name == 'pull_request'
-      && (
-        needs.set-tag-ios.result == 'success'
-        || needs.set-tag-mac.result == 'success'
-        || needs.set-tag-android.result == 'success'
-        || needs.set-tag-windows.result == 'success'
-      )
+      && needs.generate-bundle-version.result == 'success'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     needs:
       - generate-bundle-version
-      - set-tag-ios
-      - set-tag-mac
-      - set-tag-android
-      - set-tag-windows
     steps:
       - name: Comment TagName and Actions-Run URL to PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo 'Tag `v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}` was automatically created and pushed with ... https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} (Platform Status iOS: ${{ needs.set-tag-ios.result }} / macOS: ${{ needs.set-tag-mac.result }} / Android: ${{ needs.set-tag-android.result }} / Windows: ${{ needs.set-tag-windows.result }})' | gh pr comment ${{ github.event.number }} -F - --repo ${{ github.repository }}
+          echo 'Tag `v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}` was reserved and pushed. Build/publish status per platform: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}' | gh pr comment ${{ github.event.number }} -F - --repo ${{ github.repository }}
 
   create-release:
     if: |
       always()
+      && needs.generate-bundle-version.result == 'success'
       && (
-        needs.set-tag-ios.result == 'success'
-        || needs.set-tag-mac.result == 'success'
-        || needs.set-tag-android.result == 'success'
-        || needs.set-tag-windows.result == 'success'
+        needs.build-android.result == 'success'
+        || needs.build-windows.result == 'success'
+        || needs.publish-ios.result == 'success'
+        || needs.publish-mac.result == 'success'
       )
       && (
         (
@@ -435,12 +367,10 @@ jobs:
       )
     needs:
       - generate-bundle-version
-      - set-tag-ios
-      - set-tag-mac
-      - set-tag-android
-      - set-tag-windows
       - build-android
       - build-windows
+      - publish-ios
+      - publish-mac
     runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
@@ -454,3 +384,39 @@ jobs:
           ASSET_NAME_WIN_X86_SELF_CONTAINED: TRViS-win-x86-self-contained
           OUTPUT_DIR: ./out
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup-tag:
+    # The tag is reserved up-front (before building). If NO platform produced a
+    # deliverable, the reserved tag is an orphan with no release: delete it so the
+    # build number can be reclaimed by a later run.
+    # NOT run for tag-triggered builds: there the tag is the input/source of truth.
+    if: |
+      always()
+      && !startsWith(github.ref, 'refs/tags/v')
+      && needs.generate-bundle-version.result == 'success'
+      && needs.build-android.result != 'success'
+      && needs.build-windows.result != 'success'
+      && needs.publish-ios.result != 'success'
+      && needs.publish-mac.result != 'success'
+    needs:
+      - generate-bundle-version
+      - build-android
+      - build-windows
+      - publish-ios
+      - publish-mac
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Delete orphan reserved tag (no platform delivered)
+        env:
+          TAG_NAME: v${{ needs.generate-bundle-version.outputs.display_version }}-${{ needs.generate-bundle-version.outputs.build_number }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          if git ls-remote --exit-code origin "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            git push origin ":refs/tags/${TAG_NAME}"
+            echo "Deleted orphan tag ${TAG_NAME} (no platform produced a release artifact)."
+          else
+            echo "Tag ${TAG_NAME} not present on remote; nothing to delete."
+          fi


### PR DESCRIPTION
## 背景・課題

CD action はタグでバージョンを管理する都合上、同一ブランチで複数の CD を同時実行できない設計でした。従来は **workflow レベル** `concurrency` でロックを取っており、ロックは run 全体(ビルド/publish/App Store配信/release ≒数十分)の間保持されていました。

しかし実際に直列化が必要なのは「既存タグの読取 → ビルド番号採番 → タグ push」のクリティカルセクションだけです。タグさえ push されれば次の CD は安全に開始できるため、現状は過剰な待ち時間が発生していました。

## 実装内容

クリティカルセクションを `generate-bundle-version` の単一ジョブに集約し、**そのジョブにのみ job 単位 `concurrency` (`queue: max`)** を付与しました。

- 採番と `cd-set-tag`(タグ push)を同一ジョブ内に統合 → run 間でアトミックに直列化
- ロック保持は当該ジョブ実行中(~数分)のみ。`build/publish/release` はロックなしで進行し、次 run の予約は前 run の予約完了で即開始可能
- `queue: max` により最大 100 run まで FIFO でスタック(中間 run の取りこぼし無し。`queue: max` は `cancel-in-progress: true` と併用不可のため未指定)
- workflow レベル `concurrency` を撤去
- 不要になった `set-tag-{ios,mac,android,windows}` 4 ジョブを廃止
- `comment-pr` / `create-release` の `needs` / `if` を予約ジョブ基準へ変更
- `cleanup-tag` ジョブを追加: 全プラットフォーム未成功なら予約タグを削除しビルド番号を再利用可能にする。`on: push: tags` 起動時はタグが入力源のため削除しない
- `on: push: tags` の glob を `v[0-9]+.[0-9]+.[0-9]+-[0-9]+` に修正(旧 `-.[0-9]+` はリテラル `-.` を要求しており実タグ `v1.2.3-4` に発火していなかった)

## 仕様の説明

- main push / PR / workflow_dispatch: 予約ジョブで採番+タグ push → ロック解放 → 各プラットフォームのビルド/配信/リリースがロックなしで並行進行。次 run の予約ジョブは前 run の予約ジョブ完了直後(~数分)に開始
- `on: push: tags`(人が手動 push したタグ): 従来設計どおりビルド+配信のみ実行(`create-release` は push-main / dispatch のみが条件のため GitHub Release は作成しない)。glob 修正により**今回初めて実際に発火**するようになった
- 全プラットフォームが失敗/skip/cancel の場合のみ予約タグを削除。1 つでも成果物が出れば保持

## レビュアーへの注記

- `actionlint` は `concurrency.queue` を未知キーとして**誤検知**します。GitHub 公式ドキュメント(本日時点)で workflow/job 両レベルサポート済みの正規機能です。CI / pre-commit で actionlint は未実行のためブロックはありません。その他の shellcheck 警告は本変更が触れていない既存スクリプト由来です
- 判断で決めた点1: `cleanup-tag` の「全滅」判定は `build-android` / `build-windows` / `publish-ios` / `publish-mac` がすべて未成功、と解釈(Android/Windows は独立 publish ジョブが無くビルド自体が成果物のため)
- 判断で決めた点2: `on: push: tags` 経路は従来どおり Release を作りません。タグイベントでも Release を作る拡張が必要なら別途対応します

🤖 Generated with [Claude Code](https://claude.com/claude-code)
