### PR TITLE
fix(location): StartOperation command now actually starts the run

### DIFF
--- a/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
+++ b/TRViS.DTAC.Logic.Tests/VerticalStylePagePresenterTests.cs
@@ -37,6 +37,12 @@ public class VerticalStylePagePresenterTests
 		public event EventHandler<GpsLocationUpdate>? GpsLocationUpdated;
 		public event EventHandler<Exception>? ExceptionThrown;
 		public event EventHandler<bool>? IsEnabledChanged;
+		public event EventHandler<bool>? OperationStartRequested;
+
+		public void RaiseOperationStartRequested(bool start)
+		{
+			OperationStartRequested?.Invoke(this, start);
+		}
 
 		public void RaiseCanUseServiceChanged(bool value)
 		{
@@ -881,6 +887,42 @@ public class VerticalStylePagePresenterTests
 		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning,
 			"non-network-driven enable must NOT auto-start the run");
 		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+	}
+
+	// 回帰テスト (#309): OperationCommand "StartOperation" を受信しても
+	// NetworkSyncServiceCanStart が false (=SyncedData で CanStart が来ていない)
+	// だと、位置情報が ON になるだけで運行 (IsRunning) が開始しなかった不具合の防止。
+	// StartOperation は NetworkSyncServiceCanStart に関係なく運行を開始する必要がある。
+	[Fact]
+	public void OperationStartRequested_StartsRun_RegardlessOfNetworkSyncCanStart()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+		locationService.NetworkSyncServiceCanStart = false;
+
+		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		locationService.RaiseOperationStartRequested(true);
+
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning,
+			"StartOperation command must start the run even when NetworkSyncServiceCanStart is false");
+		Assert.True(presenter.CurrentState.TimetableViewState.IsRunStarted);
+		Assert.True(presenter.CurrentState.TimetableViewState.IsLocationServiceEnabled);
+	}
+
+	// 回帰テスト (#309): OperationCommand "EndOperation" で運行が終了すること。
+	[Fact]
+	public void OperationStartRequested_False_EndsRun()
+	{
+		var (presenter, locationService, _, _, appVm) = CreatePresenter();
+		appVm.SelectedTrainData = CreateTrainData(rowCount: 3);
+		locationService.RaiseOperationStartRequested(true);
+		Assert.True(presenter.CurrentState.PageHeaderState.IsRunning);
+
+		locationService.RaiseOperationStartRequested(false);
+
+		Assert.False(presenter.CurrentState.PageHeaderState.IsRunning);
+		Assert.False(presenter.CurrentState.TimetableViewState.IsRunStarted);
 	}
 
 	// 回帰テスト: サーバ駆動の自動 ON は presenter 生成前に発火する

--- a/TRViS.DTAC.Logic/Abstractions/IDtacLocationServiceController.cs
+++ b/TRViS.DTAC.Logic/Abstractions/IDtacLocationServiceController.cs
@@ -41,4 +41,13 @@ public interface IDtacLocationServiceController : ILocationService
 	/// position-marker gate opens for server-driven enablement.
 	/// </summary>
 	event EventHandler<bool>? IsEnabledChanged;
+
+	/// <summary>
+	/// Fired when a server-driven StartOperation/EndOperation command is
+	/// received. The argument is true for StartOperation (運行開始), false
+	/// for EndOperation (運行終了). Distinct from <see cref="IsEnabledChanged"/>
+	/// because EnableLocationService/DisableLocationService commands only
+	/// toggle GPS tracking and must not start/stop the run.
+	/// </summary>
+	event EventHandler<bool>? OperationStartRequested;
 }

--- a/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
+++ b/TRViS.DTAC.Logic/Presenter/VerticalStylePagePresenter.cs
@@ -49,6 +49,7 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 		_locationService.LocationStateChanged += OnLocationStateChanged_Internal;
 		_locationService.GpsLocationUpdated += OnGpsLocationUpdated_Internal;
 		_locationService.IsEnabledChanged += OnLocationServiceIsEnabledChanged_Internal;
