### PR TITLE
feat(ws): add NavigateToHome and OpenTimetable server-to-client commands

### DIFF
--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -51,6 +51,8 @@ public partial class LocationService : IDisposable
 	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
 	public event EventHandler<NotificationData>? NotificationReceived;
 	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
+	public event EventHandler? NavigateToHomeRequested;
+	public event EventHandler<OpenTimetableCommand>? OpenTimetableRequested;
 
 	/// <summary>
 	/// GPS位置情報が更新された際に発生するイベント。
@@ -188,6 +190,8 @@ void OnIsEnabledChanged(bool value)
 	void OnHeaderColorChangeRequested(object? sender, HeaderColorCommand cmd) => HeaderColorChangeRequested?.Invoke(sender, cmd);
 	void OnNotificationReceived(object? sender, NotificationData n) => NotificationReceived?.Invoke(sender, n);
 	void OnTimeFormatChangeRequested(object? sender, TimeFormatCommand cmd) => TimeFormatChangeRequested?.Invoke(sender, cmd);
+	void OnNavigateToHomeRequested(object? sender, EventArgs _) => NavigateToHomeRequested?.Invoke(sender, EventArgs.Empty);
+	void OnOpenTimetableRequested(object? sender, OpenTimetableCommand cmd) => OpenTimetableRequested?.Invoke(sender, cmd);
 
 	/// <summary>
 	/// NetworkSyncService 経由で配信された緯度経度を受け取り、
@@ -288,6 +292,8 @@ void OnIsEnabledChanged(bool value)
 			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
 			networkSyncService.NotificationReceived -= OnNotificationReceived;
 			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
+			networkSyncService.NavigateToHomeRequested -= OnNavigateToHomeRequested;
+			networkSyncService.OpenTimetableRequested -= OnOpenTimetableRequested;
 			networkSyncService.LonLatLocationReceived -= OnNetworkSyncServiceLonLatLocationReceived;
 		}
 		if (currentService is IDisposable disposable)
@@ -412,6 +418,8 @@ void OnIsEnabledChanged(bool value)
 		nextService.HeaderColorChangeRequested += OnHeaderColorChangeRequested;
 		nextService.NotificationReceived += OnNotificationReceived;
 		nextService.TimeFormatChangeRequested += OnTimeFormatChangeRequested;
+		nextService.NavigateToHomeRequested += OnNavigateToHomeRequested;
+		nextService.OpenTimetableRequested += OnOpenTimetableRequested;
 		nextService.ConnectionClosed += OnNetworkSyncServiceConnectionClosed;
 		nextService.ConnectionFailed += OnNetworkSyncServiceConnectionFailed;
 		nextService.CanStartChanged += OnNetworkSyncServiceCanStartChanged;
@@ -445,6 +453,8 @@ void OnIsEnabledChanged(bool value)
 			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
 			networkSyncService.NotificationReceived -= OnNotificationReceived;
 			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
+			networkSyncService.NavigateToHomeRequested -= OnNavigateToHomeRequested;
+			networkSyncService.OpenTimetableRequested -= OnOpenTimetableRequested;
 			networkSyncService.ConnectionClosed -= OnNetworkSyncServiceConnectionClosed;
 			networkSyncService.ConnectionFailed -= OnNetworkSyncServiceConnectionFailed;
 			networkSyncService.CanStartChanged -= OnNetworkSyncServiceCanStartChanged;

--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
@@ -295,6 +295,25 @@ public sealed class ReferenceServerClient : IDisposable
 		resp.EnsureSuccessStatusCode();
 	}
 
