### PR TITLE
fix(notification): clear on train transition; add delete-by-Id command

### DIFF
--- a/TRViS.LocationService.Tests/NotificationStoreTests.cs
+++ b/TRViS.LocationService.Tests/NotificationStoreTests.cs
@@ -251,4 +251,41 @@ public class NotificationStoreTests
 		Assert.DoesNotThrow(() => store.MarkRead("nonexistent"));
 		Assert.That(store.IsRead("nonexistent"), Is.False);
 	}
+
+	[Test]
+	public void Remove_ExistingId_ReturnsTrue_AndDropsFromRedisplayCandidates()
+	{
+		var store = new NotificationStore();
+		store.Add(Make(id: "n-1", acknowledged: true, sectionStart: "東京"));
+		Assert.That(store.GetRedisplayCandidates(), Has.Count.EqualTo(1));
+
+		bool removed = store.Remove("n-1");
+
+		Assert.That(removed, Is.True);
+		Assert.That(store.GetRedisplayCandidates(), Is.Empty);
+		Assert.That(store.Count, Is.EqualTo(0));
+	}
+
+	[Test]
+	public void Remove_UnknownOrEmptyId_ReturnsFalse_DoesNotThrow()
+	{
+		var store = new NotificationStore();
+		store.Add(Make(id: "n-1"));
+
+		Assert.That(store.Remove("nonexistent"), Is.False);
+		Assert.DoesNotThrow(() => store.Remove(""));
+		Assert.That(store.Count, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void Remove_UnacknowledgedEntry_AlsoRemoved()
+	{
+		// #327-adjacent: Remove must discard an entry regardless of read state
+		// (unread/未受領 notifications must be deletable too, not just read ones).
+		var store = new NotificationStore();
+		store.Add(Make(id: "n-1", acknowledged: false));
+
+		Assert.That(store.Remove("n-1"), Is.True);
+		Assert.That(store.Count, Is.EqualTo(0));
+	}
 }

--- a/TRViS.LocationService/LocationService.cs
+++ b/TRViS.LocationService/LocationService.cs
@@ -56,6 +56,7 @@ public partial class LocationService : IDisposable
 	public event EventHandler<bool>? OperationStartRequested;
 	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
 	public event EventHandler<NotificationData>? NotificationReceived;
+	public event EventHandler<DeleteNotificationCommand>? NotificationDeleteRequested;
 	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
 	public event EventHandler? NavigateToHomeRequested;
 	public event EventHandler<OpenTimetableCommand>? OpenTimetableRequested;
@@ -243,6 +244,8 @@ void OnIsEnabledChanged(bool value)
 
 	void OnHeaderColorChangeRequested(object? sender, HeaderColorCommand cmd) => HeaderColorChangeRequested?.Invoke(sender, cmd);
 	void OnNotificationReceived(object? sender, NotificationData n) => NotificationReceived?.Invoke(sender, n);
+
+	void OnNotificationDeleteRequested(object? sender, DeleteNotificationCommand cmd) => NotificationDeleteRequested?.Invoke(sender, cmd);
 	void OnTimeFormatChangeRequested(object? sender, TimeFormatCommand cmd) => TimeFormatChangeRequested?.Invoke(sender, cmd);
 	void OnNavigateToHomeRequested(object? sender, EventArgs _) => NavigateToHomeRequested?.Invoke(sender, EventArgs.Empty);
 	void OnOpenTimetableRequested(object? sender, OpenTimetableCommand cmd) => OpenTimetableRequested?.Invoke(sender, cmd);
@@ -347,6 +350,7 @@ void OnIsEnabledChanged(bool value)
 			networkSyncService.OperationCommandReceived -= OnOperationCommandReceived;
 			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
 			networkSyncService.NotificationReceived -= OnNotificationReceived;
+			networkSyncService.NotificationDeleteRequested -= OnNotificationDeleteRequested;
 			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
 			networkSyncService.NavigateToHomeRequested -= OnNavigateToHomeRequested;
 			networkSyncService.OpenTimetableRequested -= OnOpenTimetableRequested;
@@ -473,6 +477,7 @@ void OnIsEnabledChanged(bool value)
 		nextService.OperationCommandReceived += OnOperationCommandReceived;
 		nextService.HeaderColorChangeRequested += OnHeaderColorChangeRequested;
 		nextService.NotificationReceived += OnNotificationReceived;
+		nextService.NotificationDeleteRequested += OnNotificationDeleteRequested;
 		nextService.TimeFormatChangeRequested += OnTimeFormatChangeRequested;
 		nextService.NavigateToHomeRequested += OnNavigateToHomeRequested;
 		nextService.OpenTimetableRequested += OnOpenTimetableRequested;
@@ -508,6 +513,7 @@ void OnIsEnabledChanged(bool value)
 			networkSyncService.OperationCommandReceived -= OnOperationCommandReceived;
 			networkSyncService.HeaderColorChangeRequested -= OnHeaderColorChangeRequested;
 			networkSyncService.NotificationReceived -= OnNotificationReceived;
+			networkSyncService.NotificationDeleteRequested -= OnNotificationDeleteRequested;
 			networkSyncService.TimeFormatChangeRequested -= OnTimeFormatChangeRequested;
 			networkSyncService.NavigateToHomeRequested -= OnNavigateToHomeRequested;
 			networkSyncService.OpenTimetableRequested -= OnOpenTimetableRequested;

--- a/TRViS.LocationService/NotificationStore.cs
+++ b/TRViS.LocationService/NotificationStore.cs
@@ -187,4 +187,19 @@ public sealed class NotificationStore
 			_byId.Clear();
 		}
 	}