+		_locationService.OperationStartRequested += OnOperationStartRequested;
 		_appViewModelProvider.PropertyChanged += OnAppViewModelPropertyChanged;
 
 		// Sync initial train: PropertyChanged may have fired before this presenter subscribed.
@@ -393,6 +394,32 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 		}
 	}
 
+	/// <summary>
+	/// Called when a server-driven StartOperation/EndOperation command is
+	/// received. Unlike EnableLocationService/DisableLocationService (which
+	/// only flip <see cref="OnLocationServiceIsEnabledChanged_Internal"/>'s
+	/// gated auto-start), this explicitly starts/stops the run regardless of
+	/// <see cref="IDtacLocationServiceController.NetworkSyncServiceCanStart"/>.
+	/// </summary>
+	private void OnOperationStartRequested(object? sender, bool start)
+	{
+		if (start)
+		{
+			if (!_currentState.PageHeaderState.IsRunning)
+			{
+				SetIsRunning(true);
+			}
+			if (!_currentState.TimetableViewState.IsLocationServiceEnabled)
+			{
+				SetLocationServiceEnabled(true);
+			}
+		}
+		else if (_currentState.PageHeaderState.IsRunning)
+		{
+			SetIsRunning(false);
+		}
+	}
+
 	private void OnLocationServiceCanUseChanged(object? sender, bool canUse)
 	{
 		_currentState.PageHeaderState.CanUseLocationService = canUse;
@@ -429,6 +456,7 @@ public sealed class VerticalStylePagePresenter : ILocationMarkerStateSource, IDi
 		_locationService.LocationStateChanged -= OnLocationStateChanged_Internal;
 		_locationService.GpsLocationUpdated -= OnGpsLocationUpdated_Internal;
 		_locationService.IsEnabledChanged -= OnLocationServiceIsEnabledChanged_Internal;
+		_locationService.OperationStartRequested -= OnOperationStartRequested;
 		_appViewModelProvider.PropertyChanged -= OnAppViewModelPropertyChanged;
 	}
 }

--- a/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
+++ b/TRViS.LocationService.Tests/LocationServiceIntegrationTests.cs
@@ -77,6 +77,8 @@ internal class FakeNetworkSyncService : NetworkSyncServiceBase
 
 	public void SimulateProcessSyncedData(SyncedData syncedData) => ProcessSyncedData(syncedData);
 