+	public async Task BroadcastNavigateToHomeAsync(CancellationToken ct = default)
+	{
+		var resp = await _http.PostAsync("/control/broadcast-navigate-to-home", null, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
+	public async Task BroadcastOpenTimetableAsync(
+		string? workGroupId = null,
+		string? workId = null,
+		string? trainId = null,
+		CancellationToken ct = default)
+	{
+		var payload = new { WorkGroupId = workGroupId, WorkId = workId, TrainId = trainId };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-open-timetable", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
 	// ================================================================
 	// ユーティリティ
 	// ================================================================

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -2342,6 +2342,71 @@ public class WebSocketIntegrationTests
 	}
 
 	// ================================================================
+	// NavigateToHome コマンド
+	// ================================================================
+
+	[Test]
+	public async Task NavigateToHome_Broadcast_ClientReceivesEvent()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForNonGenericEventAsync(
+				h => service.NavigateToHomeRequested += h,
+				h => service.NavigateToHomeRequested -= h
+			);
+
+			await _control.BroadcastNavigateToHomeAsync();
+
+			// タイムアウトなしで返れば成功
+			await task;
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
+	// OpenTimetable コマンド
+	// ================================================================
+
+	[Test]
+	public async Task OpenTimetable_Broadcast_ClientReceivesEventWithIds()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<OpenTimetableCommand>(
+				h => service.OpenTimetableRequested += h,
+				h => service.OpenTimetableRequested -= h
+			);
+
+			await _control.BroadcastOpenTimetableAsync(
+				workGroupId: TestData.WorkGroupId,
+				workId: TestData.WorkId,
+				trainId: TestData.TrainId
+			);
+
+			var cmd = await task;
+			Assert.Multiple(() =>
+			{
+				Assert.That(cmd.WorkGroupId, Is.EqualTo(TestData.WorkGroupId));
+				Assert.That(cmd.WorkId, Is.EqualTo(TestData.WorkId));
+				Assert.That(cmd.TrainId, Is.EqualTo(TestData.TrainId));
+			});
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	// ================================================================
 	// 施行日テキスト (任意文字列)
 	// ================================================================
 

--- a/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
@@ -166,6 +166,8 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
 	public event EventHandler<NotificationData>? NotificationReceived;
 	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
+	public event EventHandler? NavigateToHomeRequested;
+	public event EventHandler<OpenTimetableCommand>? OpenTimetableRequested;
 	public event EventHandler? ConnectionClosed;
 	public event EventHandler? ConnectionFailed;
 	/// <summary>接続が切れて自動再接続を開始した時に発火する (#266)。</summary>
@@ -398,6 +400,19 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	{
 		Logger.Info("RaiseTimeFormatChangeRequested: Format={0}", command.Format);
 		TimeFormatChangeRequested?.Invoke(this, command);
+	}
+
+	protected void RaiseNavigateToHomeRequested()
+	{
+		Logger.Info("RaiseNavigateToHomeRequested");
+		NavigateToHomeRequested?.Invoke(this, EventArgs.Empty);
+	}
+
+	protected void RaiseOpenTimetableRequested(OpenTimetableCommand command)
+	{
+		Logger.Info("RaiseOpenTimetableRequested: WorkGroupId={0}, WorkId={1}, TrainId={2}",
+			command.WorkGroupId, command.WorkId, command.TrainId);
+		OpenTimetableRequested?.Invoke(this, command);
 	}
 
 	protected void RaiseConnectionClosed()

--- a/TRViS.NetworkSyncService/RemoteCommands.cs
+++ b/TRViS.NetworkSyncService/RemoteCommands.cs
@@ -70,3 +70,16 @@ public class TimeFormatCommand
 {
 	public string? Format { get; set; }
 }
+
+/// <summary>
+/// 指定の列車の時刻表ビュー (D-TAC 画面の「時刻表」タブ) を開かせるコマンド。
+/// <see cref="SelectTrainCommand"/> と同じ階層指定で列車を選択した上で D-TAC へ遷移し、
+/// 時刻表タブ (VerticalView) を表示する。
+/// 任意のフィールドが null の場合、その階層は変更しない。
+/// </summary>
+public class OpenTimetableCommand
+{
+	public string? WorkGroupId { get; set; }
+	public string? WorkId { get; set; }
+	public string? TrainId { get; set; }
+}

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -49,6 +49,8 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	private const string MESSAGE_TYPE_HEADER_COLOR = "HeaderColor";
 	private const string MESSAGE_TYPE_NOTIFICATION = "Notification";
 	private const string MESSAGE_TYPE_TIME_FORMAT = "TimeFormat";
+	private const string MESSAGE_TYPE_NAVIGATE_TO_HOME = "NavigateToHome";
+	private const string MESSAGE_TYPE_OPEN_TIMETABLE = "OpenTimetable";
 	private const string TIMETABLE_DATA_JSON_KEY = "Data";
 
 	// ServerInfo / DiagramInfo のJSONキー
@@ -287,6 +289,14 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			{
 				ProcessTimeFormatMessage(root);
 			}
+			else if (messageType == MESSAGE_TYPE_NAVIGATE_TO_HOME)
+			{
+				RaiseNavigateToHomeRequested();
+			}
+			else if (messageType == MESSAGE_TYPE_OPEN_TIMETABLE)
+			{
+				ProcessOpenTimetableMessage(root);
+			}
 		}
 		catch (JsonException ex)
 		{
@@ -450,6 +460,17 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			TrainId = TryGetStringProperty(root, TRAIN_ID_JSON_KEY),
 		};
 		RaiseTrainSelectionRequested(cmd);
+	}
+
+	private void ProcessOpenTimetableMessage(JsonElement root)
+	{
+		var cmd = new OpenTimetableCommand
+		{
+			WorkGroupId = TryGetStringProperty(root, WORK_GROUP_ID_JSON_KEY),
+			WorkId = TryGetStringProperty(root, WORK_ID_JSON_KEY),
+			TrainId = TryGetStringProperty(root, TRAIN_ID_JSON_KEY),
+		};
+		RaiseOpenTimetableRequested(cmd);
 	}
 
 	private void ProcessOperationCommandMessage(JsonElement root)