+
+	/// <summary>
+	/// 指定 Id の通告を、既読/未読を問わず破棄する。サーバーからの削除指示
+	/// (<see cref="TRViS.NetworkSyncService.DeleteNotificationCommand"/>) に対応する。
+	/// </summary>
+	/// <returns>該当する通告が存在し削除できたら true。未知の Id なら false。</returns>
+	public bool Remove(string id)
+	{
+		if (string.IsNullOrEmpty(id))
+			return false;
+		lock (_lock)
+		{
+			return _byId.Remove(id);
+		}
+	}
 }

--- a/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/Helpers/ReferenceServerClient.cs
@@ -359,6 +359,15 @@ public sealed class ReferenceServerClient : IDisposable
 		resp.EnsureSuccessStatusCode();
 	}
 
+	public async Task BroadcastNotificationDeleteAsync(string id, CancellationToken ct = default)
+	{
+		var payload = new { Id = id };
+		var content = new StringContent(
+			JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+		var resp = await _http.PostAsync("/control/broadcast-notification-delete", content, ct);
+		resp.EnsureSuccessStatusCode();
+	}
+
 	public async Task BroadcastTimeFormatAsync(string? format = null, CancellationToken ct = default)
 	{
 		var payload = new { Format = format };

--- a/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
+++ b/TRViS.NetworkSyncService.IntegrationTests/WebSocketIntegrationTests.cs
@@ -2577,6 +2577,30 @@ public class WebSocketIntegrationTests
 	}
 
 	[Test]
+	public async Task DeleteNotification_BroadcastFromServer_ClientReceivesEvent()
+	{
+		var service = await ConnectServiceAsync();
+		try
+		{
+			await WaitForWsClientCountAsync(_control, 1);
+
+			var task = WaitForEventAsync<DeleteNotificationCommand>(
+				h => service.NotificationDeleteRequested += h,
+				h => service.NotificationDeleteRequested -= h
+			);
+
+			await _control.BroadcastNotificationDeleteAsync("n-1");
+
+			var cmd = await task;
+			Assert.That(cmd.Id, Is.EqualTo("n-1"));
+		}
+		finally
+		{
+			await DisconnectAsync(service);
+		}
+	}
+
+	[Test]
 	public async Task TimeFormat_BroadcastSpecificFormat_ClientReceivesFormat()
 	{
 		var service = await ConnectServiceAsync();

--- a/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
+++ b/TRViS.NetworkSyncService/NetworkSyncServiceBase.cs
@@ -199,6 +199,7 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	public event EventHandler<OperationCommand>? OperationCommandReceived;
 	public event EventHandler<HeaderColorCommand>? HeaderColorChangeRequested;
 	public event EventHandler<NotificationData>? NotificationReceived;
+	public event EventHandler<DeleteNotificationCommand>? NotificationDeleteRequested;
 	public event EventHandler<TimeFormatCommand>? TimeFormatChangeRequested;
 	public event EventHandler? NavigateToHomeRequested;
 	public event EventHandler<OpenTimetableCommand>? OpenTimetableRequested;
@@ -484,6 +485,12 @@ public abstract class NetworkSyncServiceBase : ILocationService, IDisposable
 	{
 		Logger.Info("RaiseNotificationReceived: Id={0}, Title={1}", notification.Id, notification.Title);
 		NotificationReceived?.Invoke(this, notification);
+	}
+
+	protected void RaiseNotificationDeleteRequested(DeleteNotificationCommand command)
+	{
+		Logger.Info("RaiseNotificationDeleteRequested: Id={0}", command.Id);
+		NotificationDeleteRequested?.Invoke(this, command);
 	}
 
 	protected void RaiseTimeFormatChangeRequested(TimeFormatCommand command)

--- a/TRViS.NetworkSyncService/RemoteCommands.cs
+++ b/TRViS.NetworkSyncService/RemoteCommands.cs
@@ -38,6 +38,17 @@ public class OperationCommand
 }
 
 /// <summary>
+/// サーバーから、既に配信済みの通告 (<see cref="NotificationData"/>) の削除を指示するコマンド。
+/// 受信側は <see cref="Id"/> に一致する通告を、受領/未受領を問わず破棄する
+/// (保持中のポップアップ/バナー表示中であれば、それも閉じる)。
+/// </summary>
+public class DeleteNotificationCommand
+{
+	/// <summary>削除対象の <see cref="NotificationData.Id"/>。</summary>
+	public string Id { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// タイトルバー (ヘッダ) の色変更要求。
 /// <see cref="ResetToDefault"/> が true のとき、端末の設定値に戻す。
 /// false のとき、<see cref="Color_RGB"/> の RGB 値 (0xRRGGBB) を適用する。

--- a/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
+++ b/TRViS.NetworkSyncService/WebSocketNetworkSyncService.cs
@@ -51,6 +51,7 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 	private const string MESSAGE_TYPE_OPERATION_COMMAND = "OperationCommand";
 	private const string MESSAGE_TYPE_HEADER_COLOR = "HeaderColor";
 	private const string MESSAGE_TYPE_NOTIFICATION = "Notification";
+	private const string MESSAGE_TYPE_DELETE_NOTIFICATION = "DeleteNotification";
 	private const string MESSAGE_TYPE_TIME_FORMAT = "TimeFormat";
 	private const string MESSAGE_TYPE_NAVIGATE_TO_HOME = "NavigateToHome";
 	private const string MESSAGE_TYPE_OPEN_TIMETABLE = "OpenTimetable";
@@ -324,6 +325,10 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			{
 				ProcessNotificationMessage(root);
 			}
+			else if (messageType == MESSAGE_TYPE_DELETE_NOTIFICATION)
+			{
+				ProcessDeleteNotificationMessage(root);
+			}
 			else if (messageType == MESSAGE_TYPE_TIME_FORMAT)
 			{
 				ProcessTimeFormatMessage(root);
@@ -586,6 +591,17 @@ public class WebSocketNetworkSyncService : NetworkSyncServiceBase, ILoader
 			TrainId = TryGetStringProperty(root, TRAIN_ID_JSON_KEY),
 		};
 		RaiseTrainSelectionRequested(cmd);
+	}
+
+	private void ProcessDeleteNotificationMessage(JsonElement root)
+	{
+		string? id = TryGetStringProperty(root, "Id");
+		if (string.IsNullOrEmpty(id))
+		{
+			logger.Warn("ProcessDeleteNotificationMessage: Missing 'Id' field");
+			return;
+		}
+		RaiseNotificationDeleteRequested(new DeleteNotificationCommand { Id = id });
 	}
 
 	private void ProcessOpenTimetableMessage(JsonElement root)

--- a/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
+++ b/TRViS.ReferenceServer/ReferenceNetworkSyncServer.cs
@@ -157,6 +157,7 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 			("POST", "broadcast-operation-command") => await BroadcastOperationCommandAsync(request),
 			("POST", "broadcast-header-color") => await BroadcastHeaderColorAsync(request),
 			("POST", "broadcast-notification") => await BroadcastNotificationAsync(request),
+			("POST", "broadcast-notification-delete") => await BroadcastNotificationDeleteAsync(request),
 			("POST", "broadcast-time-format") => await BroadcastTimeFormatAsync(request),
 			("POST", "broadcast-navigate-to-home") => await BroadcastNavigateToHomeAsync(),
 			("POST", "broadcast-open-timetable") => await BroadcastOpenTimetableAsync(request),
@@ -656,6 +657,30 @@ public sealed class ReferenceNetworkSyncServer : IDisposable
 				SectionStartStation = TryGetString(root, "SectionStartStation"),
 				SectionEndStation = TryGetString(root, "SectionEndStation"),
 				StationsBefore = stationsBefore,
+			});
+			await BroadcastTextAsync(msg);
+			return OkJson("{\"ok\":true}");
+		}
+		catch (JsonException ex) { return Error(HttpStatusCode.BadRequest, ex.Message); }
+	}
+
+	/// <summary>
+	/// DeleteNotification: { Id: string }
+	/// </summary>
+	private async Task<HttpResponse> BroadcastNotificationDeleteAsync(HttpRequest request)
+	{
+		try
+		{
+			string body = Encoding.UTF8.GetString(request.Body);
+			using var doc = JsonDocument.Parse(body);
+			var root = doc.RootElement;
+			string? id = TryGetString(root, "Id");
+			if (string.IsNullOrEmpty(id))
+				return Error(HttpStatusCode.BadRequest, "Missing 'Id' field");
+			var msg = JsonSerializer.Serialize(new
+			{
+				MessageType = "DeleteNotification",
+				Id = id,
 			});
 			await BroadcastTextAsync(msg);
 			return OkJson("{\"ok\":true}");

--- a/TRViS.UITests/Tests/NotificationBannerTests.cs
+++ b/TRViS.UITests/Tests/NotificationBannerTests.cs
@@ -125,6 +125,44 @@ public class NotificationBannerTests : BaseUITest
 	}
 
 	/// <summary>
+	/// Regression for #327: switching to a different train (via NextTrainButton) must
+	/// discard any notification held for the previously displayed train — including
+	/// still-unacknowledged ones — rather than leaving its banner on screen. The
+	/// notification is injected before the first train is ever selected (null → train),
+	/// which must NOT clear it (nothing was "displayed" yet); only the subsequent
+	/// train → train switch should.
+	/// </summary>
+	[Test]
+	public void Banner_Cleared_WhenNextTrainButtonSwitchesTrain()
+	{
+		Assume.That(_startHomePage.IsDisplayed(), Is.True);
+
+		const string title = "Clear On Switch";
+		const string deeplink =
+			"trvis://_test/notification?id=n-clear-1&title=Clear%20On%20Switch&body=body&priority=0&compact=true&reset=true";
+		InjectNotification(deeplink);
+
+		_startHomePage.LoadSample();
+		_startHomePage.WaitForElement(AutomationIds.StartHome.WorkGroupList);
+		// Cascades to linear-train-1 (NextTrainId = linear-train-2), same seam the
+		// #225 NextTrainButton regression test uses.
+		var dtac = _startHomePage.SeedTrainSelectionWithNextTrain();
+		dtac.SwitchToTimetableTab();
+
+		var banner = new NotificationBannerPageObject(Driver);
+		Assert.That(banner.IsShown(), Is.True,
+			"Banner should backfill once D-TAC is reached for the first-ever train selection.");
+		Assert.That(banner.ReadSummary(), Is.EqualTo(title));
+
+		Assert.That(dtac.IsNextTrainButtonPresent(), Is.True,
+			"NextTrainButton must be reachable before tapping.");
+		dtac.NextTrainButton.Click();
+
+		Assert.That(banner.WaitUntilDismissed(), Is.True,
+			"Switching to the next train must discard the previous train's notification banner (#327).");
+	}
+
+	/// <summary>
 	/// An already-acknowledged notification carrying a section target (<c>sectionstart</c>
 	/// + <c>stationsbefore</c>) does not pop up, but reappears as a (no 受領 button)
 	/// banner once the current train's location enters the section, and disappears
@@ -183,6 +221,45 @@ public class NotificationBannerTests : BaseUITest
 	}
 
 	/// <summary>
