### PR TITLE
fix(location): prevent stale station state / CanStart carryover on train switch

### DIFF
--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -64,7 +64,8 @@ public class VerticalStylePagePresenterTests
 			GpsLocationUpdated?.Invoke(this, new GpsLocationUpdate(lat, lon, accuracy));
 		}
 
-		public void ResetLocationInfo() { }
+		public int ResetLocationInfoCallCount { get; private set; } = 0;
+		public void ResetLocationInfo() { ResetLocationInfoCallCount++; }
 
 		public void ForceSetLocationInfo(int stationIndex, bool isRunningToNextStation)
 		{
@@ -299,6 +300,45 @@ public class VerticalStylePagePresenterTests
 			Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
 			Assert.False(presenter.CurrentState.TimetableViewState.IsRunStarted);
 		});
+	}
+
+	/// <summary>
+	/// 不具合再現: 運行中に別列車 (Id 変化) へ切り替わった場合、
+	/// NetworkSyncServiceBase.StaLocationInfo の setter (#245) は Location_m の一致だけで
+	/// 旧列車の駅 index / 走行フラグを新配列に引き継ごうとするため、たまたま同じ物理位置に
+	/// 駅を持つ別列車へ切り替えると、無関係な旧列車の走行状態が新列車に紛れ込む恐れがある。
+	/// canSoftUpdate=false (= 別列車と確定している) 経路では、SetTimetableRows の後で
+	/// 明示的に ResetLocationInfo を呼び、誤引き継ぎを防がなければならない。
+	/// </summary>
+	[Fact]
+	public void SelectedTrainDataChanged_DifferentTrainId_ResetsLocationInfo()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, id: "train-A");
+		presenter.OnStartButtonClicked();
+		int resetsBeforeSwitch = locationService.ResetLocationInfoCallCount;
+
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, id: "train-B");
+
+		Assert.True(locationService.ResetLocationInfoCallCount > resetsBeforeSwitch,
+			"別列車への切替では、旧列車の駅 index / 走行フラグの誤引き継ぎを防ぐため ResetLocationInfo を呼ぶ必要がある");
+	}
+
+	/// <summary>
+	/// 同一列車の soft 編集 (Id 一致) では ResetLocationInfo を呼んではならない
+	/// (呼ぶと運行中の駅追跡が編集のたびに巻き戻ってしまう)。
+	/// </summary>
+	[Fact]
+	public void SelectedTrainDataChanged_SameIdAndRowCount_DoesNotResetLocationInfo()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, firstRowDriveTimeMM: 5);
+		presenter.OnStartButtonClicked();
+		int resetsBeforeEdit = locationService.ResetLocationInfoCallCount;
+
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3, firstRowDriveTimeMM: 7);
+
+		Assert.Equal(resetsBeforeEdit, locationService.ResetLocationInfoCallCount);
 	}
 
 	/// <summary>

--- a/TRViS.DTAC.Logic.Tests/ViewHostPresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/ViewHostPresenterTests.cs
@@ -78,6 +78,10 @@ public class ViewHostPresenterTests
     {
         public event EventHandler<int>? TimeChanged;
 
+        public int CurrentTimeSeconds { get; set; }
+
+        public int GetCurrentTimeSeconds() => CurrentTimeSeconds;
+
         public void RaiseTimeChanged(int totalSeconds)
             => TimeChanged?.Invoke(this, totalSeconds);
     }

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -179,6 +179,12 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 		_currentState = newState;
 
 		_locationService.SetTimetableRows(trainData?.Rows);
+		// #245 の同一列車キャリーオーバー (Location_m 一致による駅 index 引き継ぎ) は
+		// TrainId を見ていないため、たまたま同じ Location_m の駅を持つ別列車に切り替えた
+		// 場合、無関係な旧列車の駅 index / 走行フラグが新列車へ誤って引き継がれる。
+		// ここは (canSoftUpdate=false =) 同一列車編集ではないと確定している経路なので、
+		// 明示的にリセットして誤引き継ぎを防ぐ。
+		_locationService.ResetLocationInfo();
 		_markerToggle.ResetToggle();
 
 		_currentState.PageHeaderState.IsRunning = false;