--- a/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
+++ b/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
@@ -148,6 +148,8 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			("POST", "broadcast-header-color") => await BroadcastHeaderColorAsync(request),
 			("POST", "broadcast-notification") => await BroadcastNotificationAsync(request),
 			("POST", "broadcast-time-format") => await BroadcastTimeFormatAsync(request),
+			("POST", "broadcast-navigate-to-home") => await BroadcastNavigateToHomeAsync(),
+			("POST", "broadcast-open-timetable") => await BroadcastOpenTimetableAsync(request),
 			_ => Error(HttpStatusCode.NotFound, $"Unknown control endpoint: {method} /control/{sub}"),
 		};
 	}
@@ -624,6 +626,37 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			{
 				MessageType = "TimeFormat",
 				Format = format,
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
+	}
+
+	private async Task<HttpResponse> BroadcastNavigateToHomeAsync()
+	{
+		var msg = JsonSerializer.Serialize(new { MessageType = "NavigateToHome" });
+		await BroadcastTextAsync(msg);
+		return OkJson("{\"ok\":true}");
+	}
+
+	/// <summary>
+	/// OpenTimetable: { WorkGroupId?, WorkId?, TrainId? }
+	/// </summary>
+	private async Task<HttpResponse> BroadcastOpenTimetableAsync(HttpRequest request)
+	{
+		try
+		{
+			using var doc = JsonDocument.Parse(request.Body.Length > 0
+				? Encoding.UTF8.GetString(request.Body)
+				: "{}");
+			var root = doc.RootElement;
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "OpenTimetable",
+				WorkGroupId = TryGetString(root, "WorkGroupId"),
+				WorkId = TryGetString(root, "WorkId"),
+				TrainId = TryGetString(root, "TrainId"),
 			});
 			await BroadcastTextAsync(msg);
 			return OkJson("{\"ok\":true}");

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -105,6 +105,16 @@ public partial class AppShell : Shell
 		// 起動時の値も反映する (通常は null)
 		ApplyHeaderColorOverride(appVm.HeaderColorOverride_RGB, easterEggPageViewModel);
 
+		// サーバーから NavigateToHome コマンドを受信したときに、ホーム画面へ遷移する。
+		// WebSocket 受信スレッドから呼ばれるため MainThread に dispatch する。
+		appVm.NavigateToHomeRequested += (_, _) =>
+			MainThread.BeginInvokeOnMainThread(() =>
+				_ = GoToAsync("//" + nameof(StartHomePage)).ContinueWith(t =>
+				{
+					if (t.IsFaulted)
+						logger.Error(t.Exception, "NavigateToHome GoToAsync failed");
+				}, TaskScheduler.Default));
+
 		InstanceManager.AppViewModel.WindowWidth = DeviceDisplay.Current.MainDisplayInfo.Width;
 		InstanceManager.AppViewModel.WindowHeight = DeviceDisplay.Current.MainDisplayInfo.Height;
 		logger.Trace("Display Width/Height: {0}x{1}", InstanceManager.AppViewModel.WindowWidth, InstanceManager.AppViewModel.WindowHeight);

--- a/TRViS/DTAC/ViewHost.xaml.cs
+++ b/TRViS/DTAC/ViewHost.xaml.cs
@@ -23,6 +23,7 @@ public partial class ViewHost : ContentPage
 
 	private readonly ViewHostPresenter _presenter;
 	private readonly DTACViewHostViewModel _dtacViewModel;
