### PR TITLE
fix(network-sync): fall back to device time when server sends null Time_ms

### DIFF
--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
@@ -63,6 +63,19 @@ public sealed class ReferenceServerClient : IDisposable
 		resp.EnsureSuccessStatusCode();
 	}
 
+	/// <summary>
+	/// Time_ms を明示的に JSON null にリセットする (#308 回帰テスト用)。
+	/// <see cref="SetStateAsync"/> は <see cref="JsonIgnoreCondition.WhenWritingNull"/> により
+	/// null 引数のプロパティを送信 JSON から除外してしまうため、"未指定" と "明示的な null" を
+	/// 区別できない。このメソッドはリテラル null を送るための専用ヘルパー。
+	/// </summary>
+	public async Task SetStateTimeMsNullAsync(CancellationToken ct = default)
+	{
+		var content = new StringContent("{\"Time_ms\":null}", Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/state", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
 	public async Task ResetAsync(CancellationToken ct = default)
 	{
 		var resp = await _http.PostAsync("/control/reset", null, ct);
@@ -396,7 +409,7 @@ public sealed class ReferenceServerClient : IDisposable
 // ================================================================
 
 public sealed record ServerStateDto(
-	[property: JsonPropertyName("Time_ms")] long Time_ms,
+	[property: JsonPropertyName("Time_ms")] long? Time_ms,
 	[property: JsonPropertyName("Location_m")] double? Location_m,
 	[property: JsonPropertyName("CanStart")] bool CanStart,
 	[property: JsonPropertyName("Latitude_deg")] double? Latitude_deg = null,

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -227,6 +227,46 @@ public class WebSocketIntegrationTests
 		}
 	}
 
+	/// <summary>
+	/// #308: サーバーが Time_ms を JSON null で送ってきても (シナリオ未読込等)、
+	/// 受信ループが例外で落ちず、端末時刻へフォールバックして TimeChanged が
+	/// 発火し続けることを確認する。修正前は JsonElement.GetInt64() が
+	/// InvalidOperationException を投げ、以後の SyncedData が一切処理されなく
+	/// なり時計が固まっていた。
+	/// </summary>
+	[Test]
+	public async Task SyncedData_NullTimeMs_FallsBackToLocalTime_TimeChangedKeepsFiring()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var receivedTimes = new List<int>();
+			service.TimeChanged += (_, t) => receivedTimes.Add(t);
+
+			// Time_ms を明示的に null にしてブロードキャスト。例外で受信ループが
+			// 落ちていれば、以後 SyncedData を送っても TimeChanged は二度と発火しない。
+			await _control.SetStateTimeMsNullAsync();
+			await _control.BroadcastSyncedDataAsync();
+			await Task.Delay(200);
+
+			await _control.SetStateAsync(time_ms: 3_600_000, canStart: true);
+			await _control.BroadcastSyncedDataAsync();
+
+			await ReferenceServerClient.WaitForConditionAsync(
+				() => Task.FromResult(receivedTimes.Count >= 1),
+				timeoutMs: 5000
+			);
+			Assert.That(receivedTimes, Is.Not.Empty,
+				"TimeChanged should keep firing after a null Time_ms SyncedData message instead of the receive loop dying silently");
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
 	[Test]
 	public async Task SyncedData_CanStart_PropagatedCorrectly()
 	{
@@ -2342,6 +2382,52 @@ public class WebSocketIntegrationTests
 
 			// Format=null は端末既定にリセット
 			Assert.That(cmd.Format, Is.Null);
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	/// <summary>
+	/// #308: TimeFormat コマンド受信後も SyncedData による TimeChanged (時計) が
+	/// 止まらないことを確認する。TimeFormat 処理で受信ループが例外を投げて
+	/// 落ちていないか (接続断/再接続に迂回していないか) を検証する。
+	/// </summary>
+	[Test]
+	public async Task TimeFormat_ThenSyncedData_TimeChangedKeepsFiring()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var receivedTimes = new List<int>();
+			service.TimeChanged += (_, t) => receivedTimes.Add(t);
+
+			await _control.SetStateAsync(time_ms: 36_000_000, canStart: true);
+			await _control.BroadcastSyncedDataAsync();
+			await ReferenceServerClient.WaitForConditionAsync(
+				() => Task.FromResult(receivedTimes.Count >= 1),
+				timeoutMs: 5000
+			);
+
+			await _control.BroadcastTimeFormatAsync(format: "HH:mm");
+
+			for (int i = 0; i < 3; i++)
+			{
+				long time_ms = (36_000L + (i + 1) * 60_000L) * 1000;
+				await _control.SetStateAsync(time_ms: time_ms, canStart: true);
+				await _control.BroadcastSyncedDataAsync();
+				await Task.Delay(100);
+			}
+
+			await ReferenceServerClient.WaitForConditionAsync(
+				() => Task.FromResult(receivedTimes.Count >= 4),
+				timeoutMs: 5000
+			);
+			Assert.That(receivedTimes, Has.Count.GreaterThanOrEqualTo(4),
+				"TimeChanged should keep firing for SyncedData ticks received after a TimeFormat command");
 		}
 		finally
 		{

--- a/TRViS.NetworkSyncService/HttpNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/HttpNetworkSyncService.cs
@@ -155,13 +155,19 @@ public class HttpNetworkSyncService : NetworkSyncServiceBase
 		catch (KeyNotFoundException) { }
 		catch (FormatException) { }
 
-		long time_ms = 0;
+		// Time_ms が null で届く場合 (シナリオ未読込等) は端末時刻で代替する。
+		// GetInt64() は Null に対して InvalidOperationException を投げるため、
+		// 捕捉せず放置すると以後のポーリングが例外で止まり時計が固まる (#308)。
+		long time_ms = (long)DateTime.Now.TimeOfDay.TotalMilliseconds;
 		try
 		{
-			time_ms = root.GetProperty(TIME_MS_JSON_KEY).GetInt64();
+			JsonElement time_ms_element = root.GetProperty(TIME_MS_JSON_KEY);
+			if (time_ms_element.ValueKind != JsonValueKind.Null)
+				time_ms = time_ms_element.GetInt64();
 		}
 		catch (KeyNotFoundException) { }
 		catch (FormatException) { }
+		catch (InvalidOperationException) { }
 
 		// Startできない状態が特殊なため、デフォルトでtrueとする
 		bool canStart = true;

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -360,13 +360,22 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 		catch (KeyNotFoundException) { }
 		catch (FormatException) { }
 
-		long time_ms = 0;
+		// サーバーがまだ時刻を確定できない間 (シナリオ未読込等) は Time_ms が
+		// null または欠落して届くことがある。JsonElement.GetInt64() は Null に対して
+		// InvalidOperationException を投げ、これが未捕捉のまま WebSocket 受信ループを
+		// 抜けてしまうと、以後の SyncedData が一切処理されず時計が固まる (#308)。
+		// HTTP 実装 (GetSyncedDataAsync の 204/空ボディ処理) と同様に端末時刻で
+		// 代替し、クライアント側の時計を止めない。
+		long time_ms = (long)DateTime.Now.TimeOfDay.TotalMilliseconds;
 		try
 		{
-			time_ms = root.GetProperty(TIME_MS_JSON_KEY).GetInt64();
+			JsonElement time_ms_element = root.GetProperty(TIME_MS_JSON_KEY);
+			if (time_ms_element.ValueKind != JsonValueKind.Null)
+				time_ms = time_ms_element.GetInt64();
 		}
 		catch (KeyNotFoundException) { }
 		catch (FormatException) { }
+		catch (InvalidOperationException) { }
 
 		bool canStart = true;
 		try

--- a/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
+++ b/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
@@ -19,7 +19,7 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 
 	// --- サーバー状態 (immutable record + lock で一貫性を保証) ---
 	private sealed record ServerState(
-		long Time_ms,
+		long? Time_ms,
 		double Location_m,
 		bool CanStart,
 		double? Latitude_deg,
@@ -194,8 +194,8 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 				double? longitude = _state.Longitude_deg;
 				double? accuracy = _state.Accuracy_m;
 
-				if (root.TryGetProperty("Time_ms", out var t) && t.ValueKind != JsonValueKind.Null)
-					time = t.GetInt64();
+				if (root.TryGetProperty("Time_ms", out var t))
+					time = t.ValueKind == JsonValueKind.Null ? null : t.GetInt64();
 				if (root.TryGetProperty("Location_m", out var l))
 					location = l.ValueKind == JsonValueKind.Null ? double.NaN : l.GetDouble();
 				if (root.TryGetProperty("CanStart", out var cs) && cs.ValueKind != JsonValueKind.Null)


### PR DESCRIPTION
## Summary
- Fixes #308: changing the time-display format via WS could leave the DTAC clock permanently frozen with no visible error.
- Root cause: `JsonElement.GetInt64()` throws `InvalidOperationException` on a JSON `null` `Time_ms` value. This wasn't caught by the existing `catch (KeyNotFoundException)/catch (FormatException)` in `WebSocketNetworkSyncService.ProcessSyncedDataMessage` (and the equivalent `HttpNetworkSyncService` parsing). For the WebSocket path the exception escaped into the receive loop's generic handler, silently halting all further `SyncedData` processing — the clock stops advancing and the disconnect alert can itself fail silently (fire-and-forget), so nothing visible happens.
- Fix: when `Time_ms` is `null`, both parsers now fall back to the device's local wall-clock time, matching the convention `HttpNetworkSyncService` already used for its 204/empty-body case.
- Extended the reference server + integration test control API to support broadcasting an explicit `Time_ms: null`, and added regression tests:
  - `SyncedData_NullTimeMs_FallsBackToLocalTime_TimeChangedKeepsFiring` (fails without the fix, passes with it)
  - `TimeFormat_ThenSyncedData_TimeChangedKeepsFiring` (guards the originally reported scenario)

## Test plan
- [x] `dotnet test TRViS.NetworkSyncService.IntegrationTests` — 101/101 passing
- [x] `dotnet test TRViS.DTAC.Logic.Tests` — 280/280 passing
- [x] Verified the new regression test fails on the pre-fix code and passes after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RexkXbcEPA24pU9Ux7KrD4