--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -109,6 +109,8 @@ internal class FakeWebSocketNetworkSyncService : WebSocketNetworkSyncService
 	public new void RaiseConnectionFailed() => base.RaiseConnectionFailed();
 	public new void RaiseReconnecting() => base.RaiseReconnecting();
 	public new void RaiseReconnected() => base.RaiseReconnected();
+
+	public void SimulateProcessSyncedData(SyncedData syncedData) => ProcessSyncedData(syncedData);
 }
 
 // =========================================================
@@ -257,6 +259,42 @@ public class LocationServiceIntegrationTests
 	}
 
 	// -------------------------------------------------------
+	// 5b. 運行中に別列車 (TrainId 変化) へ切り替えると、旧列車の CanStart/CanUseService
+	//     を引き継がずリセットされる。切替直後にサーバへ ID 更新を送るだけでは CanStart
+	//     自体は次の SyncedData が来るまで再評価されないため、リセットしないと旧列車の
+	//     許可が新列車に一時的に紛れ込む (調査対象の不具合の派生: 別列車切替時の
+	//     CanStart 汚染)。
+	// -------------------------------------------------------
+	[Test]
+	public void SetTargetIds_DifferentTrainId_ResetsCanStartAndCanUseService()
+	{
+		// FakeWebSocketNetworkSyncService を使う: FakeNetworkSyncService (非 WebSocket 扱い)
+		// だと LocationService が裏で HTTP 相当のポーリングタスクを起動し、
+		// GetSyncedDataAsync (CanStart=false 固定) が本テストの手動 ProcessSyncedData と
+		// 競合して結果が不安定になるため。
+		var fakeNs = new FakeWebSocketNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		_locationService.SetTargetIds("wg1", "w1", "trainA");
+		fakeNs.SimulateProcessSyncedData(new SyncedData(Location_m: double.NaN, Time_ms: 0, CanStart: true));
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(fakeNs.CanStart, Is.True, "precondition: train A confirmed by server");
+			Assert.That(fakeNs.CanUseService, Is.True);
+		});
+
+		_locationService.SetTargetIds("wg1", "w1", "trainB");
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(fakeNs.CanStart, Is.False,
+				"switching to a different train must not carry over the previous train's CanStart");
+			Assert.That(fakeNs.CanUseService, Is.False,
+				"switching to a different train must not carry over the previous train's CanUseService");
+		});
+	}
+
+	// -------------------------------------------------------
 	// 6. Connection切断 → AlertRequested発火 + LonLatLocationService に切替
 	// -------------------------------------------------------
 	[Test]
@@ -354,6 +392,75 @@ public class LocationServiceIntegrationTests
 		Assert.That(_locationService.IsEnabled, Is.True,
 			"NetworkSyncService must stay enabled across SetStationLocations");
 		Assert.That(_locationService.CurrentService!.StaLocationInfo, Is.Not.Null);