+	/// Regression for the server-pushed <c>DeleteNotification</c> command: deleting a
+	/// still-unread (受領必須) notification by Id removes it entirely — including its
+	/// small banner — even though it was never acknowledged. Exercised via the
+	/// UI_TEST-only <c>trvis://_test/notification/delete?id=</c> deeplink, which drives the
+	/// same removal path (<c>NotificationCenterViewModel</c>) a real DeleteNotification
+	/// command does. Deletion is fired from StartHome (same constraint as the redisplay
+	/// test above — the connect dialog seam is only reachable there), then D-TAC is
+	/// reloaded to confirm the banner does not come back.
+	/// </summary>
+	[Test]
+	public void CompactBanner_RemovedOnDelete()
+	{
+		Assume.That(_startHomePage.IsDisplayed(), Is.True);
+
+		const string id = "n-delete-1";
+		const string deeplink =
+			$"trvis://_test/notification?id={id}&title=Delete%20Me&body=body&priority=0&compact=true&reset=true";
+		InjectNotification(deeplink);
+
+		var dtac = LoadSampleAndOpenDTAC();
+		Assert.That(dtac.IsDisplayed(), Is.True);
+
+		var banner = new NotificationBannerPageObject(Driver);
+		Assert.That(banner.IsShown(), Is.True, "Compact banner should be shown once D-TAC is reached.");
+
+		new AppShellPage(Driver).NavigateToHome();
+		_startHomePage = new StartHomePageObject(Driver);
+		_startHomePage.ClearLoaderForTesting();
+
+		DeleteNotification(id);
+
+		dtac = LoadSampleAndOpenDTAC();
+		Assert.That(dtac.IsDisplayed(), Is.True);
+		Assert.That(banner.IsShown(timeoutSeconds: 3), Is.False,
+			"Deleting the notification by Id must remove it (and its banner) entirely, " +
+			"even though it was never acknowledged.");
+	}
+
+	/// <summary>
 	/// Opens the connect dialog, types the given trvis:// deeplink into the
 	/// new-connection form and taps Connect. On success the dialog dismisses.
 	/// Mirrors NotificationPopupTests.InjectNotification, but does not return a
