### PR TITLE
Add iOS QR scanner fallback

### DIFF
--- a/TRViS/MauiProgram.cs
+++ b/TRViS/MauiProgram.cs
@@ -73,12 +73,18 @@ public static class MauiProgram
 				fonts.AddFont("NotoSansJP-Regular.ttf", "NotoSansJPRegular");
 				fonts.AddFont("NotoSansJP-Bold.ttf", "NotoSansJPBold");
 			})
-#if ANDROID || IOS
-			// In-app QR scanner (phone-only). Registers the BarcodeScanning
-			// CameraView handler used by RootPages/ScanQrPage.
-			.UseBarcodeScanning()
-#endif
 			.ConfigureFirebase();
+
+#if ANDROID
+		// Android's scanner handler is safe to register during startup.
+		builder.UseBarcodeScanning();
+#elif IOS
+		// BarcodeScanning.Native.Maui requires iOS 15.1. Do not execute any of
+		// its registration code on iOS 12-15.0; those versions create the
+		// AVFoundation fallback only when ScanQrPage is actually shown.
+		if (OperatingSystem.IsIOSVersionAtLeast(15, 1))
+			builder.UseBarcodeScanning();
+#endif
 
 		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 
@@ -221,4 +227,3 @@ public static class MauiProgram
 	}
 #endif
 }
-