+	}
+
+	// -------------------------------------------------------
+	// 7e. NetworkSyncServiceBase.StaLocationInfo の setter は「同一列車の
+	//     リアルタイム編集」(#245) 向けに Location_m の一致だけで旧 current 駅を
+	//     新配列上に追跡し直す実装になっており、TrainId を一切見ていない。
+	//     そのため、同一路線上の別列車へ切り替えたときにたまたま同じ Location_m
+	//     の駅があると、無関係な旧列車の走行状態が新列車に紛れ込む
+	//     (このテストは低レベル API 単体ではその危険があることを示す)。
+	//     実運用での唯一の呼び出し元である VerticalStylePagePresenter は、
+	//     別列車と確定している経路 (canSoftUpdate=false) で SetStationLocations の
+	//     直後に ResetLocationInfo を呼んで打ち消す設計になっている
+	//     (VerticalStylePagePresenterTests.SelectedTrainDataChanged_DifferentTrainId_ResetsLocationInfo
+	//     参照)。ここではその安全な利用パターンを低レベル API 側でも検証する。
+	// -------------------------------------------------------
+	[Test]
+	public void SetStationLocations_SwitchToDifferentTrain_WithoutExplicitReset_CanCarryOverStaleStationIndex()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		_locationService.SetTargetIds("wg1", "w1", "trainA");
+		fakeNs.SimulateCanStart(true);
+
+		// Train A: 3 stations, currently running toward station index 2 (2000m).
+		_locationService.SetStationLocations(new StaLocationInfo[]
+		{
+			new(0.0,    null, null, 200.0),
+			new(1000.0, null, null, 200.0),
+			new(2000.0, null, null, 200.0),
+		});
+		_locationService.ForceSetLocationInfo(2, true);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_locationService.CurrentService!.CurrentStationIndex, Is.EqualTo(2));
+			Assert.That(_locationService.CurrentService!.IsRunningToNextStation, Is.True);
+		});
+
+		// Switch to an entirely different train (Train B) that happens to
+		// share a station at the same physical location (2000m) as Train A's
+		// current station, but at a different index in its own list. Without
+		// an explicit reset, the raw setter blindly carries the old state over.
+		_locationService.SetTargetIds("wg1", "w1", "trainB");
+		_locationService.SetStationLocations(new StaLocationInfo[]
+		{
+			new(500.0,  null, null, 200.0),
+			new(2000.0, null, null, 200.0),
+			new(4000.0, null, null, 200.0),
+		});
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_locationService.CurrentService!.CurrentStationIndex, Is.EqualTo(1),
+				"Documents the raw setter's coincidental Location_m carry-over across unrelated trains");
+			Assert.That(_locationService.CurrentService!.IsRunningToNextStation, Is.True,
+				"Documents that the running flag also leaks across unrelated trains without an explicit reset");
+		});
+
+		// The real call site (VerticalStylePagePresenter) always follows a
+		// hard train switch with an explicit reset to undo this leak.
+		_locationService.CurrentService!.ResetLocationInfo();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_locationService.CurrentService!.CurrentStationIndex, Is.EqualTo(0),
+				"An explicit ResetLocationInfo after switching trains must clear the carried-over index");
+			Assert.That(_locationService.CurrentService!.IsRunningToNextStation, Is.False,
+				"An explicit ResetLocationInfo after switching trains must clear the carried-over running flag");
+		});
 	}
 
 	[Test]
@@ -572,5 +679,60 @@ public class LocationServiceIntegrationTests
 		fakeNs.SimulateDiagramInfoUpdated(new DiagramInfo { Id = "d-1" });
 
 		Assert.That(callCount, Is.EqualTo(0));
+	}
+
+	// -------------------------------------------------------
+	// 20. スレッド安全性: バックグラウンドの SyncedData 受信 (ProcessSyncedData →
+	//     CurrentStationIndex/IsRunningToNextStation の更新) と、UI 側からの
+	//     列車切替 (StaLocationInfo の差し替え) が同時に走っても例外にならず、
+	//     最終状態が新しい配列の範囲内に収まっていること。
+	//     (NetworkSyncServiceBase._locationStateLock による排他化の回帰テスト)
+	// -------------------------------------------------------
+	[Test]
+	public void ConcurrentSyncedDataAndStationSwitch_DoesNotThrow_AndStaysInBounds()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		fakeNs.SimulateCanStart(true);
+
+		var stationsA = new StaLocationInfo[]
+		{
+			new(0.0,    null, null, 200.0),
+			new(1000.0, null, null, 200.0),
+			new(2000.0, null, null, 200.0),
+		};
+		var stationsB = new StaLocationInfo[]
+		{
+			new(500.0,  null, null, 200.0),
+			new(1500.0, null, null, 200.0),
+		};
+		_locationService.SetStationLocations(stationsA);
+
+		const int iterations = 200;
+		var receiverTask = Task.Run(() =>
+		{
+			for (int i = 0; i < iterations; i++)
+			{
+				fakeNs.SimulateProcessSyncedData(new SyncedData(
+					Location_m: (i % 3) * 1000.0,
+					Time_ms: i * 1000,
+					CanStart: true
+				));
+			}
+		});
+		var switcherTask = Task.Run(() =>
+		{
+			for (int i = 0; i < iterations; i++)
+			{
+				_locationService.SetStationLocations(i % 2 == 0 ? stationsA : stationsB);
+			}
+		});
+
+		Assert.DoesNotThrow(() => Task.WaitAll(receiverTask, switcherTask));
+
+		var finalStations = _locationService.CurrentService!.StaLocationInfo!;
+		Assert.That(_locationService.CurrentService!.CurrentStationIndex,
+			Is.InRange(0, finalStations.Length - 1),
+			"CurrentStationIndex must stay within the bounds of whichever station array ended up current");
 	}
 }

