### PR TITLE
fix(sync): preserve train selection and running state across WS reconnect

### DIFF
--- a/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
+++ b/TRViS.Core.Tests/TimetableSelectionManagerTests.cs
@@ -310,6 +310,174 @@ public class TimetableSelectionManagerTests
 		Assert.Null(manager.OrderedTrainDataList);
 	}
 
+	// ----- ReconnectLoader (#311: WS再接続後も行路IDが一致すれば内部状態を維持) -----
+
+	[Fact]
+	public void ReconnectLoader_PreservesSelection_WhenWorkGroupWorkTrainIdsAllStillPresent()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		CommitFirstSelection(manager);
+		manager.SelectedWork = loader.WorkLists["wg-1"][1];
+		manager.SelectedTrainData = loader.TrainListsByWorkId["w-1-1"][1];
+
+		// 再接続: 新しい Loader インスタンス (同じ WorkGroupId/WorkId/TrainId を含む)
+		var reconnectLoader = new FakeLoader();
+		reconnectLoader.Setup(BuildSampleData());
+		manager.ReconnectLoader(reconnectLoader);
+		Assert.True(manager.IsAwaitingReconnectData);
+
+		// この時点ではまだ選択はクリアされていない (新データ到着前)
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-1-1", manager.SelectedTrainData?.Id);
+
+		// 時刻表再配信 (TimetableUpdated -> Refresh) を模す
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-1-1", manager.SelectedTrainData?.Id);
+		Assert.False(manager.IsAwaitingReconnectData); // 判定が確定した (呼び出し側はここで復元判定してよい)
+	}
+
+	[Fact]
+	public void ReconnectLoader_ClearsToUnselected_WhenWorkGroupIdMissing_DoesNotFallbackToFirst()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildMultiWgSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		manager.SelectedWorkGroup = loader.WorkGroups[1]; // wg-2
+
+		// 再接続後、wg-2 が存在しないデータが再配信される
+		var reconnectLoader = new FakeLoader();
+		reconnectLoader.Setup(BuildSampleData()); // wg-1 のみ
+		manager.ReconnectLoader(reconnectLoader);
+		manager.Refresh();
+
+		// 通常の Refresh() (フォールバック挙動) と異なり、先頭 (wg-1) へは
+		// フォールバックせず未選択のままにする。
+		Assert.Null(manager.SelectedWorkGroup);
+		Assert.Null(manager.SelectedWork);
+		Assert.Null(manager.SelectedTrainData);
+	}
+
+	[Fact]
+	public void ReconnectLoader_ClearsToUnselected_WhenWorkIdMissing_DoesNotFallbackToFirst()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		CommitFirstSelection(manager);
+		manager.SelectedWork = loader.WorkLists["wg-1"][1]; // w-1-1
+
+		var data = BuildSampleData();
+		data.WorkLists["wg-1"] = [data.WorkLists["wg-1"][0]]; // w-1-1 を消す
+		data.TrainListsByWorkId.Remove("w-1-1");
+		var reconnectLoader = new FakeLoader();
+		reconnectLoader.Setup(data);
+		manager.ReconnectLoader(reconnectLoader);
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id); // WorkGroup は維持
+		Assert.Null(manager.SelectedWork); // 先頭 (w-1-0) へはフォールバックしない
+		Assert.Null(manager.SelectedTrainData);
+	}
+
+	[Fact]
+	public void ReconnectLoader_ClearsToUnselected_WhenTrainIdMissing_DoesNotFallbackToFirst()
+	{
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		CommitFirstSelection(manager);
+		manager.SelectedTrainData = loader.TrainListsByWorkId["w-1-0"][1]; // t-1-0-1
+
+		var data = BuildSampleData();
+		data.TrainListsByWorkId["w-1-0"] = [data.TrainListsByWorkId["w-1-0"][0]]; // t-1-0-1 を消す
+		data.TrainDataById.Remove("t-1-0-1");
+		var reconnectLoader = new FakeLoader();
+		reconnectLoader.Setup(data);
+		manager.ReconnectLoader(reconnectLoader);
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id); // WorkGroup / Work は維持
+		Assert.Equal("w-1-0", manager.SelectedWork?.Id);
+		Assert.Null(manager.SelectedTrainData); // 先頭 (t-1-0-0) へはフォールバックしない
+	}
+
+	[Fact]
+	public void ReconnectLoader_WaitsForData_WhenNarrowScopeUpdateArrivesBeforeFullRedelivery()
+	{
+		// 再接続直後、サーバーがまだ全体 (Scope.All) を再配信しておらず、
+		// (何らかの理由で) 部分的な更新が先に TimetableUpdated として届き、
+		// Loader からはまだ空リストしか読めない場合。ID が「消えた」と誤判定して
+		// 選択を投げ捨てず、次の Refresh (実データ到着後) まで判定を持ち越す。
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		CommitFirstSelection(manager);
+		manager.SelectedWork = loader.WorkLists["wg-1"][1];
+		manager.SelectedTrainData = loader.TrainListsByWorkId["w-1-1"][1];
+
+		var reconnectLoader = new FakeLoader();
+		reconnectLoader.Setup(new SampleData()); // まだ何も届いていない (空)
+		manager.ReconnectLoader(reconnectLoader);
+		Assert.True(manager.IsAwaitingReconnectData);
+		manager.Refresh(); // 空データでの最初の Refresh -> 判定を持ち越すだけ、選択は消さない
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-1-1", manager.SelectedTrainData?.Id);
+		// 呼び出し側 (#311: 運行状態の復元判定) は、このフラグが true の間は
+		// 「一致」を確定として扱ってはならない (実データ未着の可能性があるため)。
+		Assert.True(manager.IsAwaitingReconnectData);
+
+		// 実データが届く
+		reconnectLoader.Setup(BuildSampleData());
+		manager.Refresh();
+
+		Assert.Equal("wg-1", manager.SelectedWorkGroup?.Id);
+		Assert.Equal("w-1-1", manager.SelectedWork?.Id);
+		Assert.Equal("t-1-1-1", manager.SelectedTrainData?.Id);
+		Assert.False(manager.IsAwaitingReconnectData); // 判定が確定した
+	}
+
+	[Fact]
+	public void ReconnectLoader_OnlyAffectsNextSingleRefresh()
+	{
+		// strict-match は再接続直後の1回だけ適用され、以降の Refresh() は
+		// 通常どおり (リアルタイム編集向けの) フォールバック挙動に戻る。
+		var loader = new FakeLoader();
+		loader.Setup(BuildSampleData());
+
+		var manager = new TimetableSelectionManager { Loader = loader };
+		CommitFirstSelection(manager);
+		manager.SelectedTrainData = loader.TrainListsByWorkId["w-1-0"][1]; // t-1-0-1
+
+		var reconnectLoader = new FakeLoader();
+		reconnectLoader.Setup(BuildSampleData());
+		manager.ReconnectLoader(reconnectLoader);
+		manager.Refresh(); // 1st refresh after reconnect: strict match, all ids present -> preserved
+
+		Assert.Equal("t-1-0-1", manager.SelectedTrainData?.Id);
+
+		// 通常のリアルタイム編集で Train が消える -> 通常どおり先頭にフォールバック
+		var data = BuildSampleData();
+		data.TrainListsByWorkId["w-1-0"] = [data.TrainListsByWorkId["w-1-0"][0]];
+		data.TrainDataById.Remove("t-1-0-1");
+		reconnectLoader.Setup(data);
+		manager.Refresh();
+
+		Assert.Equal("t-1-0-0", manager.SelectedTrainData?.Id);
+	}
+
 	// ----- ヘルパー -----
 
 	private static TrainData SimpleTrain(string id) =>