+	private readonly AppViewModel _appViewModel;
 
 #if UI_TEST
 	private AppViewModel? _testAppVm;
@@ -38,6 +39,7 @@ public partial class ViewHost : ContentPage
 			out DTACViewHostViewModel dtacViewModel);
 
 		_dtacViewModel = dtacViewModel;
+		_appViewModel = vm;
 
 #if UI_TEST
 		_testAppVm = vm;
@@ -55,11 +57,14 @@ public partial class ViewHost : ContentPage
 		// instances can be GC'd after each visit.
 		// HorizontalTimetablePage uses the same factory and is always RegisterRoute'd
 		// (fresh per visit on all platforms), so its Unloaded+Dispose is unconditional.
+		_appViewModel.OpenTimetableViewRequested += OnOpenTimetableViewRequested;
+
 #if ANDROID
 		Unloaded += (_, _) =>
 		{
 			Shell.Current.Navigated -= OnShellNavigated;
 			_dtacViewModel.PropertyChanged -= OnDtacViewModelPropertyChanged;
+			_appViewModel.OpenTimetableViewRequested -= OnOpenTimetableViewRequested;
 			if (Shell.Current is AppShell appShellForCleanup)
 				appShellForCleanup.SafeAreaMarginChanged -= AppShell_SafeAreaMarginChanged;
 			_presenter.Dispose();
@@ -436,6 +441,21 @@ public partial class ViewHost : ContentPage
 	{
 		base.OnAppearing();
 		UpdateOrientation();
+		if (_appViewModel.ConsumeOpenTimetableTabSwitchPending())
+			_dtacViewModel.TabMode = DTACViewHostViewModel.Mode.VerticalView;
+	}
+
+	// サーバーから OpenTimetable コマンドを受信し、かつ ViewHost が既にアクティブな場合に
+	// 即座に時刻表タブへ切り替える。ホーム画面側から遷移してくる場合は OnAppearing で処理する。
+	private void OnOpenTimetableViewRequested(object? sender, EventArgs _)
+	{
+		MainThread.BeginInvokeOnMainThread(() =>
+		{
+			if (!ReferenceEquals(Shell.Current?.CurrentPage, this))
+				return;
+			if (_appViewModel.ConsumeOpenTimetableTabSwitchPending())
+				_dtacViewModel.TabMode = DTACViewHostViewModel.Mode.VerticalView;
+		});
 	}
 
 	protected override void OnDisappearing()

--- a/TRViS/RootPages/StartHomePage.xaml.cs
+++ b/TRViS/RootPages/StartHomePage.xaml.cs
@@ -671,6 +671,8 @@ public partial class StartHomePage : ContentPage
 		viewModel.PropertyChanged += OnViewModelPropertyChanged;
 		viewModel.AutoNavigateToTimetableRequested -= OnAutoNavigateToTimetableRequested;
 		viewModel.AutoNavigateToTimetableRequested += OnAutoNavigateToTimetableRequested;
+		viewModel.OpenTimetableViewRequested -= OnOpenTimetableViewRequested;
+		viewModel.OpenTimetableViewRequested += OnOpenTimetableViewRequested;
 
 		UpdatePrivacyDependentControls();
 
@@ -701,6 +703,7 @@ public partial class StartHomePage : ContentPage
 		base.OnDisappearing();
 		viewModel.PropertyChanged -= OnViewModelPropertyChanged;
 		viewModel.AutoNavigateToTimetableRequested -= OnAutoNavigateToTimetableRequested;
+		viewModel.OpenTimetableViewRequested -= OnOpenTimetableViewRequested;
 	}
 
 	// The pending intent is latched on AppViewModel (not a field here): a
@@ -728,6 +731,22 @@ public partial class StartHomePage : ContentPage
 		if ((Shell.Current?.Navigation?.ModalStack?.Count ?? 0) > 0)
 			return;
 		viewModel.ConsumeAutoNavigateToTimetablePending();