--- a/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
@@ -52,41 +52,47 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 		get => _staLocationInfo;
 		set
 		{
-			if (_staLocationInfo == value)
-				return;
-
-			// 旧 current 駅を控えておく (新配列で対応駅を Location_m で探すため)。
-			StaLocationInfo? oldCurrentStation = null;
-			if (_staLocationInfo is not null
-				&& CurrentStationIndex >= 0
-				&& CurrentStationIndex < _staLocationInfo.Length)
+			// WebSocket 受信ループ (バックグラウンドスレッド、ProcessSyncedData 経由) と
+			// UI 側 (列車切替等、この setter を直接呼ぶ) が異なるスレッドから同時に駅
+			// index/走行フラグを触りうるため、_locationStateLock で一貫性を保つ。
+			lock (_locationStateLock)
 			{
-				oldCurrentStation = _staLocationInfo[CurrentStationIndex];
-			}
-			int oldIndex = CurrentStationIndex;
-			bool oldRunning = IsRunningToNextStation;
+				if (_staLocationInfo == value)
+					return;
 
-			_staLocationInfo = value;
-			_lonLatStationDetector.SetStationLocations(value);
+				// 旧 current 駅を控えておく (新配列で対応駅を Location_m で探すため)。
+				StaLocationInfo? oldCurrentStation = null;
+				if (_staLocationInfo is not null
+					&& CurrentStationIndex >= 0
+					&& CurrentStationIndex < _staLocationInfo.Length)
+				{
+					oldCurrentStation = _staLocationInfo[CurrentStationIndex];
+				}
+				int oldIndex = CurrentStationIndex;
+				bool oldRunning = IsRunningToNextStation;
 
-			// #245: 「現在の位置情報サービスの状態をもとに、更新後の駅 index を計算する」
-			// 旧 current 駅が新配列にも存在するならその index に追従させ、走行フラグを引き継ぐ。
-			// (= 「前の駅が削除された」「後の駅が追加された」等の編集で index がずれたケース)
-			// 存在しなければ駅自体が削除されたものとみなしてリセットする。
-			int newIndex = FindStationIndexByLocation_m(value, oldCurrentStation);
-			if (newIndex < 0)
-			{
-				ResetLocationInfo();
-				return;
+				_staLocationInfo = value;
+				_lonLatStationDetector.SetStationLocations(value);
+
+				// #245: 「現在の位置情報サービスの状態をもとに、更新後の駅 index を計算する」
+				// 旧 current 駅が新配列にも存在するならその index に追従させ、走行フラグを引き継ぐ。
+				// (= 「前の駅が削除された」「後の駅が追加された」等の編集で index がずれたケース)
+				// 存在しなければ駅自体が削除されたものとみなしてリセットする。
+				int newIndex = FindStationIndexByLocation_m(value, oldCurrentStation);
+				if (newIndex < 0)
+				{
+					ResetLocationInfo();
+					return;
+				}
+				if (newIndex == oldIndex && oldRunning == IsRunningToNextStation)
+				{
+					// 状態が変わらない: _lonLatStationDetector は上の SetStationLocations で履歴クリア
+					// 済みなので Sync で同期だけ取り、外部にはイベントを飛ばさない。
+					_lonLatStationDetector.Sync(newIndex, oldRunning);
+					return;
+				}
+				ForceSetLocationInfo(newIndex, oldRunning);
 			}
-			if (newIndex == oldIndex && oldRunning == IsRunningToNextStation)
-			{
-				// 状態が変わらない: _lonLatStationDetector は上の SetStationLocations で履歴クリア
-				// 済みなので Sync で同期だけ取り、外部にはイベントを飛ばさない。
-				_lonLatStationDetector.Sync(newIndex, oldRunning);
-				return;
-			}
-			ForceSetLocationInfo(newIndex, oldRunning);
 		}
 	}
 