--- a/TRViS/Platforms/iOS/ScanQrPage.iOS.cs
+++ b/TRViS/Platforms/iOS/ScanQrPage.iOS.cs
@@ -1,0 +1,556 @@
+using AVFoundation;
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using UIKit;
+
+using TRViS.Services;
+
+namespace TRViS.RootPages;
+
+public partial class ScanQrPage
+{
+	private LegacyIosQrScannerSession? _legacyIosScanner;
+
+	/// <summary>
+	/// Starts the iOS 12-compatible scanner only after ScanQrPage is visible.
+	/// The implementation deliberately contains no managed NSObject subclasses:
+	/// those are registered by the static iOS registrar during app startup even
+	/// when their instances are created lazily.
+	/// </summary>
+	[SupportedOSPlatform("ios12.2")]
+	[UnsupportedOSPlatform("ios15.1")]
+	private async Task<bool> StartLegacyIosScannerAsync()
+	{
+		AVAuthorizationStatus status =
+			AVCaptureDevice.GetAuthorizationStatus(AVAuthorizationMediaType.Video);
+
+		if (status == AVAuthorizationStatus.NotDetermined)
+		{
+			bool granted =
+				await AVCaptureDevice.RequestAccessForMediaTypeAsync(AVAuthorizationMediaType.Video);
+			if (!granted)
+				return false;
+		}
+		else if (status != AVAuthorizationStatus.Authorized)
+		{
+			return false;
+		}
+
+		UIView nativeHost = await GetNativeCameraHostAsync();
+
+		if (_legacyIosScanner is null)
+		{
+			_legacyIosScanner = new LegacyIosQrScannerSession(
+				nativeHost,
+				value => MainThread.BeginInvokeOnMainThread(
+					async () => await TryHandleCandidateAsync(value)));
+			CameraHost.SizeChanged += OnLegacyCameraHostSizeChanged;
+		}
+		_legacyIosScanner.Start();
+		return true;
+	}
+
+	/// <summary>
+	/// On iOS 12 the CameraHost ContentView's Handler is sometimes not yet
+	/// created when OnAppearing runs (the native view hasn't finished attaching
+	/// to the window), so <c>CameraHost.Handler</c> can still be null here. Wait
+	/// for HandlerChanged instead of assuming it is already available.
+	/// </summary>
+	private async Task<UIView> GetNativeCameraHostAsync()
+	{
+		if (CameraHost.Handler?.PlatformView is UIView existingHost)
+			return existingHost;
+
+		TaskCompletionSource<UIView> tcs =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		void OnHandlerChanged(object? sender, EventArgs e)
+		{
+			if (CameraHost.Handler?.PlatformView is UIView view)
+				tcs.TrySetResult(view);
+		}
+
+		CameraHost.HandlerChanged += OnHandlerChanged;
+		try
+		{
+			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+			using CancellationTokenRegistration registration = cts.Token.Register(() =>
+				tcs.TrySetException(
+					new InvalidOperationException("The native camera host is not available.")));
+
+			return await tcs.Task;
+		}
+		finally
+		{
+			CameraHost.HandlerChanged -= OnHandlerChanged;
+		}
+	}
+
+	private void StopLegacyIosScanner()
+		=> _legacyIosScanner?.Stop();
+
+	private Task DisposeLegacyIosScannerAsync()
+	{
+		if (_legacyIosScanner is null)
+			return Task.CompletedTask;
+
+		CameraHost.SizeChanged -= OnLegacyCameraHostSizeChanged;
+		_legacyIosScanner.Dispose();
+		_legacyIosScanner = null;
+		return Task.CompletedTask;
+	}
+
+	private void OnLegacyCameraHostSizeChanged(object? sender, EventArgs e)
+		=> _legacyIosScanner?.UpdatePreviewFrame();
+
+	private void ToggleLegacyIosTorch()
+	{
+		bool enabled = _legacyIosScanner?.ToggleTorch() ?? false;
+		logger.Trace("Legacy iOS torch toggled -> {0}", enabled);
+	}
+}
+
+/// <summary>
+/// iOS 12 QR backend without application-defined NSObject subclasses.
+/// A tiny Objective-C delegate class is created only when this scanner opens,
+/// so it never enters .NET iOS's startup-time static registrar.
+/// </summary>
+[SupportedOSPlatform("ios12.2")]
+[UnsupportedOSPlatform("ios15.1")]
+internal sealed class LegacyIosQrScannerSession : IDisposable
+{
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
+
+	private readonly UIView _host;
+	private readonly Action<string> _detected;
+	private readonly DispatchQueue _captureQueue =
+		new("dev.t0r.trvis.legacy-qr-capture");
+
+	private AVCaptureSession? _session;
+	private AVCaptureDevice? _camera;
+	private AVCaptureMetadataOutput? _metadataOutput;
+	private UIView? _preview;
+	private AVCaptureVideoPreviewLayer? _previewLayer;
+	private IntPtr _delegateHandle;
+	private bool _configured;
+	private bool _disposed;
+	private bool _torchOn;
+	private NSTimer? _frameConvergenceTimer;
+
+	internal LegacyIosQrScannerSession(UIView host, Action<string> detected)
+	{
+		_host = host;
+		_detected = detected;
+	}
+
+	internal void Start()
+	{
+		ObjectDisposedException.ThrowIf(_disposed, this);
+
+		if (!_configured)
+			Configure();
+
+		AVCaptureSession session = _session
+			?? throw new InvalidOperationException("The capture session was not configured.");
+		if (!session.Running)
+			_captureQueue.DispatchAsync(session.StartRunning);
+	}
+
+	internal void Stop()
+	{
+		AVCaptureSession? session = _session;
+		if (session?.Running == true)
+			_captureQueue.DispatchAsync(session.StopRunning);
+	}
+
+	internal bool ToggleTorch()
+	{
+		AVCaptureDevice? camera = _camera;
+		if (camera is null || !camera.HasTorch)
+			return false;
+
+		NSError? error;
+		if (!camera.LockForConfiguration(out error))
+		{
+			logger.Warn("Could not lock camera for torch configuration: {0}", error);
+			return _torchOn;
+		}
+
+		try
+		{
+			_torchOn = !_torchOn;
+			camera.TorchMode = _torchOn
+				? AVCaptureTorchMode.On
+				: AVCaptureTorchMode.Off;
+			return _torchOn;
+		}
+		finally
+		{
+			camera.UnlockForConfiguration();
+		}
+	}
+
+	private void Configure()
+	{
+		using AVCaptureDeviceDiscoverySession discovery =
+			AVCaptureDeviceDiscoverySession.Create(
+				[AVCaptureDeviceType.BuiltInWideAngleCamera],
+				AVMediaTypes.Video,
+				AVCaptureDevicePosition.Back);
+		_camera = discovery.Devices.FirstOrDefault()
+			?? throw new InvalidOperationException("No rear camera is available.");
+
+		AVCaptureDeviceInput input = AVCaptureDeviceInput.FromDevice(
+			_camera,
+			out NSError? inputError)
+			?? throw new InvalidOperationException(
+				$"Could not create camera input: {inputError?.LocalizedDescription}");
+
+		var session = new AVCaptureSession();
+		var output = new AVCaptureMetadataOutput();
+
+		if (!session.CanAddInput(input))
+			throw new InvalidOperationException("Could not add camera input.");
+		session.AddInput(input);
+
+		if (!session.CanAddOutput(output))
+			throw new InvalidOperationException("Could not add QR metadata output.");
+		session.AddOutput(output);
+
+		_delegateHandle = LegacyQrMetadataDelegate.Create(this);
+		LegacyQrMetadataDelegate.SetOutputDelegate(
+			output,
+			_delegateHandle,
+			_captureQueue);
+		output.MetadataObjectTypes = AVMetadataObjectType.QRCode;
+
+		var preview = new UIView
+		{
+			Frame = _host.Bounds,
+			AutoresizingMask =
+				UIViewAutoresizing.FlexibleWidth |
+				UIViewAutoresizing.FlexibleHeight,
+		};
+		var previewLayer = new AVCaptureVideoPreviewLayer(session)
+		{
+			Frame = preview.Bounds,
+			VideoGravity = AVLayerVideoGravity.ResizeAspectFill,
+		};
+		preview.Layer.AddSublayer(previewLayer);
+		_host.InsertSubview(preview, 0);
+
+		_session = session;
+		_metadataOutput = output;
+		_preview = preview;
+		_previewLayer = previewLayer;
+		_configured = true;
+		UpdatePreviewFrame();
+		StartFrameConvergencePolling();
+	}
+
+	/// <summary>
+	/// On the "camera permission already granted" fast path, OnAppearing can
+	/// reach here before MAUI's AbsoluteLayout has arranged CameraHost to its
+	/// final size, so <c>_host.Bounds</c> is still (0,0,0,0) here. The
+	/// CameraHost.SizeChanged subscription is set up before this call, but the
+	/// arrange pass that follows does not reliably re-raise it once the
+	/// handler already exists, leaving the preview permanently zero-sized (no
+	/// visible video). Poll for a short window until the host reports a real
+	/// size, re-applying the preview frame each tick; this is independent of
+	/// exactly when/whether SizeChanged fires.
+	/// </summary>
+	private void StartFrameConvergencePolling()
+	{
+		int tickCount = 0;
+		_frameConvergenceTimer = NSTimer.CreateRepeatingScheduledTimer(TimeSpan.FromMilliseconds(100), timer =>
+		{
+			tickCount++;
+			UpdatePreviewFrame();
+
+			bool hasSize = _host.Bounds.Width > 0 && _host.Bounds.Height > 0;
+			if (hasSize || tickCount >= 20 || _disposed)
+			{
+				timer.Invalidate();
+				_frameConvergenceTimer = null;
+			}
+		});
+	}
+
+	internal void UpdatePreviewFrame()
+	{
+		if (_preview is null || _previewLayer is null)
+			return;
+
+		_preview.Frame = _host.Bounds;
+		_previewLayer.Frame = _preview.Bounds;
+
+		AVCaptureConnection? connection = _previewLayer.Connection;
+		if (connection?.SupportsVideoOrientation != true)
+			return;
+
+		connection.VideoOrientation = UIDevice.CurrentDevice.Orientation switch
+		{
+			UIDeviceOrientation.PortraitUpsideDown => AVCaptureVideoOrientation.PortraitUpsideDown,
+			// Device and capture landscape directions are intentionally mirrored.
+			UIDeviceOrientation.LandscapeLeft => AVCaptureVideoOrientation.LandscapeRight,
+			UIDeviceOrientation.LandscapeRight => AVCaptureVideoOrientation.LandscapeLeft,
+			_ => AVCaptureVideoOrientation.Portrait,
+		};
+	}
+
+	internal void OnMetadataObjects(AVMetadataObject[] metadataObjects)
+	{
+		foreach (AVMetadataObject metadataObject in metadataObjects)
+		{
+			if (metadataObject is AVMetadataMachineReadableCodeObject code &&
+				code.Type == AVMetadataObjectType.QRCode &&
+				!string.IsNullOrWhiteSpace(code.StringValue))
+			{
+				_detected(code.StringValue);
+				return;
+			}
+		}
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+			return;
+		_disposed = true;
+
+		_frameConvergenceTimer?.Invalidate();
+		_frameConvergenceTimer = null;
+
+		// Tear down the UI-side objects synchronously — this only detaches the
+		// preview from the screen and does not need the camera to have stopped.
+		_preview?.RemoveFromSuperview();
+		_previewLayer?.Dispose();
+		_preview?.Dispose();
+
+		// AVCaptureSession.StopRunning() can block for several seconds on some
+		// hardware (observed ~9s on an iPad Air 2 running iOS 12.5.8). Waiting
+		// for it synchronously here stalls whatever the caller does next (e.g.
+		// the AppLink navigation after a successful scan), so hand the actual
+		// stop -> detach delegate -> release native objects sequence off to the
+		// capture queue and let it finish in the background instead of blocking
+		// the caller. Order matches the original synchronous teardown.
+		AVCaptureSession? session = _session;
+		AVCaptureMetadataOutput? metadataOutput = _metadataOutput;
+		AVCaptureDevice? camera = _camera;
+		IntPtr delegateHandle = _delegateHandle;
+		DispatchQueue captureQueue = _captureQueue;
+		_delegateHandle = IntPtr.Zero;
+		captureQueue.DispatchAsync(() =>
+		{
+			// Runs on a background GCD queue with nothing above it to catch an
+			// unhandled throw (the original DispatchSync let exceptions
+			// propagate to the caller's try/catch); report explicitly instead.
+			try
+			{
+				if (session?.Running == true)
+					session.StopRunning();
+
+				if (metadataOutput is not null)
+					LegacyQrMetadataDelegate.SetOutputDelegate(metadataOutput, IntPtr.Zero, null);
+				if (delegateHandle != IntPtr.Zero)
+					LegacyQrMetadataDelegate.Destroy(delegateHandle);
+
+				metadataOutput?.Dispose();
+				session?.Dispose();
+				camera?.Dispose();
+				captureQueue.Dispose();
+			}
+			catch (Exception ex)
+			{
+				logger.Error(ex, "Background camera teardown failed");
+				InstanceManager.CrashlyticsWrapper.Log(ex, "LegacyIosQrScannerSession.Dispose (background teardown)");
+			}
+		});
+	}
+}
+
+/// <summary>
+/// Runtime-created Objective-C implementation of
+/// AVCaptureMetadataOutputObjectsDelegate. This is intentionally not an
+/// NSObject-derived managed class, so the static registrar never sees it.
+/// </summary>
+[SupportedOSPlatform("ios12.2")]
+[UnsupportedOSPlatform("ios15.1")]
+internal static class LegacyQrMetadataDelegate
+{
+	private const string DelegateClassName = "TRViSLegacyQrMetadataDelegate";
+	private const string CallbackSelectorName =
+		"captureOutput:didOutputMetadataObjects:fromConnection:";
+	private const string SetDelegateSelectorName =
+		"setMetadataObjectsDelegate:queue:";
+
+	private static readonly object classLock = new();
+	private static readonly ConcurrentDictionary<IntPtr, WeakReference<LegacyIosQrScannerSession>>
+		sessions = new();
+	private static readonly MetadataCallback metadataCallback = OnMetadata;
+	private static IntPtr delegateClass;
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate void MetadataCallback(
+		IntPtr self,
+		IntPtr command,
+		IntPtr output,
+		IntPtr metadataObjects,
+		IntPtr connection);
+
+	internal static IntPtr Create(LegacyIosQrScannerSession session)
+	{
+		IntPtr nativeClass = GetOrCreateClass();
+		IntPtr instance = IntPtr_objc_msgSend(
+			IntPtr_objc_msgSend(nativeClass, Selector.GetHandle("alloc")),
+			Selector.GetHandle("init"));
+		if (instance == IntPtr.Zero)
+			throw new InvalidOperationException("Could not create the native QR delegate.");
+
+		sessions[instance] = new WeakReference<LegacyIosQrScannerSession>(session);
+		return instance;
+	}
+
+	internal static void Destroy(IntPtr instance)
+	{
+		sessions.TryRemove(instance, out _);
+		objc_release(instance);
+	}
+
+	internal static void SetOutputDelegate(
+		AVCaptureMetadataOutput output,
+		IntPtr delegateHandle,
+		DispatchQueue? queue)
+	{
+		void_objc_msgSend_IntPtr_IntPtr(
+			output.Handle,
+			Selector.GetHandle(SetDelegateSelectorName),
+			delegateHandle,
+			queue?.Handle ?? IntPtr.Zero);
+	}
+
+	private static IntPtr GetOrCreateClass()
+	{
+		if (delegateClass != IntPtr.Zero)
+			return delegateClass;
+
+		lock (classLock)
+		{
+			if (delegateClass != IntPtr.Zero)
+				return delegateClass;
+
+			IntPtr existingClass = objc_getClass(DelegateClassName);
+			if (existingClass != IntPtr.Zero)
+			{
+				delegateClass = existingClass;
+				return delegateClass;
+			}
+
+			IntPtr nsObjectClass = objc_getClass("NSObject");
+			IntPtr newClass = objc_allocateClassPair(
+				nsObjectClass,
+				DelegateClassName,
+				IntPtr.Zero);
+			if (newClass == IntPtr.Zero)
+				throw new InvalidOperationException("Could not allocate the native QR delegate class.");
+
+			IntPtr protocol = objc_getProtocol("AVCaptureMetadataOutputObjectsDelegate");
+			if (protocol == IntPtr.Zero || !class_addProtocol(newClass, protocol))
+				throw new InvalidOperationException("Could not add the QR metadata protocol.");
+
+			IntPtr callbackPointer = Marshal.GetFunctionPointerForDelegate(metadataCallback);
+			if (!class_addMethod(
+				newClass,
+				Selector.GetHandle(CallbackSelectorName),
+				callbackPointer,
+				"v@:@@@"))
+			{
+				throw new InvalidOperationException("Could not add the QR metadata callback.");
+			}
+
+			objc_registerClassPair(newClass);
+			delegateClass = newClass;
+			return delegateClass;
+		}
+	}
+
+	[MonoPInvokeCallback(typeof(MetadataCallback))]
+	private static void OnMetadata(
+		IntPtr self,
+		IntPtr command,
+		IntPtr output,
+		IntPtr metadataObjects,
+		IntPtr connection)
+	{
+		try
+		{
+			if (!sessions.TryGetValue(self, out var weakSession) ||
+				!weakSession.TryGetTarget(out LegacyIosQrScannerSession? session))
+			{
+				return;
+			}
+
+			AVMetadataObject?[]? objects =
+				NSArray.ArrayFromHandle<AVMetadataObject>((NativeHandle)metadataObjects);
+			if (objects is null)
+				return;
+
+			session.OnMetadataObjects(objects.OfType<AVMetadataObject>().ToArray());
+		}
+		catch (Exception ex)
+		{
+			logger.Warn(ex, "Native iOS QR metadata callback failed");
+			InstanceManager.CrashlyticsWrapper.Log(ex, "LegacyQrMetadataDelegate.OnMetadata");
+		}
+	}
+
+	private static readonly NLog.Logger logger = LoggerService.GetGeneralLogger();
+
+	private const string ObjectiveCLibrary = "/usr/lib/libobjc.dylib";
+
+	[DllImport(ObjectiveCLibrary)]
+	private static extern IntPtr objc_getClass(string name);
+
+	[DllImport(ObjectiveCLibrary)]
+	private static extern IntPtr objc_getProtocol(string name);
+
+	[DllImport(ObjectiveCLibrary)]
+	private static extern IntPtr objc_allocateClassPair(
+		IntPtr superclass,
+		string name,
+		IntPtr extraBytes);
+
+	[DllImport(ObjectiveCLibrary)]
+	private static extern void objc_registerClassPair(IntPtr cls);
+
+	[DllImport(ObjectiveCLibrary)]
+	[return: MarshalAs(UnmanagedType.I1)]
+	private static extern bool class_addProtocol(IntPtr cls, IntPtr protocol);
+
+	[DllImport(ObjectiveCLibrary)]
+	[return: MarshalAs(UnmanagedType.I1)]
+	private static extern bool class_addMethod(
+		IntPtr cls,
+		IntPtr selector,
+		IntPtr implementation,
+		string types);
+
+	[DllImport(ObjectiveCLibrary)]
+	private static extern void objc_release(IntPtr value);
+
+	[DllImport(ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+	private static extern IntPtr IntPtr_objc_msgSend(
+		IntPtr receiver,
+		IntPtr selector);
+
+	[DllImport(ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+	private static extern void void_objc_msgSend_IntPtr_IntPtr(
+		IntPtr receiver,
+		IntPtr selector,
+		IntPtr firstArgument,
+		IntPtr secondArgument);
+}

--- a/TRViS/Resources/Raw/sample_data.json
+++ b/TRViS/Resources/Raw/sample_data.json
@@ -1269,6 +1269,7 @@
       {
         "Id": "hako-diagram-2stations",
         "Name": "ハコ図(2駅・図表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram2-1",
@@ -1285,6 +1286,7 @@
       {
         "Id": "hako-diagram-3stations",
         "Name": "ハコ図(3駅・図表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram3-1",
@@ -1311,6 +1313,7 @@
       {
         "Id": "hako-diagram-4stations",
         "Name": "ハコ図(4駅・図表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram4-1",
@@ -1347,6 +1350,7 @@
       {
         "Id": "hako-diagram-5stations",
         "Name": "ハコ図(5駅・図表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram5-1",
@@ -1393,6 +1397,7 @@
       {
         "Id": "hako-diagram-6stations",
         "Name": "ハコ図(6駅・図表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram6-1",
@@ -1449,6 +1454,7 @@
       {
         "Id": "hako-diagram-7stations",
         "Name": "ハコ図(7駅・図表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram7-1",
@@ -1615,6 +1621,7 @@
       {
         "Id": "hako-diagram-8stations",
         "Name": "ハコ図(8駅・一覧表示)",
+        "AffectDate": "20260704",
         "Trains": [
           {
             "Id": "diagram8-1",

--- a/TRViS/RootPages/ScanQrPage.xaml
+++ b/TRViS/RootPages/ScanQrPage.xaml
@@ -2,25 +2,19 @@
 <ContentPage
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-	xmlns:barcode="clr-namespace:BarcodeScanning;assembly=BarcodeScanning.Native.Maui"
 	xmlns:loc="clr-namespace:TRViS.Localization"
 	x:Class="TRViS.RootPages.ScanQrPage"
 	BackgroundColor="Black"
 	Title="{loc:Translate ScanQr_Title}">
 
 	<AbsoluteLayout x:Name="RootLayout">
-		<!-- Live camera preview. BarcodeSymbologies is restricted to QRCode so
-		     the native detector ignores 1-D barcodes / DataMatrix / etc.; the
-		     "only TRViS AppLink" gate is enforced separately in code-behind. -->
-		<barcode:CameraView
-			x:Name="Barcode"
+		<!-- The actual camera is inserted only after this page appears. This is
+		     deliberately a neutral host: iOS 12 gets an AVFoundation preview,
+		     while newer iOS and Android get BarcodeScanning.CameraView. -->
+		<ContentView
+			x:Name="CameraHost"
 			AbsoluteLayout.LayoutFlags="All"
-			AbsoluteLayout.LayoutBounds="0,0,1,1"
-			BarcodeSymbologies="QRCode"
-			CaptureQuality="Medium"
-			TapToFocusEnabled="True"
-			VibrationOnDetected="False"
-			OnDetectionFinished="OnDetectionFinished"/>
+			AbsoluteLayout.LayoutBounds="0,0,1,1"/>
 
 		<!-- Centered viewfinder guide (visual only; InputTransparent so taps
 		     reach the camera for tap-to-focus). -->

--- a/TRViS/RootPages/ScanQrPage.xaml.cs
+++ b/TRViS/RootPages/ScanQrPage.xaml.cs
@@ -24,6 +24,7 @@ public partial class ScanQrPage : ContentPage
 	// fires repeatedly while a code stays in frame, so a plain bool is enough
 	// to ensure we handle the first accepted TRViS link exactly once.
 	private bool _handled;
+	private CameraView? _modernScanner;
 
 	public ScanQrPage()
 	{
@@ -33,12 +34,8 @@ public partial class ScanQrPage : ContentPage
 #if UI_TEST
 		// The CI emulator has no usable camera, and initializing the live
 		// CameraView there stalls the GL/surface pipeline (10 s+ frame times) so
-		// the page never renders for Appium. The E2E drives the "only TRViS
-		// AppLinks" gate through the hidden seam buttons instead of a real
-		// detection, so drop the camera preview entirely (and never request
-		// camera permission — see OnAppearing). Every other Barcode access is
-		// compiled out under UI_TEST for the same reason.
-		RootLayout.Children.Remove(Barcode);
+		// the page never renders for Appium. The camera is not inserted into
+		// CameraHost in UI_TEST; hidden seam buttons drive the AppLink gate.
 		BuildTestSeamButtons();
 #endif
 	}
@@ -86,6 +83,34 @@ public partial class ScanQrPage : ContentPage
 		await Task.CompletedTask;
 		return;
 #else
+		try
+		{
+#if IOS
+			if (!OperatingSystem.IsIOSVersionAtLeast(15, 1))
+			{
+				if (!await StartLegacyIosScannerAsync())
+					await HandlePermissionDeniedAsync();
+				return;
+			}
+#endif
+			await StartModernScannerAsync();
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "Starting QR scanner failed");
+			InstanceManager.CrashlyticsWrapper.Log(ex, "ScanQrPage.OnAppearing (start scanner)");
+			await Util.DisplayAlertAsync(
+				AppResources.Common_Error,
+				AppResources.ScanQr_OpenFailedMessage,
+				AppResources.Common_OK);
+			await CloseAsync();
+		}
+#endif
+	}
+
+#if !UI_TEST
+	private async Task StartModernScannerAsync()
+	{
 		// The library owns the platform permission request (camera, and on
 		// Android the auto-granted VIBRATE). Ask before enabling the preview.
 		bool granted;
@@ -102,18 +127,35 @@ public partial class ScanQrPage : ContentPage
 
 		if (!granted)
 		{
-			logger.Warn("Camera permission not granted -> closing scanner");
-			await Util.DisplayAlertAsync(
-				AppResources.ScanQr_PermissionDeniedTitle,
-				AppResources.ScanQr_PermissionDeniedBody,
-				AppResources.Common_OK);
-			await CloseAsync();
+			await HandlePermissionDeniedAsync();
 			return;
 		}
 
-		Barcode.CameraEnabled = true;
-#endif
+		if (_modernScanner is null)
+		{
+			_modernScanner = new CameraView
+			{
+				TapToFocusEnabled = true,
+				VibrationOnDetected = false,
+			};
+			_modernScanner.OnDetectionFinished += OnDetectionFinished;
+			CameraHost.Content = _modernScanner;
+		}
+
+		_modernScanner.PauseScanning = false;
+		_modernScanner.CameraEnabled = true;
 	}
+
+	private async Task HandlePermissionDeniedAsync()
+	{
+		logger.Warn("Camera permission not granted -> closing scanner");
+		await Util.DisplayAlertAsync(
+			AppResources.ScanQr_PermissionDeniedTitle,
+			AppResources.ScanQr_PermissionDeniedBody,
+			AppResources.Common_OK);
+		await CloseAsync();
+	}
+#endif
 
 	protected override void OnDisappearing()
 	{
@@ -122,7 +164,7 @@ public partial class ScanQrPage : ContentPage
 		// Release the camera whenever the page leaves the screen (successful
 		// scan, close button, OS-level dismissal). Handler disconnection is
 		// automatic from .NET MAUI 9, so nothing else is required.
-		Barcode.CameraEnabled = false;
+		StopScanner();
 #endif
 	}
 
@@ -170,8 +212,9 @@ public partial class ScanQrPage : ContentPage
 
 		logger.Info("Accepted TRViS AppLink from QR: {0}", trvisLink);
 #if !UI_TEST
-		Barcode.PauseScanning = true;
-		Barcode.CameraEnabled = false;
+		if (_modernScanner is not null)
+			_modernScanner.PauseScanning = true;
+		StopScanner();
 #endif
 
 		// Haptic confirmation, fired only once a TRViS AppLink is accepted (the
@@ -206,7 +249,7 @@ public partial class ScanQrPage : ContentPage
 	{
 		logger.Trace("Close clicked");
 #if !UI_TEST
-		Barcode.CameraEnabled = false;
+		StopScanner();
 #endif
 		await CloseAsync();
 	}
@@ -214,20 +257,50 @@ public partial class ScanQrPage : ContentPage
 	private void OnTorchClicked(object sender, EventArgs e)
 	{
 #if !UI_TEST
-		Barcode.TorchOn = !Barcode.TorchOn;
-		logger.Trace("Torch toggled -> {0}", Barcode.TorchOn);
+#if IOS
+		if (!OperatingSystem.IsIOSVersionAtLeast(15, 1))
+		{
+			ToggleLegacyIosTorch();
+			return;
+		}
+#endif
+		if (_modernScanner is not null)
+		{
+			_modernScanner.TorchOn = !_modernScanner.TorchOn;
+			logger.Trace("Torch toggled -> {0}", _modernScanner.TorchOn);
+		}
 #endif
 	}
+
+#if !UI_TEST
+	private void StopScanner()
+	{
+#if IOS
+		if (!OperatingSystem.IsIOSVersionAtLeast(15, 1))
+		{
+			StopLegacyIosScanner();
+			return;
+		}
+#endif
+		if (_modernScanner is not null)
+			_modernScanner.CameraEnabled = false;
+	}
+#endif
 
 	private async Task CloseAsync()
 	{
 		try
 		{
+#if IOS && !UI_TEST
+			if (!OperatingSystem.IsIOSVersionAtLeast(15, 1))
+				await DisposeLegacyIosScannerAsync();
+#endif
 			await Navigation.PopModalAsync();
 		}
 		catch (Exception ex)
 		{
 			logger.Error(ex, "PopModalAsync failed");
+			InstanceManager.CrashlyticsWrapper.Log(ex, "ScanQrPage.CloseAsync (PopModalAsync failed)");
 		}
 	}
 

--- a/TRViS/RootPages/ScanQrPage.xaml.cs
+++ b/TRViS/RootPages/ScanQrPage.xaml.cs
@@ -137,6 +137,8 @@ public partial class ScanQrPage : ContentPage
 			{
 				TapToFocusEnabled = true,
 				VibrationOnDetected = false,
+				BarcodeSymbologies = BarcodeFormats.QRCode,
+				CaptureQuality = CaptureQuality.Medium,
 			};
 			_modernScanner.OnDetectionFinished += OnDetectionFinished;
 			CameraHost.Content = _modernScanner;

--- a/TRViS/RootPages/StartGridView.xaml.cs
+++ b/TRViS/RootPages/StartGridView.xaml.cs
@@ -99,18 +99,13 @@ public partial class StartGridView : Grid
 			});
 
 		// The in-app QR scanner (ScanQrPage / BarcodeScanning) is compiled on
-		// phone TFMs only, and its native backend has a higher OS floor than the
-		// app itself (MLKit needs Android 24, Vision/AVFoundation needs iOS 15.1;
-		// the app supports Android 23 / iOS 12.2). Hide the entry button where
-		// the scanner isn't available so those users never reach a CameraView
-		// that would crash. Everything else keeps the manual URL / file flow.
+		// phone TFMs only. Android's MLKit backend needs Android 24. On iOS
+		// 15.1+ BarcodeScanning.Native.Maui is used; iOS 12.2-15.0 uses the
+		// lazily-created AVFoundation fallback in ScanQrPage.
 #if ANDROID
 		if (!OperatingSystem.IsAndroidVersionAtLeast(24))
 			ScanQrButton.IsVisible = false;
-#elif IOS
-		if (!OperatingSystem.IsIOSVersionAtLeast(15, 1))
-			ScanQrButton.IsVisible = false;
-#else
+#elif !IOS
 		ScanQrButton.IsVisible = false;
 #endif
 	}

--- a/TRViS/TRViS.csproj
+++ b/TRViS/TRViS.csproj
@@ -36,9 +36,10 @@
 		<NeutralLanguage>en</NeutralLanguage>
 		<NoWarn>$(NoWarn);NU1608</NoWarn>
 		<ValidateXcodeVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">false</ValidateXcodeVersion>
-		<!-- In-app QR scanner (BarcodeScanning.Native.Maui) is phone-only: it uses
-		     native MLKit (Android) / Vision (iOS). The scan button and ScanQrPage
-		     are compiled only for these TFMs; desktop keeps the manual-URL flow.
+		<!-- In-app QR scanner is phone-only. Android and iOS 15.1+ use
+		     BarcodeScanning.Native.Maui; iOS 12.2-15.0 uses an AVFoundation
+		     fallback. The scan page is compiled only for phone TFMs; desktop
+		     keeps the manual-URL flow.
 		     The library also supports MacCatalyst/Windows, but scanning a QR with a
 		     desktop webcam is not a target workflow and pulling the native/ZXingCpp
 		     dependencies into those builds is avoided. -->
@@ -140,9 +141,9 @@
 			Include="BarcodeScanning.Native.Maui"
 			Version="3.0.4" />
 	</ItemGroup>
-	<!-- The scanner page references BarcodeScanning's CameraView, whose assembly
-	     is only referenced on mobile TFMs. Exclude the page (and its generated
-	     XAML partial) from desktop builds so they still compile. -->
+	<!-- The scanner page's modern backend references BarcodeScanning.CameraView,
+	     whose assembly is only referenced on mobile TFMs. Exclude the page (and
+	     its generated XAML partial) from desktop builds so they still compile. -->
 	<ItemGroup Condition="'$(IsMobileTarget)' != 'true'">
 		<MauiXaml Remove="RootPages\ScanQrPage.xaml" />
 		<Compile Remove="RootPages\ScanQrPage.xaml.cs" />


### PR DESCRIPTION
## Summary
- Adds an AVFoundation-based QR scanner for iOS 12 devices that predate the modern `BarcodeScanning.Native.Maui` camera view.
- Fixes issues found while testing on real iOS 12.5.8 hardware:
  - Waits for `CameraHost.HandlerChanged` before grabbing its native `PlatformView`, instead of assuming the handler is already attached when `OnAppearing` runs (previously threw immediately).
  - Moves `AVCaptureSession` teardown in `Dispose()` onto the capture queue asynchronously so callers (e.g. QR-accept → AppLink navigation) aren't blocked for several seconds by a slow hardware stop; wraps it in try/catch since it now runs unguarded on a background GCD queue.
  - Polls for `CameraHost`'s real size for up to ~2s after configuring the session, since MAUI's layout arrange can complete without re-firing `SizeChanged` once the handler already exists — otherwise leaving the preview permanently zero-sized (no visible video).
  - Reports the previously-silent `PopModalAsync` and native QR delegate callback failures to Crashlytics.

## Test plan
- [x] Builds cleanly for `net10.0-ios` and `net10.0-android`
- [x] Verified on real iPad Air 2 (iOS 12.5.8): scanner opens, camera preview shows, QR scan is accepted and navigates to the AppLink flow, close button responds promptly
- [ ] Reviewer: spot-check the modern (iOS 15.1+/Android) scanner path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AGTup8R2PPrAmcaSNe2xD