+		await HomeGridView.NavigateToDTACAsync();
+	}
+
+	void OnOpenTimetableViewRequested(object? sender, EventArgs e)
+	{
+		MainThread.BeginInvokeOnMainThread(async () => await TryConsumeOpenTimetableViewAsync());
+	}
+
+	async Task TryConsumeOpenTimetableViewAsync()
+	{
+		if (!viewModel.OpenTimetableNavigationPending)
+			return;
+		if ((Shell.Current?.Navigation?.ModalStack?.Count ?? 0) > 0)
+			return;
+		// Tab の切り替えは ViewHost.OnAppearing が OpenTimetableTabSwitchPending を確認して行う。
+		viewModel.ConsumeOpenTimetableNavigationPending();
 		await HomeGridView.NavigateToDTACAsync();
 	}
 

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -239,6 +239,46 @@ public partial class AppViewModel : ObservableObject
 		_ExternalResourceUrlHistory = AppPreferenceService.GetFromJson(AppPreferenceKeys.ExternalResourceUrlHistory, [], out _, StringListJsonSourceGenerationContext.Default.ListString);
 	}
 
+	/// <summary>
+	/// サーバーからホーム画面への遷移要求を受信したときに発火する。
+	/// AppShell が購読して MainThread 上でナビゲーションを実行する。
+	/// WebSocket 受信スレッドから呼ばれるため、UI 操作は購読側で MainThread に dispatch する。
+	/// </summary>
+	public event EventHandler? NavigateToHomeRequested;
+
+	/// <summary>
+	/// サーバーから OpenTimetable コマンドを受信し、列車選択を適用した後に発火する。
+	/// StartHomePage (ホーム画面表示中) が購読して D-TAC へ遷移し、
+	/// ViewHost が購読して時刻表タブへ切り替える。
+	/// WebSocket 受信スレッドから呼ばれるため、UI 操作は購読側で MainThread に dispatch する。
+	/// </summary>
+	public event EventHandler? OpenTimetableViewRequested;
+
+	/// <summary>
+	/// D-TAC への遷移が未処理であることを表す latch。
+	/// StartHomePage が消費して <see cref="HomeGridView.NavigateToDTACAsync"/> を実行する。
+	/// </summary>
+	public bool OpenTimetableNavigationPending { get; private set; }
+
+	/// <summary>
+	/// D-TAC の時刻表タブへの切り替えが未処理であることを表す latch。
+	/// ViewHost が消費して TabMode を VerticalView に設定する。
+	/// StartHomePage とは独立しており、ナビゲーション後に ViewHost.OnAppearing で確認する。
+	/// </summary>
+	public bool OpenTimetableTabSwitchPending { get; private set; }
+
+	public void ConsumeOpenTimetableNavigationPending() => OpenTimetableNavigationPending = false;
+
+	/// <summary>
+	/// <see cref="OpenTimetableTabSwitchPending"/> フラグを消費する。消費できた場合 true を返す。
+	/// </summary>
+	public bool ConsumeOpenTimetableTabSwitchPending()
+	{
+		if (!OpenTimetableTabSwitchPending) return false;
+		OpenTimetableTabSwitchPending = false;
+		return true;
+	}
+
 	internal void SubscribeToLocationService(TRViS.Services.LocationService locationService)
 	{
 		locationService.TimetableUpdated += OnTimetableUpdated;
@@ -246,10 +286,48 @@ public partial class AppViewModel : ObservableObject
 		locationService.HeaderColorChangeRequested += OnHeaderColorChangeRequested;
 		locationService.TimeFormatChangeRequested += OnTimeFormatChangeRequested;
 		locationService.DiagramInfoUpdated += OnDiagramInfoUpdated;
+		locationService.NavigateToHomeRequested += OnNavigateToHomeRequested;
+		locationService.OpenTimetableRequested += OnOpenTimetableRequested;
 		// NotificationReceived / OperationCommandReceived / ServerInfo は
 		// LocationService 側で受信される。OperationCommand の動作 (位置情報 ON/OFF) は
 		// LocationService が直接適用する。Notification / ServerInfo の UI 表示は
 		// 個別画面側で必要に応じて購読する。
+	}
+
+	void OnNavigateToHomeRequested(object? sender, EventArgs _)
+	{
+		logger.Info("OnNavigateToHomeRequested");
+		NavigateToHomeRequested?.Invoke(this, EventArgs.Empty);
+	}
+
+	void OnOpenTimetableRequested(object? sender, OpenTimetableCommand cmd)
+	{
+		logger.Info("OnOpenTimetableRequested: WorkGroupId={0}, WorkId={1}, TrainId={2}",
+			cmd.WorkGroupId, cmd.WorkId, cmd.TrainId);
+
+		// 列車選択を適用 (SelectTrain と同じ階層ロジック)
+		if (cmd.WorkGroupId is not null)
+		{
+			var wg = SelectionManager.WorkGroupList?.FirstOrDefault(w => w.Id == cmd.WorkGroupId);
+			if (wg is not null && SelectionManager.SelectedWorkGroup?.Id != wg.Id)
+				SelectionManager.SelectedWorkGroup = wg;
+		}
+		if (cmd.WorkId is not null)
+		{
+			var work = SelectionManager.WorkList?.FirstOrDefault(w => w.Id == cmd.WorkId);
+			if (work is not null && SelectionManager.SelectedWork?.Id != work.Id)
+				SelectionManager.SelectedWork = work;
+		}
+		if (cmd.TrainId is not null)
+		{
+			var train = SelectionManager.OrderedTrainDataList?.FirstOrDefault(t => t.Id == cmd.TrainId);
+			if (train is not null && SelectionManager.SelectedTrainData?.Id != train.Id)
+				SelectionManager.SelectedTrainData = train;
+		}
+
+		OpenTimetableNavigationPending = true;
+		OpenTimetableTabSwitchPending = true;
+		OpenTimetableViewRequested?.Invoke(this, EventArgs.Empty);
 	}
 
 	/// <summary>