@@ -109,6 +115,13 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	// SyncedData が <see cref="SyncedData.Location_m"/> を持たない接続向けのフォールバック。
 	private readonly LonLatStationDetector _lonLatStationDetector = new();
 
+	// CurrentStationIndex/IsRunningToNextStation/StaLocationInfo/_lonLatStationDetector の
+	// 一連の読み書きを保護する。WebSocket 受信ループと UI スレッドからの直接呼び出しが
+	// 非同期に競合しうるため、これらをまとめて操作する箇所は必ずこのロックを取る。
+	// lock は同一スレッドから再入可能なので、ロック済みメソッドから他のロック済み
+	// メソッド (ForceSetLocationInfo 等) を呼び出しても問題ない。
+	private readonly object _locationStateLock = new();
+
 	private string? _WorkGroupId;
 	public string? WorkGroupId
 	{
@@ -118,6 +131,9 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 			if (_WorkGroupId == value)
 				return;
 			_WorkGroupId = value;
+			// 対象 WorkGroup が変わる = CanStart/CanUseService はもはや別対象に対する
+			// 古い許可なので、サーバが新対象について再確認するまで引き継いではならない。
+			ResetCanStartAndCanUseServiceOnTargetChanged();
 			OnWorkGroupIdChanged(value);
 		}
 	}
@@ -131,6 +147,7 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 			if (_WorkId == value)
 				return;
 			_WorkId = value;
+			ResetCanStartAndCanUseServiceOnTargetChanged();
 			OnWorkIdChanged(value);
 		}
 	}
@@ -144,8 +161,22 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 			if (_TrainId == value)
 				return;
 			_TrainId = value;
+			ResetCanStartAndCanUseServiceOnTargetChanged();
 			OnTrainIdChanged(value);
 		}
+	}
+
+	/// <summary>
+	/// WorkGroupId/WorkId/TrainId のいずれかが変わったとき、旧対象向けの CanStart/CanUseService
+	/// を引き継がないようにリセットする。切替直後にサーバへ ID 更新を送るだけで CanStart 自体は
+	/// 次の SyncedData が来るまで再評価されないため、そのままにすると旧対象の許可が新対象に
+	/// 一時的に紛れ込む (例: 別列車へ切替後、次の同期が来るまで前の列車の CanStart=true が
+	/// 残ったまま CanUseServiceChanged 等の別イベントで誤って自動開始判定されうる)。
+	/// </summary>
+	private void ResetCanStartAndCanUseServiceOnTargetChanged()
+	{
+		CanStart = false;
+		CanUseService = false;
 	}
 
 	public int CurrentStationIndex { get; private set; }
