### PR TITLE
fix(ios): hop back to main thread after camera permission prompt

### DIFF
--- a/TRViS/Platforms/iOS/ScanQrPage.iOS.cs
+++ b/TRViS/Platforms/iOS/ScanQrPage.iOS.cs
@@ -32,6 +32,17 @@ public partial class ScanQrPage
 		{
 			bool granted =
 				await AVCaptureDevice.RequestAccessForMediaTypeAsync(AVAuthorizationMediaType.Video);
+
+			// AVCaptureDevice's completion handler fires on an arbitrary
+			// dispatch queue (Apple's documented behavior, not guaranteed to
+			// be the main queue), so execution can resume here off the main
+			// thread. Everything below this point (GetNativeCameraHostAsync,
+			// Configure()) touches UIView/autolayout state, which UIKit
+			// requires to happen on the main thread -- hop back explicitly
+			// instead of relying on the awaited continuation's thread.
+			if (!MainThread.IsMainThread)
+				await MainThread.InvokeOnMainThreadAsync(() => { });
+
 			if (!granted)
 				return false;
 		}


### PR DESCRIPTION
## Summary
- Fixes #306 — "modifying the autolayout engine from a background thread" warning seen while testing the iOS 12 legacy QR scanner fallback.
- `AVCaptureDevice.RequestAccessForMediaTypeAsync`'s completion handler is documented by Apple to fire on an arbitrary background dispatch queue, not necessarily the main queue. On a fresh (`NotDetermined`) permission prompt, execution could therefore resume off the main thread right where `StartLegacyIosScannerAsync` goes on to build the camera preview UI (`Configure()`'s `InsertSubview` + `Frame` assignment), which is exactly the kind of UIKit/autolayout mutation that must happen on the main thread.
- Adds an explicit `MainThread.InvokeOnMainThreadAsync` hop immediately after that await, only when not already on the main thread, so all the downstream UI setup is guaranteed to run on main regardless of which queue completed the permission request.

## Test plan
- [x] `dotnet build TRViS/TRViS.csproj -f net10.0-ios` succeeds with no new warnings/errors.
- [ ] Manually re-test the "Scan QR" flow on real iOS 12 hardware (fresh camera-permission prompt) to confirm the autolayout warning no longer appears in the device log.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01QQLM7Ssh495AkyGKQWHWY9