--- a/docs/network-sync-service/en/server-to-client-messages.md
+++ b/docs/network-sync-service/en/server-to-client-messages.md
@@ -20,6 +20,8 @@ must carry a `MessageType` field (exact case). Unknown/missing
 | `HeaderColor` | Change header color | [§7](#7-headercolor) |
 | `Notification` | Notification | [§8](#8-notification) |
 | `TimeFormat` | Time display format | [§9](#9-timeformat) |
+| `NavigateToHome` | Navigate to home screen | [§10](#10-navigatetohome) |
+| `OpenTimetable` | Open timetable view for a specified train | [§11](#11-opentimetable) |
 
 > Notation: "Required" means a field the server effectively needs to
 > produce meaningful behavior. "Optional" may be omitted. A type
@@ -250,6 +252,53 @@ Specifies the title-bar time display format.
 | `Format` | string | e.g. `"HH:mm:ss"` / `"HH:mm"`. `null` or omitted → reset to device default. |
 
 The format string is interpreted per the client's time formatter.
+
+## 10. NavigateToHome
+
+Instructs the client to navigate to the home (start) screen.
+No additional fields are needed; the payload contains only `MessageType`.
+
+```jsonc
+{
+  "MessageType": "NavigateToHome"
+}
+```
+
+Only `MessageType` is present. On receipt the client navigates to the
+home screen immediately. Operation state and train selection are not
+affected by this command; use other server-driven commands to control
+those independently.
+
+---
+
+## 11. OpenTimetable
+
+Selects the specified train and opens the timetable view (D-TAC screen,
+"時刻表" tab) directly. On receipt the client:
+
+1. Applies the train selection (WorkGroupId / WorkId / TrainId) — same
+   rules as [`SelectTrain`](#5-selecttrain).
+2. Navigates to the D-TAC screen if not already there.
+3. Switches to the timetable (VerticalView) tab.
+
+```jsonc
+{
+  "MessageType": "OpenTimetable",
+  "WorkGroupId": "wg-1",  // string | null
+  "WorkId": "w-1",        // string | null
+  "TrainId": "t-1"        // string | null
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `WorkGroupId` | string | Optional. WorkGroup to select. |
+| `WorkId` | string | Optional. Work to select. |
+| `TrainId` | string | Optional. Train to select. |
+
+Each field is only accepted when of **JSON string type** (numbers etc.
+are ignored). A `null` or omitted field leaves that selection level
+unchanged.
 
 ---
 

--- a/docs/network-sync-service/ja/server-to-client-messages.md
+++ b/docs/network-sync-service/ja/server-to-client-messages.md
@@ -20,6 +20,8 @@ JSON オブジェクトで、必ず `MessageType` フィールド（正確なケ
 | `HeaderColor` | ヘッダ色変更 | [§7](#7-headercolor) |
 | `Notification` | 通告 | [§8](#8-notification) |
 | `TimeFormat` | 時刻表示書式 | [§9](#9-timeformat) |
+| `NavigateToHome` | ホーム画面へ遷移 | [§10](#10-navigatetohome) |
+| `OpenTimetable` | 指定列車の時刻表ビューを開く | [§11](#11-opentimetable) |
 
 > 表記規約: 「必須」はサーバーが意味のある動作をさせるために事実上
 > 必要なフィールド。「任意」は省略可能。型不一致はおおむね「無視
@@ -245,6 +247,50 @@ WorkGroup の上位概念である「ダイヤ」の情報。`RequestDiagramInfo
 | `Format` | string | 例: `"HH:mm:ss"` / `"HH:mm"`。`null` または省略時は端末既定にリセット。 |
 
 書式文字列の解釈はクライアント側の時刻フォーマッタに準じます。
+
+## 10. NavigateToHome
+
+クライアントをホーム画面（スタート画面）へ遷移させる指示。
+追加フィールドは不要で、`MessageType` のみのペイロードとなります。
+
+```jsonc
+{
+  "MessageType": "NavigateToHome"
+}
+```
+
+フィールドは `MessageType` のみ。受信するとクライアントはホーム画面へ
+即座に遷移します（実行中の操作状態や列車選択はサーバー主導の他のコマンドで
+別途制御してください）。
+
+---
+
+## 11. OpenTimetable
+
+指定の列車を選択し、D-TAC 画面の「時刻表」タブを直接開きます。
+受信するとクライアントは以下を順番に実行します。
+
+1. 列車選択を適用（WorkGroupId / WorkId / TrainId） — [`SelectTrain`](#5-selecttrain) と同じルール。
+2. D-TAC 画面が表示されていなければ遷移する。
+3. 時刻表（VerticalView）タブへ切り替える。
+
+```jsonc
+{
+  "MessageType": "OpenTimetable",
+  "WorkGroupId": "wg-1",  // string | null
+  "WorkId": "w-1",        // string | null
+  "TrainId": "t-1"        // string | null
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `WorkGroupId` | string | 任意。選択する WorkGroup。 |
+| `WorkId` | string | 任意。選択する Work。 |
+| `TrainId` | string | 任意。選択する Train。 |
+
+各フィールドは **JSON 文字列型** のときのみ採用されます（数値等は無視）。
+`null` または省略した場合、その階層の選択は変更されません。
 
 ---
 


### PR DESCRIPTION
## Summary

- **NavigateToHome**: サーバーからホーム画面への遷移を指示するコマンド。`MessageType` のみのシンプルなペイロード。`AppShell` が受信してメインスレッドで `GoToAsync("//StartHomePage")` を実行。
- **OpenTimetable**: 指定列車（WorkGroupId/WorkId/TrainId）を選択し、D-TAC 画面へ遷移した上で「時刻表」タブ（VerticalView）を開くコマンド。

## 実装詳細

両コマンドともイベントチェーン全体を通して配線:
`NetworkSyncServiceBase` → `WebSocketNetworkSyncService` → `LocationService` → `AppViewModel` → `AppShell`/`StartHomePage`/`ViewHost`

**OpenTimetable の設計ポイント:**
- 列車選択は `SelectTrain` と同じロジックを `AppViewModel` で適用
- ナビゲーション用 latch (`OpenTimetableNavigationPending`) と タブ切り替え用 latch (`OpenTimetableTabSwitchPending`) を分離
  - `StartHomePage` がナビゲーション latch を消費して `NavigateToDTACAsync()` を呼ぶ（二重遷移防止）
  - `ViewHost` がタブ切り替え latch を消費して `TabMode = VerticalView` を設定
- `TabMode` 変更は `UpdateOrientation()` を伴うため、ViewHost がアクティブになってから初めて変更する（ホーム画面にいる間の強制回転を回避）
- Android (fresh instance per navigation) のコールドスタートレースは latch + `ViewHost.OnAppearing` で対応

**ReferenceServer / テスト / ドキュメント:**
- `/control/broadcast-navigate-to-home` および `/control/broadcast-open-timetable` エンドポイント追加
- 統合テスト 2 件追加（合計 87 件 / 全パス）
- `docs/network-sync-service/` の ja・en 両ドキュメントを §10・§11 として更新

## Test plan

- [x] `dotnet test TRViS.NetworkSyncService.IntegrationTests` — 87/87 passed
- [ ] iOS 実機: WebSocket 接続中にサーバーから `NavigateToHome` を送信 → ホーム画面に戻る
- [ ] iOS 実機: WebSocket 接続中にサーバーから `OpenTimetable` を送信 → D-TAC の時刻表タブが開く
- [ ] iOS 実機: D-TAC 表示中に `OpenTimetable` を送信 → タブのみが切り替わり、二重遷移しない
- [ ] Android 実機: 同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUKbvQEh9AGWjHp7rmXExH