+	public new void RaiseOperationCommandReceived(OperationCommand command) => base.RaiseOperationCommandReceived(command);
+
 	protected override Task<SyncedData> GetSyncedDataAsync(CancellationToken token)
 	{
 		OnGetSyncedData?.Invoke();
@@ -734,5 +736,76 @@ public class LocationServiceIntegrationTests
 		Assert.That(_locationService.CurrentService!.CurrentStationIndex,
 			Is.InRange(0, finalStations.Length - 1),
 			"CurrentStationIndex must stay within the bounds of whichever station array ended up current");
+	}
+
+	// -------------------------------------------------------
+	// 21. 回帰テスト (#309): OperationCommand "StartOperation" は
+	//     IsEnabled=true にするだけでなく、OperationStartRequested(true) も
+	//     発火しなければならない。これが無いと、CanStart が来ていない
+	//     (SyncedData 未受信の) 状態では運行 (IsRunning) が開始しない。
+	// -------------------------------------------------------
+	[Test]
+	public void OperationCommand_StartOperation_EnablesLocationAndRaisesOperationStartRequested()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		bool? raisedStart = null;
+		_locationService.OperationStartRequested += (_, start) => raisedStart = start;
+
+		fakeNs.RaiseOperationCommandReceived(new OperationCommand { Action = OperationCommandType.StartOperation });
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_locationService.IsEnabled, Is.True);
+			Assert.That(raisedStart, Is.True);
+		});
+	}
+
+	// -------------------------------------------------------
+	// 22. 回帰テスト (#309): OperationCommand "EndOperation" は
+	//     IsEnabled=false にするだけでなく、OperationStartRequested(false) も
+	//     発火しなければならない。
+	// -------------------------------------------------------
+	[Test]
+	public void OperationCommand_EndOperation_DisablesLocationAndRaisesOperationStartRequested()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+		fakeNs.RaiseOperationCommandReceived(new OperationCommand { Action = OperationCommandType.StartOperation });
+
+		bool? raisedStart = null;
+		_locationService.OperationStartRequested += (_, start) => raisedStart = start;
+
+		fakeNs.RaiseOperationCommandReceived(new OperationCommand { Action = OperationCommandType.EndOperation });
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_locationService.IsEnabled, Is.False);
+			Assert.That(raisedStart, Is.False);
+		});
+	}
+
+	// -------------------------------------------------------
+	// 23. EnableLocationService / DisableLocationService は位置情報のみを
+	//     切り替え、OperationStartRequested は発火しないこと
+	//     (運行の開始/終了と GPS on/off の切り替えは別物であるべき)。
+	// -------------------------------------------------------
+	[Test]
+	public void OperationCommand_EnableDisableLocationService_DoesNotRaiseOperationStartRequested()
+	{
+		var fakeNs = new FakeNetworkSyncService();
+		_locationService.SetNetworkSyncService(fakeNs);
+
+		bool raised = false;
+		_locationService.OperationStartRequested += (_, _) => raised = true;
+
+		fakeNs.RaiseOperationCommandReceived(new OperationCommand { Action = OperationCommandType.EnableLocationService });
+		Assert.That(_locationService.IsEnabled, Is.True);
+
+		fakeNs.RaiseOperationCommandReceived(new OperationCommand { Action = OperationCommandType.DisableLocationService });
+		Assert.That(_locationService.IsEnabled, Is.False);
+
+		Assert.That(raised, Is.False);
 	}
 }

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -48,6 +48,12 @@ public partial class LocationService : IDisposable
 	public event EventHandler<DiagramInfo>? DiagramInfoUpdated;
 	public event EventHandler<SelectTrainCommand>? TrainSelectionRequested;
 	public event EventHandler<OperationCommand>? OperationCommandReceived;
+	/// <summary>
+	/// StartOperation/EndOperation コマンドを受信したときに発火する。
+	/// true=StartOperation(運行開始), false=EndOperation(運行終了)。
+	/// EnableLocationService/DisableLocationService (位置情報 ON/OFF のみ) では発火しない。
+	/// </summary>
+	public event EventHandler<bool>? OperationStartRequested;
 	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
 	public event EventHandler<NotificationData>? NotificationReceived;
 	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
@@ -200,7 +206,9 @@ void OnIsEnabledChanged(bool value)
 
 	/// <summary>
 	/// 運行操作コマンドを受信したときの処理。
