### PR TITLE
fix(ci): pin Appium + uiautomator2 driver to fix Android UI tests (#298)

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -65,6 +65,21 @@ env:
   # Invoke-WebRequest resolves "localhost" to ::1 (IPv6) while Appium
   # listens on 0.0.0.0 (IPv4 only), causing connection refused.
   APPIUM_URL: http://127.0.0.1:4723
+  # Appium tool versions — PINNED. `npm install -g appium` and
+  # `appium driver install uiautomator2` are otherwise unversioned and
+  # resolve to "latest" on every run, so an upstream release silently
+  # changes the test environment. appium-uiautomator2-driver 8.0.0
+  # (2026-06-26) regressed resource-id reporting: the app launches and
+  # renders, the emulator stays alive, but the bundled uiautomator2 server
+  # (v10.2.4) matches 0 elements for every AutomationId → resource-id
+  # (StartHome.Title, SelectFile.Title, DTAC.TestNavigateHomeButton),
+  # failing 11/11 Android UI tests deterministically (#298). 7.6.2 is the
+  # last release before that regression and matches the last green run;
+  # it peer-depends on appium ^3.0.0, so appium stays on 3.5.2 (the same
+  # core the green and red runs both used — only the driver changed).
+  # Revisit / bump the driver once the upstream regression is fixed.
+  APPIUM_VERSION: "3.5.2"
+  UIA2_DRIVER_VERSION: "7.6.2"
 
   # Android emulator settings
   ANDROID_EMULATOR_API_LEVEL: 34
@@ -153,8 +168,8 @@ jobs:
 
       - name: Install Appium and UiAutomator2 driver
         run: |
-          npm install -g appium
-          appium driver install uiautomator2
+          npm install -g appium@${{ env.APPIUM_VERSION }}
+          appium driver install uiautomator2@${{ env.UIA2_DRIVER_VERSION }}
 
       - name: Install Android emulator system image
         run: |
@@ -631,8 +646,10 @@ jobs:
           /p:DefineConstants="${{ env.UI_TEST_DEFINES }}"
 
       - name: Install Appium and Windows driver
+        # appium pinned via APPIUM_VERSION (same 3.5.2 this job already used);
+        # the windows driver is unaffected by #298 and stays unpinned.
         run: |
-          npm install -g appium
+          npm install -g appium@${{ env.APPIUM_VERSION }}
           appium driver install --source=npm appium-windows-driver
 
       - name: Run Windows UI Tests


### PR DESCRIPTION
Fixes #298.

## 根本原因

`ui-test-android` の 11/11 全滅は**コード起因ではなく、Appium UiAutomator2 ドライバーの自動更新 7.6.2 → 8.0.x が原因**。

- アプリは正常に起動・描画している（logcat: `Displayed …MainActivity +6.5s`、StartHome の `MaterialButton` を約26個生成、エミュレータは teardown まで生存、リトライループも "emulator is alive — not retrying"）。
- それでも `FindElements` が48回すべて `Matched 0 elements` — 3画面にまたがる3つの resource-id（`StartHome.Title` / `SelectFile.Title` / `DTAC.TestNavigateHomeButton`）が同時に消える。局所的なコード変更では起こり得ない、自動化レイヤー側の階層報告の全体変化。
- **同一ツリー**が 7.6.2 では成功（2026-06-21）、8.0.1 では失敗。`AutomationId`/`StartHome`/`AppShell`/`App`/`MauiProgram` に触れる差分はゼロ。
- Windows ジョブ（同じ appium コア 3.5.2・別ドライバー）は同じ失敗実行内で**成功** → 原因を uiautomator2 ドライバーに限定。
- uiautomator2 **8.0.0 は 2026-06-26 リリース**で、決定的失敗の開始時期と一致（同梱サーバー v10.2.4）。

Issue が指摘する「同日にブランチ成功／マージ失敗」は別問題（間欠的な UIA2 instrumentation クラッシュ = 既知の DTAC teardown フレーク、部分失敗）で、本件のレッドヘリング。

## 修正

`npm install -g appium` / `appium driver install uiautomator2` は未固定で毎回 latest を引くため、回帰が静かに混入した。env に版を固定:

- `UIA2_DRIVER_VERSION: "7.6.2"` — 回帰直前の既知良好版（appium `^3.0.0` に peer-depend）
- `APPIUM_VERSION: "3.5.2"` — 成功時・失敗時どちらの実行も使っていたコア版（変わっていない）

Windows の appium も同 env で同版に固定（挙動は現状と同一・再現性のみ向上）。Windows ドライバーは本件と無関係のため未固定のまま。

## 検証

ローカルでエミュレータを再現できないため、**このPRの `ui-test-android` が緑になることで検証**する。ドライバー 8.x への前向き対応（v10 サーバーの変更点解明）は upstream の回帰修正後のフォローアップ。