@@ -284,59 +315,65 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	/// </summary>
 	private void UpdateCurrentStationWithLonLat(double longitude_deg, double latitude_deg)
 	{
-		if (StaLocationInfo is null || !IsEnabled)
-			return;
-
-		bool changed = _lonLatStationDetector.UpdateWithLonLat(longitude_deg, latitude_deg);
-		if (changed)
+		lock (_locationStateLock)
 		{
-			ForceSetLocationInfo(_lonLatStationDetector.CurrentStationIndex, _lonLatStationDetector.IsRunningToNextStation);
+			if (StaLocationInfo is null || !IsEnabled)
+				return;
+
+			bool changed = _lonLatStationDetector.UpdateWithLonLat(longitude_deg, latitude_deg);
+			if (changed)
+			{
+				ForceSetLocationInfo(_lonLatStationDetector.CurrentStationIndex, _lonLatStationDetector.IsRunningToNextStation);
+			}
 		}
 	}
 
 	void UpdateCurrentStationWithLocation(double location_m)
 	{
-		if (StaLocationInfo is null || !IsEnabled || double.IsNaN(location_m))
-			return;
-
-		bool isIn(double threshold1, double threshold2)
+		lock (_locationStateLock)
 		{
-			if (threshold1 < threshold2)
-				return threshold1 <= location_m && location_m < threshold2;
+			if (StaLocationInfo is null || !IsEnabled || double.IsNaN(location_m))
+				return;
+
+			bool isIn(double threshold1, double threshold2)
+			{
+				if (threshold1 < threshold2)
+					return threshold1 <= location_m && location_m < threshold2;
+				else
+					return threshold2 <= location_m && location_m < threshold1;
+			}
+
+			// 距離が逆戻りする可能性は考えない
+			for (int i = 0; i < StaLocationInfo.Length; i++)
+			{
+				double staLocation_m = StaLocationInfo[i].Location_m;
+				double staNearbyRadius_m = StaLocationInfo[i].NearbyRadius_m;
+				if (isIn(staLocation_m - staNearbyRadius_m, staLocation_m + staNearbyRadius_m))
+				{
+					if (i != CurrentStationIndex || IsRunningToNextStation)
+						ForceSetLocationInfo(i, false);
+					return;
+				}
+				else if (i != 0 && isIn(StaLocationInfo[i - 1].Location_m, staLocation_m))
+				{
+					if (i - 1 != CurrentStationIndex || !IsRunningToNextStation)
+						ForceSetLocationInfo(i - 1, true);
+					return;
+				}
+			}
+
+			double distanceFromFirstStation = Math.Abs(location_m - StaLocationInfo[0].Location_m);
+			double distanceFromLastStation = Math.Abs(location_m - StaLocationInfo[^1].Location_m);
+			if (distanceFromFirstStation < distanceFromLastStation)
+			{
+				if (0 != CurrentStationIndex || IsRunningToNextStation)
+					ForceSetLocationInfo(0, false);
+			}
 			else
-				return threshold2 <= location_m && location_m < threshold1;
-		}
-
-		// 距離が逆戻りする可能性は考えない
-		for (int i = 0; i < StaLocationInfo.Length; i++)
-		{
-			double staLocation_m = StaLocationInfo[i].Location_m;
-			double staNearbyRadius_m = StaLocationInfo[i].NearbyRadius_m;
-			if (isIn(staLocation_m - staNearbyRadius_m, staLocation_m + staNearbyRadius_m))
 			{
-				if (i != CurrentStationIndex || IsRunningToNextStation)
-					ForceSetLocationInfo(i, false);
-				return;
+				if (StaLocationInfo.Length - 1 != CurrentStationIndex || IsRunningToNextStation)
+					ForceSetLocationInfo(StaLocationInfo.Length - 1, false);
 			}
-			else if (i != 0 && isIn(StaLocationInfo[i - 1].Location_m, staLocation_m))
-			{
-				if (i - 1 != CurrentStationIndex || !IsRunningToNextStation)
-					ForceSetLocationInfo(i - 1, true);
-				return;
-			}
-		}
-
-		double distanceFromFirstStation = Math.Abs(location_m - StaLocationInfo[0].Location_m);
-		double distanceFromLastStation = Math.Abs(location_m - StaLocationInfo[^1].Location_m);
-		if (distanceFromFirstStation < distanceFromLastStation)
-		{
-			if (0 != CurrentStationIndex || IsRunningToNextStation)
-				ForceSetLocationInfo(0, false);
-		}
-		else
-		{
-			if (StaLocationInfo.Length - 1 != CurrentStationIndex || IsRunningToNextStation)
-				ForceSetLocationInfo(StaLocationInfo.Length - 1, false);
 		}
 	}
 
