### PR TITLE
ci(ui-test): temporarily disable ui-test-android and ui-test-windows

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -646,6 +646,10 @@ jobs:
   # Windows UI Tests
   # ─────────────────────────────────────────────
   ui-test-windows:
+    # Temporarily disabled alongside ui-test-android (see that job's comment)
+    # — being run down together while Android/Windows E2E instability is
+    # investigated (#321). Remove this line to re-enable.
+    if: false
     runs-on: windows-latest
     # Successful runs take ~18 min; this PR's run hit 20m14s and was killed by
     # the timeout mid-suite (no test actually failed — see run 28673468160).

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -95,6 +95,12 @@ jobs:
   # Android UI Tests  (self-managed emulator)
   # ─────────────────────────────────────────────
   ui-test-android:
+    # Temporarily disabled: the self-managed emulator has become too
+    # unreliable to gate PRs on (recurring UiAutomator2/instrumentation
+    # crashes cascading the whole suite, plus separate structural flakiness
+    # under the NotificationBannerTests fixture — see #321). Remove this
+    # line to re-enable once the underlying instability is addressed.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
## Summary
- Disables `ui-test-android` and `ui-test-windows` (`if: false`) in `.github/workflows/ui-test.yml`.

## Why
Both Android and Windows E2E have become too unreliable to gate PRs on right now:
- **Android**: recurring UiAutomator2/instrumentation-crash flake (`socket hang up`, emulator going to `missing` state) that cascades the whole suite, independent of any app change. Separately, a structural issue under the `NotificationBannerTests` fixture where state/resources appear to degrade across repeated DTAC round-trips within a shared session — whichever test runs next after the previous one hits the wall fails with the same `ConnectServer.Title` timeout.
- **Windows**: a real redisplay-logic bug surfaced in the same `NotificationBannerTests` fixture (banner doesn't reappear after ack + entering a section), plus the job has been running close to its timeout budget as the suite grows.

See #321 for the investigation so far on both platforms.

Rather than keep whack-a-moling individual test ignores while root causes are investigated, this disables both jobs temporarily so CI stops blocking unrelated PRs on this instability.

## Follow-up
Re-enable by removing the respective `if: false` lines once #321 is resolved (or the infra is otherwise stabilized).

## Test plan
- [ ] Confirm CI on this PR shows `ui-test-android` and `ui-test-windows` as skipped, not failing.
- [ ] Confirm no other job depends on either (checked: none do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6WVYPRvPJLs5ZunS4MYmH