-	/// 位置情報サービスの有効/無効はここで適用し、運行開始/終了は AppViewModel 側に委譲する。
+	/// 位置情報サービスの有効/無効はここで適用する。運行開始/終了そのもの
+	/// (PageHeaderState.IsRunning 等) は <see cref="OperationStartRequested"/>
+	/// 経由で Presenter 側に委譲する。
 	/// </summary>
 	void OnOperationCommandReceived(object? sender, OperationCommand cmd)
 	{
@@ -208,13 +216,19 @@ void OnIsEnabledChanged(bool value)
 		switch (cmd.Action)
 		{
 			case OperationCommandType.EnableLocationService:
-			case OperationCommandType.StartOperation:
-				// StartOperation は位置情報サービスを ON にすることで運行を開始する
 				IsEnabled = true;
 				break;
+			case OperationCommandType.StartOperation:
+				// StartOperation は位置情報サービス ON に加えて運行開始そのものも要求する
+				IsEnabled = true;
+				OperationStartRequested?.Invoke(sender, true);
+				break;
 			case OperationCommandType.DisableLocationService:
+				IsEnabled = false;
+				break;
 			case OperationCommandType.EndOperation:
 				IsEnabled = false;
+				OperationStartRequested?.Invoke(sender, false);
 				break;
 		}
 		OperationCommandReceived?.Invoke(sender, cmd);

--- a/TRViS/DTAC/Adapters/LocationServiceAdapter.cs
+++ b/TRViS/DTAC/Adapters/LocationServiceAdapter.cs
@@ -77,6 +77,12 @@ internal class LocationServiceAdapter : IDtacLocationServiceController
 
 	public event EventHandler<bool>? IsEnabledChanged;
 
+	public event EventHandler<bool>? OperationStartRequested
+	{
+		add => _locationService.OperationStartRequested += value;
+		remove => _locationService.OperationStartRequested -= value;
+	}
+
 	public event EventHandler<Exception>? ExceptionThrown
 	{
 		add => _locationService.ExceptionThrown += value;

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -365,8 +365,10 @@ public partial class AppViewModel : ObservableObject
 		locationService.NavigateToHomeRequested += OnNavigateToHomeRequested;
 		locationService.OpenTimetableRequested += OnOpenTimetableRequested;
 		// NotificationReceived / OperationCommandReceived / ServerInfo は
-		// LocationService 側で受信される。OperationCommand の動作 (位置情報 ON/OFF) は
-		// LocationService が直接適用する。Notification / ServerInfo の UI 表示は
+		// LocationService 側で受信される。OperationCommand のうち位置情報 ON/OFF は
+		// LocationService が直接適用し、運行開始/終了そのものは
+		// LocationService.OperationStartRequested 経由で DTAC.Adapters.LocationServiceAdapter
+		// → VerticalStylePagePresenter に委譲される。Notification / ServerInfo の UI 表示は
 		// 個別画面側で必要に応じて購読する。
 	}
 


### PR DESCRIPTION
## Summary

- `OperationCommand` `StartOperation`/`EndOperation` previously only toggled `LocationService.IsEnabled` (GPS on/off). The run itself (`PageHeaderState.IsRunning` / `TimetableViewState.IsRunStarted`) only auto-started as a side effect gated behind `NetworkSyncServiceCanStart`, which is set by a *separate* `SyncedData` message. So a server sending `StartOperation` without a preceding `SyncedData` with `CanStart=true` flipped location on/off but never started the operation — matching the reported behavior in #309.
- Added a dedicated `OperationStartRequested` event on `LocationService`, raised only for `StartOperation`(`true`)/`EndOperation`(`false`), distinct from the location on/off toggle.
- Plumbed the event through `IDtacLocationServiceController` → `LocationServiceAdapter` → `VerticalStylePagePresenter`, which now calls `SetIsRunning(true/false)` directly, independent of the `CanStart` gate.

## Why

`EnableLocationService`/`DisableLocationService` and `StartOperation`/`EndOperation` are semantically different commands (GPS toggle vs. run start/stop) but were collapsed into the same handling path, and the run-start side effect only fired when data happened to arrive in a particular order/combination.

## Test plan

- [x] `TRViS.LocationService.Tests`: new tests confirming `StartOperation`/`EndOperation` raise `OperationStartRequested` and toggle `IsEnabled`, while `EnableLocationService`/`DisableLocationService` do not raise it (51/51 passing).
- [x] `TRViS.DTAC.Logic.Tests`: new presenter tests confirming `StartOperation` starts the run even when `NetworkSyncServiceCanStart` is false, and `EndOperation` stops it (282/282 passing).
- [x] Built the main MAUI app (`net10.0-maccatalyst`) to confirm `LocationServiceAdapter.cs` compiles against the updated interface.

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)