@@ -190,6 +267,13 @@ public class NotificationBannerTests : BaseUITest
 	/// only surfaces once D-TAC is reached.
 	/// </summary>
 	private void InjectNotification(string deeplink) => SubmitDeeplink(deeplink);
+
+	/// <summary>
+	/// Same connect-dialog round trip as <see cref="InjectNotification"/>, for the
+	/// UI_TEST-only <c>trvis://_test/notification/delete?id=</c> seam. Requires Start mode
+	/// (StartBody) to reach ConnectServerButton, same constraint as <see cref="SetLocation"/>.
+	/// </summary>
+	private void DeleteNotification(string id) => SubmitDeeplink($"trvis://_test/notification/delete?id={id}");
 
 	/// <summary>
 	/// Same connect-dialog round trip as <see cref="InjectNotification"/>, used for

--- a/TRViS/AppShell.xaml.cs
+++ b/TRViS/AppShell.xaml.cs
@@ -119,6 +119,9 @@ public partial class AppShell : Shell
 		// WebSocket 切断等で通告が一括破棄されたら、まだ表示していない待機列も空にする
 		// (表示中のポップアップ自体は NotificationPopupPage が自分で閉じる)。
 		appVm.NotificationCenter.Cleared += OnNotificationCenterCleared;
+		// サーバーから個別の通告削除指示を受けたら、まだ表示していない待機列から該当 Id
+		// だけを取り除く (表示中のポップアップ自体は NotificationPopupPage が自分で閉じる)。
+		appVm.NotificationCenter.NotificationRemoved += OnNotificationCenterEntryRemoved;
 
 		InstanceManager.AppViewModel.WindowWidth = DeviceDisplay.Current.MainDisplayInfo.Width;
 		InstanceManager.AppViewModel.WindowHeight = DeviceDisplay.Current.MainDisplayInfo.Height;
@@ -149,6 +152,28 @@ public partial class AppShell : Shell
 	void OnNotificationCenterCleared(object? sender, EventArgs e)
 	{
 		MainThread.BeginInvokeOnMainThread(() => _notificationQueue.Clear());
+	}
+
+	void OnNotificationCenterEntryRemoved(object? sender, string id)
+	{
+		// NotificationRemoved は UI スレッド上で発火する契約だが、キュー操作を確実に UI
+		// スレッドで行うため dispatch する (二重 dispatch は無害)。
+		MainThread.BeginInvokeOnMainThread(() =>
+		{
+			if (_notificationQueue.Count == 0)
+				return;
+
+			// Queue<T> は該当要素だけの削除を提供しないため、丸ごと作り直す。
+			var remaining = new Queue<Services.NotificationStore.Entry>(_notificationQueue.Count);
+			while (_notificationQueue.Count > 0)
+			{
+				var entry = _notificationQueue.Dequeue();
+				if (entry.Id != id)
+					remaining.Enqueue(entry);
+			}
+			while (remaining.Count > 0)
+				_notificationQueue.Enqueue(remaining.Dequeue());
+		});
 	}
 
 	void OnNotificationDisplayRequested(object? sender, Services.NotificationStore.Entry entry)

--- a/TRViS/RootPages/NotificationPopupPage.xaml.cs
+++ b/TRViS/RootPages/NotificationPopupPage.xaml.cs
@@ -89,6 +89,10 @@ public partial class NotificationPopupPage : ContentPage
 		// WebSocket 切断等で保持中の通告が一括破棄されたら、受領必須であってもこのポップアップを
 		// 自分で閉じる (この通告はもうサーバーとの整合性が取れないため)。
 		_viewModel.Cleared += OnNotificationsCleared;