--- a/TRViS.Core/TimetableSelectionManager.cs
+++ b/TRViS.Core/TimetableSelectionManager.cs
@@ -233,7 +233,11 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 	/// そのまま選択を維持する (リアルタイム更新時の挙動)。
 	/// false の場合、常に先頭の列車を選択する。
 	/// </param>
-	private void RefreshTrainDataForWork(Work? work, bool preserveSelection)
+	/// <param name="fallbackToFirstOnMissing">
+	/// 選択していた Id が新リストに存在しないときに先頭の列車へフォールバックするか。
+	/// false の場合は未選択 (null) のままにする (#311: WS再接続時の strict-match 用)。
+	/// </param>
+	private void RefreshTrainDataForWork(Work? work, bool preserveSelection, bool fallbackToFirstOnMissing = true)
 	{
 		if (work is null || _loader is null)
 		{
@@ -258,17 +262,61 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 					SelectedTrainData = matched;
 					return;
 				}
+
+				// strict-match (#311) で新リストがまだ空なら、"消えた" のか
+				// "非同期ローダーの新データがまだ届いていない" のか区別できないため、
+				// 判定を次の Refresh に持ち越す (親の WorkGroup/Work 階層と同じ扱い)。
+				if (!fallbackToFirstOnMissing && orderedList.Count == 0)
+				{
+					_strictIdMatchOnNextRefresh = true;
+					return;
+				}
 			}
 		}
 