@@ -473,20 +510,26 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 		bool isRunningToNextStation
 	)
 	{
-		CurrentStationIndex = stationIndex;
-		IsRunningToNextStation = isRunningToNextStation;
-		// 緯度経度ベースの駅判定エンジンも外部の強制セットに合わせて状態同期する。
-		// (距離履歴は外部介入の時点で意味を失うのでクリアする)
-		_lonLatStationDetector.Sync(stationIndex, isRunningToNextStation);
-		LocationStateChanged?.Invoke(this, new LocationStateChangedEventArgs(CurrentStationIndex, IsRunningToNextStation));
+		lock (_locationStateLock)
+		{
+			CurrentStationIndex = stationIndex;
+			IsRunningToNextStation = isRunningToNextStation;
+			// 緯度経度ベースの駅判定エンジンも外部の強制セットに合わせて状態同期する。
+			// (距離履歴は外部介入の時点で意味を失うのでクリアする)
+			_lonLatStationDetector.Sync(stationIndex, isRunningToNextStation);
+			LocationStateChanged?.Invoke(this, new LocationStateChangedEventArgs(CurrentStationIndex, IsRunningToNextStation));
+		}
 	}
 
 	public void ResetLocationInfo()
 	{
-		CurrentStationIndex = 0;
-		IsRunningToNextStation = false;
-		_lonLatStationDetector.Reset();
-		LocationStateChanged?.Invoke(this, new LocationStateChangedEventArgs(CurrentStationIndex, IsRunningToNextStation));
+		lock (_locationStateLock)
+		{
+			CurrentStationIndex = 0;
+			IsRunningToNextStation = false;
+			_lonLatStationDetector.Reset();
+			LocationStateChanged?.Invoke(this, new LocationStateChangedEventArgs(CurrentStationIndex, IsRunningToNextStation));
+		}
 	}
 
 	public abstract void Dispose();


### PR DESCRIPTION
## Summary
- Fix: switching to a different train mid-run could carry over the previous train's `CurrentStationIndex`/`IsRunningToNextStation` when the new train coincidentally has a station at the same `Location_m` as the old one. The #245 same-train-edit carry-over logic in `NetworkSyncServiceBase.StaLocationInfo` never checked `TrainId`; `VerticalStylePagePresenter` now explicitly calls `ResetLocationInfo()` after a confirmed (non-soft) train switch.
- Fix: `WorkGroupId`/`WorkId`/`TrainId` changes now reset `CanStart`/`CanUseService`, so a stale permission from the previous train can't leak into the newly selected train until the server re-confirms via the next `SyncedData` message.
- Hardening: added locking (`_locationStateLock`) around `NetworkSyncServiceBase`'s station-tracking mutations (`StaLocationInfo` setter, `ForceSetLocationInfo`, `ResetLocationInfo`, `UpdateCurrentStationWithLocation`/`UpdateCurrentStationWithLonLat`) since the WebSocket receive loop (background thread) and UI-driven train switches could otherwise race on the same mutable state.
- Incidental: fixed a pre-existing unrelated build break in `ViewHostPresenterTests.cs` (`FakeTimeProvider` missing `ITimeProvider.GetCurrentTimeSeconds()`) that was blocking the whole `TRViS.DTAC.Logic.Tests` project from compiling.

## Test plan
- [x] `TRViS.LocationService.Tests`: 48/48 passing (added `SetStationLocations_SwitchToDifferentTrain_WithoutExplicitReset_CanCarryOverStaleStationIndex`, `SetTargetIds_DifferentTrainId_ResetsCanStartAndCanUseService`, `ConcurrentSyncedDataAndStationSwitch_DoesNotThrow_AndStaysInBounds`)
- [x] `TRViS.DTAC.Logic.Tests`: 227/227 passing (added `SelectedTrainDataChanged_DifferentTrainId_ResetsLocationInfo`, `SelectedTrainDataChanged_SameIdAndRowCount_DoesNotResetLocationInfo`)
- [x] `TRViS.NetworkSyncService.IntegrationTests`: 87/87 passing (no regressions)
- [x] Reran `TRViS.LocationService.Tests` 5x in a row to confirm the new concurrency/CanStart tests are stable, not flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfwCVdJSHtwhR94j2MNxY6