+
+		// サーバーからこの通告 (Id 一致) の削除指示を受けたら、受領必須であってもこの
+		// ポップアップを自分で閉じる (削除済みの通告に対して受領を送っても意味が無いため)。
+		_viewModel.NotificationRemoved += OnNotificationRemoved;
 	}
 
 	private void OnLoadedApplyLabelColumnWidth(object? sender, EventArgs e)
@@ -123,6 +127,14 @@ public partial class NotificationPopupPage : ContentPage
 	private void OnNotificationsCleared(object? sender, EventArgs e)
 	{
 		if (_isClosing)
+			return;
+		_isClosing = true;
+		_ = CloseAsync();
+	}
+
+	private void OnNotificationRemoved(object? sender, string id)
+	{
+		if (_isClosing || id != _entry.Id)
 			return;
 		_isClosing = true;
 		_ = CloseAsync();
@@ -365,6 +377,7 @@ public partial class NotificationPopupPage : ContentPage
 		// このポップアップが消えるので、小型バナーの受領ボタンの点滅を再開させる。
 		_viewModel.NotifyPopupVisibilityChanged(false);
 		_viewModel.Cleared -= OnNotificationsCleared;
+		_viewModel.NotificationRemoved -= OnNotificationRemoved;
 
 		try
 		{

--- a/TRViS/ViewModels/AppViewModel.AppLink.cs
+++ b/TRViS/ViewModels/AppViewModel.AppLink.cs
@@ -166,6 +166,18 @@ public partial class AppViewModel
 			return true;
 		}
 
+		// Test-only: delete a previously-injected Notification by Id, mirroring the
+		// server-pushed DeleteNotification command, without a real WebSocket server.
+		// Format: trvis://_test/notification/delete?id=<id>
+		// Must be checked before TestNotificationPrefix below, since it is a longer
+		// prefix of the same path ("trvis://_test/notification").
+		const string TestDeleteNotificationPrefix = "trvis://_test/notification/delete";
+		if (uri.StartsWith(TestDeleteNotificationPrefix, StringComparison.OrdinalIgnoreCase))
+		{
+			HandleTestDeleteNotification(uri);
+			return true;
+		}
+
 		// Test-only: inject a Notification into NotificationCenter so UI tests can
 		// exercise the receive→popup→受領 flow without a real WebSocket server.
 		// Format: trvis://_test/notification?id=<id>&title=<t>&summary=<s>&body=<bbcode>&priority=<n>&acknowledged=<bool>&reset=<bool>
@@ -908,6 +920,38 @@ public partial class AppViewModel
 			await WaitForRoutingModalDismissedAsync();
 			NotificationCenter.InjectNotificationForTesting(n, fakeAck);
 			logger.Info("Test inject notification: dispatched (id={0}, priority={1}, acknowledged={2}, fakeAck={3})", n.Id, n.Priority, n.Acknowledged, fakeAck);
+		});
+	}
+
+	/// <summary>
+	/// Test-only: delete a previously-injected/received Notification by Id via the same
+	/// removal path a real server-pushed DeleteNotification command takes, so UI tests
+	/// can exercise the delete → banner/popup dismissal flow without a real WebSocket server.
+	/// </summary>
+	private void HandleTestDeleteNotification(string uri)
+	{
+		logger.Info("Test delete notification invoked: {0}", uri);
+
+		int qIndex = uri.IndexOf('?');
+		var query = qIndex >= 0
+			? HttpUtility.ParseQueryString(uri.Substring(qIndex + 1))
+			: new System.Collections.Specialized.NameValueCollection();
+
+		string? id = query["id"];
+		if (string.IsNullOrEmpty(id))
+		{
+			logger.Warn("Test delete notification: missing 'id' query parameter");
+			return;
+		}
+
+		// InjectNotification と同じ理由 (仲介 ConnectServerDialog の自己クローズが、
+		// 同期実行した後続の PopModalAsync を巻き込むのを避ける) で、ダイアログが
+		// モーダルスタックから消えてから削除する。
+		MainThread.BeginInvokeOnMainThread(async () =>
+		{
+			await WaitForRoutingModalDismissedAsync();
+			NotificationCenter.DeleteNotificationForTesting(id);
+			logger.Info("Test delete notification: dispatched (id={0})", id);
 		});
 	}
 

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -404,14 +404,41 @@ public partial class AppViewModel : ObservableObject
 	}
 
 	/// <summary>