-		SelectedTrainData = orderedList.Count > 0 ? orderedList[0] : null;
+		SelectedTrainData = fallbackToFirstOnMissing && orderedList.Count > 0 ? orderedList[0] : null;
 	}
 
 	// ---------- Refresh / Reset ----------
 
+	// #311: WS再接続で Loader インスタンスが差し替わった直後、次の 1 回の
+	// Refresh() だけ strict-match (フォールバックしない) にするための一時フラグ。
+	private bool _strictIdMatchOnNextRefresh;
+
+	/// <summary>
+	/// WS再接続などで Loader インスタンスが新しくなった際に呼ぶ。通常の
+	/// <see cref="Loader"/> セッター (<see cref="OnLoaderChanged"/>) と異なり、
+	/// 現在の選択を直ちにクリアしない。WorkGroupId / WorkId / TrainId が
+	/// 再配信された新データにも全て存在する場合に限り選択を維持し (#311)、
+	/// 途中の階層で Id が見つからなければそこから下を明示的に未選択にする
+	/// (先頭へのフォールバックはしない)。
+	/// 新データ自体は非同期に届くため、実際の照合は次の <see cref="Refresh"/>
+	/// 呼び出し (再配信された TimetableUpdated 経由) で行う。
+	/// </summary>
+	public void ReconnectLoader(ILoader? newLoader)
+	{
+		if (ReferenceEquals(_loader, newLoader))
+			return;
+
+		_loader = newLoader;
+		_strictIdMatchOnNextRefresh = true;
+	}
+
+	/// <summary>
+	/// true の間は、<see cref="ReconnectLoader"/> 後の strict-match 判定がまだ
+	/// 確定していない (新データがまだ届いておらず、Refresh() が「持ち越し」で
+	/// 早期 return した状態)。呼び出し側 (#311: 位置情報 ON/OFF の復元判定) は、
+	/// このフラグが false に落ちる ( = 実データで判定が確定した) まで、選択 Id
+	/// の一致を「本物の一致」として扱ってはならない — true の間の一致は単に
+	/// 古い選択オブジェクトがまだ残っているだけで、実データ未着の可能性がある。
+	/// </summary>
+	public bool IsAwaitingReconnectData => _strictIdMatchOnNextRefresh;
+
 	/// <summary>
 	/// Re-reads lists from the current Loader, preserving valid current selections.
-	/// Falls back to the first item when the current selection is no longer present.
+	/// Falls back to the first item when the current selection is no longer present
+	/// (unless this call follows <see cref="ReconnectLoader"/>, in which case a
+	/// missing Id clears the selection instead of falling back — #311).
 	/// </summary>
 	/// <remarks>
 	/// リアルタイム編集対応: 各階層で現在の選択 Id がまだ存在すれば保持し、