-	/// 選択列車が切り替わったときに、その駅順を <see cref="NotificationCenter"/> へ反映する。
+	/// 直前に <see cref="NotificationCenter"/> へ駅順を反映した際の選択列車 Id。
+	/// 「表示中の列車から別の列車への遷移」だけを検出するために保持する
+	/// (初回選択 (null → 列車) では、まだ何も表示していないため破棄不要)。
+	/// </summary>
+	string? _lastNotifiedTrainId;
+
+	/// <summary>
+	/// 選択列車が別の列車へ切り替わったときに、保持中の通告をすべて破棄し、その駅順を
+	/// <see cref="NotificationCenter"/> へ反映する。別の列車の通告を破棄せず表示し続けると
+	/// 実際とは異なる列車の通告が残ってしまうため、切り替え時にまず <see cref="NotificationCenterViewModel.ClearAll"/>
+	/// で破棄し、切り替え後にサーバーから送信される通告で更新されるのを待つ。
+	/// 初回選択 (未選択 → 列車) および Home 復帰時の Loader クリア (列車 → 未選択)
+	/// はまだ「別の列車」が表示されていない/されなくなっただけなので対象外。
 	/// <see cref="SelectionManager"/> は選択列車が変わると <see cref="SelectionManager.SelectedTrainData"/>
 	/// で PropertyChanged を発火するので、それをフィルタして拾う。
 	/// </summary>
 	void OnSelectionManagerPropertyChangedForNotificationCenter(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 	{
 		if (e.PropertyName == nameof(SelectedTrainData))
+		{
+			string? newTrainId = SelectedTrainData?.Id;
+			// null を経由する遷移 (Home 復帰時の Loader クリア等) は「表示中の列車から
+			// 別の列車への遷移」ではないため対象外。実際の列車切り替え (NextTrainButton /
+			// SelectTrainCommand / 検索) は SelectedTrainData を null を挟まず直接 A→B へ
+			// 設定するため、ここを非 null 同士の差分に限定しても実切り替えの検出漏れはない。
+			if (_lastNotifiedTrainId is not null && newTrainId is not null && _lastNotifiedTrainId != newTrainId)
+			{
+				// SelectedTrainData の PropertyChanged はサーバー起点 (OnTrainSelectionRequested) の
+				// 場合バックグラウンドスレッドから発火し得るため、UI スレッド専有の ClearAll はここで
+				// 明示的にメインスレッドへ回す。
+				MainThread.BeginInvokeOnMainThread(NotificationCenter.ClearAll);
+			}
+			_lastNotifiedTrainId = newTrainId;
 			PushSelectedTrainStationsToNotificationCenter();
+		}
 	}
 
 	/// <summary>

--- a/TRViS/ViewModels/NotificationCenterViewModel.cs
+++ b/TRViS/ViewModels/NotificationCenterViewModel.cs
@@ -65,6 +65,15 @@ public sealed class NotificationCenterViewModel : ObservableObject
 	/// </summary>
 	public event EventHandler<string>? BannerDismissed;
 
+	/// <summary>
+	/// 指定 Id の通告が削除されたときに発火する (サーバーからの削除指示、または UI_TEST の
+	/// 削除 seam)。開いている大型ポップアップのうち該当 Id のものだけを自己クローズさせ、
+	/// AppShell の表示待ちキューから該当 Id のみを取り除くために使う。表示中の小型バナーは
+	/// <see cref="RemoveNotification"/> が併せて発火する <see cref="BannerDismissed"/> で消える。
+	/// UI スレッド上で発火する。
+	/// </summary>
+	public event EventHandler<string>? NotificationRemoved;
+
 	// 現在表示中の通告ポップアップ (拡大表示) の数。AppShell のキュー直列化により通常は
 	// 同時に 1 つだが、close→次表示の切り替わりの一瞬だけ増減が重なる可能性に備えてカウンタに
 	// している。UI スレッド専有。
@@ -101,11 +110,13 @@ public sealed class NotificationCenterViewModel : ObservableObject
 		if (_locationService is not null)
 		{
 			_locationService.NotificationReceived -= OnNotificationReceived;
+			_locationService.NotificationDeleteRequested -= OnNotificationDeleteRequested;
 			_locationService.LocationStateChanged -= OnLocationStateChanged;
 			_locationService.NetworkConnectionLost -= OnNetworkConnectionLost;
 		}
 		_locationService = locationService;
 		_locationService.NotificationReceived += OnNotificationReceived;
+		_locationService.NotificationDeleteRequested += OnNotificationDeleteRequested;
 		_locationService.LocationStateChanged += OnLocationStateChanged;
 		_locationService.NetworkConnectionLost += OnNetworkConnectionLost;
 	}
@@ -180,6 +191,40 @@ public sealed class NotificationCenterViewModel : ObservableObject
 				}
 			}
 		});
+	}
+
+	/// <summary>
+	/// サーバーからの通告削除指示 (<see cref="DeleteNotificationCommand"/>) を受けて、指定 Id の
+	/// 通告を破棄する。WebSocket 受信スレッドから呼ばれ得るため UI スレッドへ回す。
+	/// </summary>
+	private void OnNotificationDeleteRequested(object? sender, DeleteNotificationCommand cmd)
+	{
+		logger.Info("NotificationDeleteRequested: Id={0}", cmd.Id);
+		MainThread.BeginInvokeOnMainThread(() => RemoveNotification(cmd.Id));
+	}
+
+	/// <summary>
+	/// 指定 Id の通告を、受領済み/未受領・表示中/未表示を問わず破棄する。
+	/// <see cref="NotificationStore"/> から削除し、追跡中の状態
+	/// (<see cref="_pendingCompactKeys"/>/<see cref="_entriesById"/>) からも取り除いた上で、
+	/// 表示中の小型バナーがあれば <see cref="BannerDismissed"/> で消し、開いている大型ポップアップ
+	/// (該当 Id のみ)・AppShell の表示待ちキュー (該当 Id のみ) には <see cref="NotificationRemoved"/>
+	/// で通知する。UI スレッド上でのみ呼ぶこと。
+	/// </summary>
+	private void RemoveNotification(string? id)
+	{
+		if (string.IsNullOrEmpty(id))
+			return;
+
+		bool existed = _store.Remove(id);
+		_pendingCompactKeys.Remove(id);
+		_entriesById.Remove(id);
+
+		if (_shownBannerKeys.Remove(id))
+			BannerDismissed?.Invoke(this, id);
+
+		if (existed)
+			NotificationRemoved?.Invoke(this, id);
 	}
 
 	/// <summary>
@@ -386,6 +431,16 @@ public sealed class NotificationCenterViewModel : ObservableObject
 		if (fakeAck && !string.IsNullOrEmpty(n.Id))
 			_testInjectedIds.Add(n.Id);
 		OnNotificationReceived(this, n);
+	}
+
+	/// <summary>
+	/// UI_TEST 専用: 実サーバー無しで通告削除 (<see cref="DeleteNotificationCommand"/>) をシミュレートする。
+	/// <see cref="RemoveNotification"/> と同じ経路 (本番の削除ハンドラーが呼ぶものと同一) を通す。
+	/// </summary>
+	public void DeleteNotificationForTesting(string id)
+	{
+		_testInjectedIds.Remove(id);
+		RemoveNotification(id);
 	}
 
 	/// <summary>

--- a/TRViS/ViewModels/NotificationCenterViewModel.cs
+++ b/TRViS/ViewModels/NotificationCenterViewModel.cs
@@ -190,6 +190,15 @@ public sealed class NotificationCenterViewModel : ObservableObject
 					DisplayRequested?.Invoke(this, result.Entry);
 				}
 			}
+			else if (result.Entry.IsRead && result.Entry.HasRedisplayTarget)
+			{
+				// 受領済み・区間指定付きの通告は ShouldDisplay=false (初回ポップアップ対象外) だが、
+				// 列車遷移直後にサーバーから受領済み一覧として再送された場合、現在位置が既に
+				// その区間内であれば LocationStateChanged が改めて発火するとは限らない
+				// (位置が変わらなければ何も起きない) ため、ここで明示的に再評価しないと
+				// バナーが表示されないまま取り残される。
+				RefreshRedisplay();
+			}
 		});
 	}
 

--- a/docs/network-sync-service/en/README.md
+++ b/docs/network-sync-service/en/README.md
@@ -55,6 +55,7 @@ or remote commands you must implement WebSocket.
 | Operation command | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
 | Header color (HeaderColor) | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
 | Notification | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