@@ -279,6 +327,9 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 	{
 		if (_loader is null)
 			return;
+
+		bool strictIdMatch = _strictIdMatchOnNextRefresh;
+		_strictIdMatchOnNextRefresh = false;
 
 		var newWorkGroupList = _loader.GetWorkGroupList();
 		WorkGroupList = newWorkGroupList;
@@ -302,8 +353,19 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 
 		if (matchedWorkGroup is null)
 		{
-			// 既存選択が消えた → 先頭にフォールバック (cascade で配下も再構築される)
-			var fallback = newWorkGroupList.FirstOrDefault();
+			// strict-match (再接続直後) かつ新リストがまだ空の場合、"ID が消えた" のか
+			// "非同期ローダーの新データがまだ届いていない" のか区別できない。誤って
+			// 選択を消してしまわないよう、フラグを持ち越して次の Refresh を待つ
+			// (#311; 空でないのに Id が無ければ本当に消えたとみなし下のロジックへ進む)。
+			if (strictIdMatch && newWorkGroupList.Count == 0)
+			{
+				_strictIdMatchOnNextRefresh = true;
+				return;
+			}
+
+			// 既存選択が消えた → 通常は先頭にフォールバック (cascade で配下も再構築される)。
+			// strict-match (再接続直後) では先頭を選ばず未選択のままにする。
+			var fallback = strictIdMatch ? null : newWorkGroupList.FirstOrDefault();
 			SelectedWorkGroup = fallback;
 			// WorkGroup が空ならば、setter の早期 return で配下が初期化されないため明示的に空にする
 			if (fallback is null)
@@ -331,7 +393,14 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 
 		if (matchedWork is null)
 		{
-			var fallback = newWorkList.FirstOrDefault();
+			// WorkGroup 側と同じ理由: strict-match で新リストがまだ空なら判定を持ち越す。
+			if (strictIdMatch && newWorkList.Count == 0)
+			{
+				_strictIdMatchOnNextRefresh = true;
+				return;
+			}
+
+			var fallback = strictIdMatch ? null : newWorkList.FirstOrDefault();
 			SelectedWork = fallback;
 			// Work が空ならば、配下の Train も明示的に空にする
 			if (fallback is null)
@@ -347,7 +416,7 @@ public class TimetableSelectionManager : INotifyPropertyChanged
 		}
 
 		// Train リストは再構築しつつ、Id が一致すれば選択を保持する。
-		RefreshTrainDataForWork(matchedWork, preserveSelection: true);
+		RefreshTrainDataForWork(matchedWork, preserveSelection: true, fallbackToFirstOnMissing: !strictIdMatch);
 	}
 
 	// ---------- Helpers ----------

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -65,6 +65,16 @@ public partial class AppViewModel
 	private void MarkServerConnectionLost()
 	{
 		logger.Info("WebSocket connection lost -> IsServerConnectionLost = true");
+
+		// #311: この時点では LocationService 側の ConnectionClosed ハンドラ (GPSへの
+		// フォールバック + IsEnabled=false 強制) はまだ呼ばれていない — WsConnectionLostWatcher
+		// (この呼び出し元) は SetNetworkSyncService より前、HandleWebSocketAppLinkAsync 内で
+		// 先に Watch() されているため、同一 ConnectionClosed の multicast 呼び出し順で
+		// こちらが先に実行される。運行状態 (位置情報 ON/OFF) を復元したいなら、それが
+		// 強制 OFF される前の「今」の値をここで捕まえる必要がある
+		// (再接続ボタン押下時点で捕まえると、既に false になっていて復元できない)。
+		RememberSelectionForReconnect(InstanceManager.LocationService.IsEnabled);
+
 		RunOnMainThread(() =>
 		{
 			// 再接続試行が終わった (クリーンクローズ or 再接続失敗) 状態。
@@ -118,7 +128,7 @@ public partial class AppViewModel
 		}
 		logger.Info("ReconnectWebSocketAsync: reconnecting to {0}", info.ResourceUri);
 		// addToHistory: false — a reconnect is not a new user-initiated entry.
-		return HandleWebSocketAppLinkAsync(info, _lastWebSocketOriginalAppLink, addToHistory: false, token);
+		return HandleWebSocketAppLinkAsync(info, _lastWebSocketOriginalAppLink, addToHistory: false, token, isReconnect: true);
 	}
 
 	public Task<bool> HandleAppLinkUriAsync(string uri, CancellationToken token)
@@ -383,7 +393,7 @@ public partial class AppViewModel
 		return true;
 	}
 
-	async Task<bool> HandleWebSocketAppLinkAsync(AppLinkInfo appLinkInfo, string? originalAppLink, bool addToHistory, CancellationToken token)
+	async Task<bool> HandleWebSocketAppLinkAsync(AppLinkInfo appLinkInfo, string? originalAppLink, bool addToHistory, CancellationToken token, bool isReconnect = false)
 	{
 		if (appLinkInfo.ResourceUri is null)
 		{
@@ -415,7 +425,20 @@ public partial class AppViewModel
 			IsServerReconnecting = false;
 
 			ILoader? lastLoader = this.Loader;
-			this.SetLoader(service, originalAppLink ?? appLinkInfo.ResourceUri?.ToString());
+			string? sourceLabel = originalAppLink ?? appLinkInfo.ResourceUri?.ToString();
+			if (isReconnect)
+			{
+				// #311: 再接続では選択状態 (WorkGroup/Work/TrainData) を直ちに捨てない。
+				// 再配信された時刻表で Id が一致すれば維持され、一致しなければ未選択に戻る
+				// (SetLoaderForReconnect / OnTimetableUpdated 参照)。運行状態 (位置情報
+				// ON/OFF) の復元用スナップショットは、強制 OFF される前に
+				// MarkServerConnectionLost 側で既に取得済み。
+				this.SetLoaderForReconnect(service, sourceLabel);
+			}
+			else
+			{
+				this.SetLoader(service, sourceLabel);
+			}
 			logger.Info("Loader Initialized from WebSocket");
 			lastLoader?.Dispose();
 			logger.Debug("Last Loader Disposed");
@@ -427,6 +450,8 @@ public partial class AppViewModel
 			// the selection is best-effort here (SelectionManager.OnLoaderChanged
 			// already auto-committed if a single WorkGroup was present); the
 			// server's SelectTrain push refines it afterwards regardless.
+			// On a reconnect the selection is already non-null (preserved above),
+			// so this intentionally does not override it.
 			if (SelectionManager.SelectedWorkGroup is null)
 				SelectionManager.SelectedWorkGroup = SelectionManager.WorkGroupList?.FirstOrDefault();
 			RequestAutoNavigateToTimetable();

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -54,6 +54,44 @@ public partial class AppViewModel : ObservableObject
 		Loader = loader;
 	}
 
+	// #311: 次の OnLoaderChanged 呼び出し 1 回だけ、選択状態をハードリセットせず
+	// TimetableSelectionManager.ReconnectLoader (Id 一致時の維持) に回すためのフラグ。
+	private bool _preserveSelectionOnNextLoaderChange;
+
+	/// <summary>
+	/// WS再接続 (#311) 用の Loader 差し替え。<see cref="SetLoader"/> と異なり、
+	/// WorkGroup/Work/TrainData の選択状態をハードリセットしない。時刻表が
+	/// 再配信され Id が一致すれば選択は維持され、一致しなければ未選択に戻る
+	/// (<see cref="TimetableSelectionManager.ReconnectLoader"/> 参照)。
+	/// </summary>
+	public void SetLoaderForReconnect(ILoader? loader, string? sourceLabel)
+	{
+		LoaderSourceLabel = sourceLabel;
+		_preserveSelectionOnNextLoaderChange = true;
+		Loader = loader;
+	}
+
+	// #311: WS再接続で Loader を差し替えた際に、直前の運行状態 (位置情報 ON/OFF)
+	// を記憶しておき、再配信された時刻表で WorkGroupId/WorkId/TrainId が全て
+	// 一致したときだけ復元する (OnTimetableUpdated 参照)。
+	private (string? WorkGroupId, string? WorkId, string? TrainId, bool WasLocationEnabled)? _pendingReconnectLocationRestore;
+
+	/// <summary>
+	/// WebSocket 切断検知の直後 (<c>MarkServerConnectionLost</c>、位置情報サービスが
+	/// GPS フォールバックで IsEnabled を強制 OFF する前) に呼び、その時点の選択 Id と
+	/// 位置情報サービスの有効状態を記録する。再接続ボタン押下時点では既に IsEnabled が
+	/// false になっているため、ここより後で捕まえても復元できない。
+	/// </summary>
+	internal void RememberSelectionForReconnect(bool isLocationEnabled)
+	{
+		_pendingReconnectLocationRestore = (
+			SelectionManager.SelectedWorkGroup?.Id,
+			SelectionManager.SelectedWork?.Id,
+			SelectionManager.SelectedTrainData?.Id,
+			isLocationEnabled
+		);
+	}
+
 	/// <summary>
 	/// サーバーから受信した最新のダイヤ情報 (ダイヤ名・説明など)。未受信／非接続時は null。
 	/// 接続情報画面で読み取り専用表示するために購読される。
@@ -419,7 +457,20 @@ public partial class AppViewModel : ObservableObject
 
 	partial void OnLoaderChanged(ILoader? value)
 	{
-		SelectionManager.Loader = value;
+		if (_preserveSelectionOnNextLoaderChange)
+		{
+			_preserveSelectionOnNextLoaderChange = false;
+			SelectionManager.ReconnectLoader(value);
+		}
+		else
+		{
+			SelectionManager.Loader = value;
+			// #311: 再接続以外の経路 (新規ファイルオープン等) でハードリセットされた
+			// 場合、直前の切断時に取っていた位置情報復元スナップショットは無意味な
+			// ので捨てる。残したままだと、後で無関係な TimetableUpdated の Id が
+			// たまたま一致したときに誤って IsEnabled を復元しかねない。
+			_pendingReconnectLocationRestore = null;
+		}
 		// ローダーが切り替わったら以前のダイヤ情報は無効。サーバー接続なら
 		// 接続時に再要求され DiagramInfoUpdated で改めて設定される。SetLoader は
 		// この後に NetworkSyncService を接続するため、ここでのクリアが新しい応答を
@@ -460,6 +511,54 @@ public partial class AppViewModel : ObservableObject
 			logger.Debug("Refreshing selection from Loader cache");
 			SelectionManager.Refresh();
 		}
+
+		// #311: WS再接続直後の再配信であれば、直前の WorkGroupId/WorkId/TrainId が
+		// すべて一致した場合に限り運行状態 (位置情報 ON/OFF) を復元する。
+		// 一致しなかった場合は消費するだけで何もしない (フォールバック先の別の
+		// 列車に対して運行状態を引き継がない)。
+		// SelectionManager.IsAwaitingReconnectData が true の間は、新データがまだ
+		// 届いておらず Refresh() が判定を持ち越した状態 (=選択 Id は古いオブジェクトの
+		// ままで「一致」に見えるだけ) なので、判定が確定するまで消費せず待つ。
+		if (SelectionManager.IsAwaitingReconnectData)
+		{
+			// まだ判定できない: スナップショットを残したまま次の TimetableUpdated を待つ。
+		}
+		else if (_pendingReconnectLocationRestore is { } restore)
+		{
+			_pendingReconnectLocationRestore = null;
+			if (ShouldRestoreLocationEnabled(
+				restore,
+				SelectionManager.SelectedWorkGroup?.Id,
+				SelectionManager.SelectedWork?.Id,
+				SelectionManager.SelectedTrainData?.Id))
+			{
+				logger.Info("Reconnect: selection ids matched -> restoring location service IsEnabled");
+				InstanceManager.LocationService.IsEnabled = true;
+			}
+		}
+	}
+
+	/// <summary>
+	/// #311 の復元条件を切り出した純粋関数: 切断時に記憶した
+	/// WorkGroupId/WorkId/TrainId が、再配信後に確定した現在の選択と
+	/// すべて一致し、かつ切断前に運行中 (位置情報 ON) だった場合にのみ true。
+	/// MAUI/InstanceManager に依存しないため、呼び出し側 (<see cref="OnTimetableUpdated"/>)
+	/// が <see cref="TimetableSelectionManager.IsAwaitingReconnectData"/> で
+	/// 判定確定後であることを保証した上で呼ぶこと。
+	/// </summary>
+	internal static bool ShouldRestoreLocationEnabled(
+		(string? WorkGroupId, string? WorkId, string? TrainId, bool WasLocationEnabled) snapshot,
+		string? currentWorkGroupId,
+		string? currentWorkId,
+		string? currentTrainId)
+	{
+		if (!snapshot.WasLocationEnabled)
+			return false;
+
+		return
+			currentWorkGroupId == snapshot.WorkGroupId &&
+			currentWorkId == snapshot.WorkId &&
+			currentTrainId == snapshot.TrainId;
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- After a WebSocket reconnect, the selected WorkGroup/Work/TrainData was hard-reset even when the redelivered timetable had the same IDs, and 運行状態/位置情報 ON-OFF (`LocationService.IsEnabled`) was forced off with no automatic way back.
- `TimetableSelectionManager.ReconnectLoader()` now swaps the loader without wiping selection; a one-shot strict-match pass in `Refresh()` restores the prior selection only when WorkGroupId → WorkId → TrainId all still resolve in the redelivered data (falling back to unselected, not the first item, on any miss — confirmed this fallback semantics with the requester).
- `AppViewModel` snapshots `IsEnabled` and the selected IDs the moment a disconnect is detected (before the GPS-fallback path forces `IsEnabled` off), and restores it only once the post-reconnect data confirms the same train is still present.
- Guards against a partial/empty timetable update racing ahead of the full redelivery (`IsAwaitingReconnectData`), so the preserved selection isn't prematurely wiped.

Fixes #311

## Test plan
- [x] `dotnet test TRViS.Core.Tests` — 41/41 passing, including 6 new tests covering preserve-on-match, clear-on-miss at each level (WorkGroup/Work/Train), the async keep-waiting race, and the one-shot scope of the strict-match flag
- [x] `dotnet build TRViS/TRViS.csproj -f net10.0-ios` — builds clean
- [ ] Manual verification against a real WS server reconnect (not exercised in this session — no MAUI/AppViewModel test harness exists in this repo for the `IsEnabled` restore wiring; that half is reasoning-verified via code trace, not test-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GYxfJeZQuwdGyZtQmm9Sn