+| Delete notification (DeleteNotification) | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md#13-deletenotification) |
 | Time format (TimeFormat) | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
 | Train search (SearchTrain) | ❌ | ✅ ※4 | [client-to-server-messages](client-to-server-messages.md#4-searchtrain) |
 | Client→server ID notification | ✅ ※2 | ✅ | per-transport docs |
@@ -111,3 +112,11 @@ keeps working unchanged. Availability of the feature is **negotiated via
 the [`Features`](server-to-client-messages.md#3-serverinfo) array on
 `ServerInfo`** (advertise `"TrainSearch"`), **not** via the version
 number — the version bump is informational.
+
+**`DeleteNotification`.** The server can also send
+[`DeleteNotification`](server-to-client-messages.md#13-deletenotification)
+to retract an already-delivered notification by `Id`. This does not
+require a protocol version bump: it is a plain additional `MessageType`,
+and a client that predates it simply ignores the unknown message per
+the existing "unknown `MessageType` is ignored" rule — no capability
+negotiation is needed.

--- a/docs/network-sync-service/en/server-to-client-messages.md
+++ b/docs/network-sync-service/en/server-to-client-messages.md
@@ -23,6 +23,7 @@ must carry a `MessageType` field (exact case). Unknown/missing
 | `NavigateToHome` | Navigate to home screen | [§10](#10-navigatetohome) |
 | `OpenTimetable` | Open timetable view for a specified train | [§11](#11-opentimetable) |
 | `SearchTrainResponse` | Result of a train-search request | [§12](#12-searchtrainresponse) |
+| `DeleteNotification` | Delete an already-delivered notification by Id | [§13](#13-deletenotification) |
 
 > Notation: "Required" means a field the server effectively needs to
 > produce meaningful behavior. "Optional" may be omitted. A type
@@ -419,6 +420,37 @@ timetable rows — those are fetched separately via
 - Matching semantics are driven by the request's `MatchMode`
   (see [`SearchTrain`](client-to-server-messages.md#4-searchtrain)) —
   `Prefix` (default), `Contains`, or `Exact` — not server-defined.
+
+---
+
+## 13. DeleteNotification
+
+Instructs the client to discard an already-delivered
+[`Notification`](#8-notification) (§8) by `Id`, whether or not the
+client has acknowledged it. Use this to retract a notification that is
+no longer relevant (e.g. superseded, issued in error, or tied to a
+train the crew has since left).
+
+```jsonc
+{
+  "MessageType": "DeleteNotification",
+  "Id": "n-001"   // string (required)
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `Id` | string | Identifier of the notification to delete — the same value as the target `Notification.Id`. **Required**; a missing or empty `Id` is ignored (logged and no-op). |
+
+- Removes the notification regardless of read/acknowledgement state —
+  an unacknowledged notification is discarded too, not just
+  already-acknowledged ones.
+- If the notification is currently shown as the large popup or a small
+  banner, the client dismisses it immediately. If it is only queued
+  (not yet shown), it is removed from the queue instead. If no
+  notification with that `Id` is currently held, the message is a no-op.
+- An unknown `Id` (already deleted, expired, or never delivered) is not
+  an error — the client simply has nothing to remove.
 
 ---
 

--- a/docs/network-sync-service/ja/README.md
+++ b/docs/network-sync-service/ja/README.md
@@ -54,6 +54,7 @@ HTTP は WebSocket の **厳密なサブセット** です。HTTP では同期�
 | 運行操作（OperationCommand） | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
 | ヘッダ色変更（HeaderColor） | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
 | 通告（Notification） | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
+| 通告削除（DeleteNotification） | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md#13-deletenotification) |
 | 時刻表示書式（TimeFormat） | ❌ | ✅ | [server-to-client-messages](server-to-client-messages.md) |
 | 列車検索（SearchTrain） | ❌ | ✅ ※4 | [client-to-server-messages](client-to-server-messages.md#4-searchtrain) |
 | クライアント→サーバーの ID 通知 | ✅ ※2 | ✅ | 各トランスポート文書 |
@@ -109,3 +110,10 @@ TRViS は配信されたコマンド（`SelectTrain` / `OperationCommand` /
 **`ServerInfo` の [`Features`](server-to-client-messages.md#3-serverinfo)
 配列でネゴシエーション**され（`"TrainSearch"` を広告）、バージョン番号
 では判定されません（バージョンの更新は情報提供の意味合いです）。
+
+**`DeleteNotification`。** サーバーは配信済みの通告を `Id` 指定で撤回
+する [`DeleteNotification`](server-to-client-messages.md#13-deletenotification)
+も送信できます。これはプロトコルバージョンの更新を必要としません。
+単なる追加の `MessageType` であり、対応していないクライアントは既存の
+「未知の `MessageType` は無視される」規則により単に無視するため、機能
+ネゴシエーションも不要です。

--- a/docs/network-sync-service/ja/server-to-client-messages.md
+++ b/docs/network-sync-service/ja/server-to-client-messages.md
@@ -23,6 +23,7 @@ JSON オブジェクトで、必ず `MessageType` フィールド（正確なケ
 | `NavigateToHome` | ホーム画面へ遷移 | [§10](#10-navigatetohome) |
 | `OpenTimetable` | 指定列車の時刻表ビューを開く | [§11](#11-opentimetable) |
 | `SearchTrainResponse` | 列車検索要求への結果応答 | [§12](#12-searchtrainresponse) |
+| `DeleteNotification` | 配信済み通告を Id 指定で削除 | [§13](#13-deletenotification) |
 
 > 表記規約: 「必須」はサーバーが意味のある動作をさせるために事実上
 > 必要なフィールド。「任意」は省略可能。型不一致はおおむね「無視
@@ -409,6 +410,35 @@ WorkGroup の上位概念である「ダイヤ」の情報。`RequestDiagramInfo
 - 一致判定はリクエストの `MatchMode`
   （[`SearchTrain`](client-to-server-messages.md#4-searchtrain) 参照）
   — `Prefix`（既定）/ `Contains` / `Exact` — によって決まり、サーバー任意ではありません。
+
+---
+
+## 13. DeleteNotification
+
+配信済みの [`Notification`](#8-notification)（§8）を `Id` 指定で
+破棄させる指示です。クライアント側で受領済みかどうかを問わず削除
+します。もう有効でなくなった通告（差し替えられた、誤って発行した、
+乗務員が既に離れた列車に紐づく等）を撤回する用途に使います。
+
+```jsonc
+{
+  "MessageType": "DeleteNotification",
+  "Id": "n-001"   // string（必須）
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `Id` | string | 削除対象の通告 Id。対象 `Notification.Id` と同じ値。**必須**。欠落／空文字は無視されます（ログのみで no-op）。 |
+
+- 既読／受領の状態に関わらず削除します — 未受領の通告も、既に受領済み
+  の通告と同様に破棄されます。
+- 対象の通告が現在大型ポップアップまたは小型バナーとして表示中の場合
+  は即座に閉じます。まだ表示されていない（表示待ちキュー内の）場合は
+  そのキューから取り除かれます。該当 `Id` の通告を保持していない場合
+  は no-op です。
+- 未知の `Id`（既に削除済み・期限切れ・そもそも配信されていない等）は
+  エラーではありません — クライアント側に削除対象が存在しないだけです。
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes #327: switching to a different train no longer leaves the previous train's notifications on screen. Received notifications (including unacknowledged ones) are discarded on a genuine train→train transition, and repopulated by whatever the server sends after the switch.
- Adds a `DeleteNotification` WebSocket command so the server can retract an already-delivered notification by Id, whether or not it was acknowledged.

## What changed

**Train-transition clear (#327)**
- `AppViewModel.OnSelectionManagerPropertyChangedForNotificationCenter` now calls `NotificationCenter.ClearAll()` when `SelectedTrainData` changes from one non-null train Id to a *different* non-null train Id — covering all switch paths (search, NextTrainButton, server `SelectTrainCommand`) since they all funnel through this single property.
- Deliberately does **not** fire on transitions through `null` (first-ever selection, or Home navigation / loader reset such as `ClearLoaderForTesting`), since those aren't a train→train switch and clearing there would wipe out the existing acknowledged-notification redisplay flow.

**Delete notification by Id**
- New `DeleteNotification` WebSocket message (`{ "MessageType": "DeleteNotification", "Id": "..." }`), propagated end-to-end: `WebSocketNetworkSyncService` → `NetworkSyncServiceBase` → `LocationService` → `NotificationCenterViewModel`.
- `NotificationCenterViewModel` exposes a new per-Id `NotificationRemoved` event, wired into:
  - `NotificationStore.Remove(id)` (store + redisplay-candidate cleanup)
  - `AppShell`'s queued-popup purge
  - `NotificationPopupPage` self-close when the currently open popup matches the deleted Id
  - Small-banner dismissal
- UI_TEST-only seam: `trvis://_test/notification/delete?id=<id>` deeplink.
- `TRViS.ReferenceServer` gains a `/control/broadcast-notification-delete` control endpoint for integration testing.

## Test plan

- [x] `TRViS.LocationService.Tests` — full suite passes (70/70), incl. 3 new `NotificationStore.Remove` tests (existing id, unknown/empty id, unacknowledged entry).
- [x] `TRViS.NetworkSyncService.IntegrationTests` — full suite passes (109/109), incl. new `DeleteNotification_BroadcastFromServer_ClientReceivesEvent`.
- [x] `TRViS` (maccatalyst) and `TRViS.UITests` build cleanly.
- [ ] New Appium E2E tests (`Banner_Cleared_WhenNextTrainButtonSwitchesTrain`, `CompactBanner_RemovedOnDelete`) are added but not runnable in this environment — need to pass in CI. Reviewers should watch the `ui-test-*` CI jobs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)