### PR TITLE
feat(train-search): allow train search with JSON/SQLite loaded files

### DIFF
--- a/TRViS.UITests/AutomationIds.cs
+++ b/TRViS.UITests/AutomationIds.cs
@@ -135,6 +135,12 @@ public static class AutomationIds
 		// can be E2E-verified without a real server.
 		public const string TestSimulateWebSocketSearchButton = "StartHome.TestSimulateWebSocketSearchButton";
 
+		// Builds a JSON-BACKED loader (SampleDataLoader, no WebSocket involved) with
+		// real sample data, commits the first WG/Work and navigates to DTAC. Proves
+		// the QuickSwitch Search tab and train search also work against a local
+		// JSON/SQLite-loaded file, not just a WebSocket connection.
+		public const string TestSimulateLocalSearchButton = "StartHome.TestSimulateLocalSearchButton";
+
 		// Direct invoker for OnSelectFileClicked. Bypasses the styled
 		// SelectFileButton because Appium UIAutomator2's ACTION_CLICK against
 		// MAUI's PrimaryActionButton-styled Button silently fails to dispatch

--- a/TRViS.UITests/Pages/DTACViewHostPageObject.cs
+++ b/TRViS.UITests/Pages/DTACViewHostPageObject.cs
@@ -554,6 +554,14 @@ public class DTACViewHostPageObject : PageObject
 		Thread.Sleep(200);
 	}
 
+	/// <summary>Switches the match mode to 中間一致 (Contains) — needed when the query
+	/// isn't a true prefix of the target train number (default mode is Prefix).</summary>
+	public void TapMatchModeContains()
+	{
+		FindByAutomationId(AutomationIds.DTAC.QuickSwitch.SearchMatchModeContains).Click();
+		Thread.Sleep(200);
+	}
+
 	/// <summary>
 	/// Types a train number. On wide screens QuickSwitchPopup shows a software numeric
 	/// keypad and makes TrainNumberEntry read-only (no OS keyboard); on narrow screens

--- a/TRViS.UITests/Pages/StartHomePageObject.cs
+++ b/TRViS.UITests/Pages/StartHomePageObject.cs
@@ -520,6 +520,15 @@ public class StartHomePageObject : PageObject
 	/// </summary>
 	public void SimulateWebSocketSearchForTesting() => TestSimulateWebSocketSearchButton.Click();
 
+	public AppiumElement TestSimulateLocalSearchButton => FindByAutomationId(AutomationIds.StartHome.TestSimulateLocalSearchButton);
+
+	/// <summary>
+	/// Taps the UI_TEST-only seam that builds a JSON-backed (SampleDataLoader) loader —
+	/// no WebSocket involved — commits the first WG/Work and navigates to DTAC, so the
+	/// QuickSwitch Search tab can be exercised against a local file's already-loaded data.
+	/// </summary>
+	public void SimulateLocalSearchForTesting() => TestSimulateLocalSearchButton.Click();
+
 	/// <summary>
 	/// Filename written by <see cref="SeedSqliteForTesting"/>. Mirrors the
 	/// constant in StartHomePage.xaml.cs so tests can look up the rendered

--- a/TRViS.UITests/Tests/TrainSearchTests.cs
+++ b/TRViS.UITests/Tests/TrainSearchTests.cs
@@ -108,4 +108,60 @@ public class TrainSearchTests : BaseUITest
 		Assert.That(dtac.IsSearchTabPresent(timeoutSeconds: 2), Is.False,
 			"QuickSwitch must be closed at the end of the test so it doesn't leak into the next fixture's shared session.");
 	}
+
+	// Real entry (both the software numeric keypad and Keyboard.Numeric OS keyboard,
+	// see DTACViewHostPageObject.EnterTrainNumber) only ever produces digits, so unlike
+	// the WebSocket test's canned "9999" this test must search for a train number that
+	// actually exists in sample_data.json and is reachable by typing digits alone.
+	// sample_data.json's real train numbers are all kanji-prefixed ("試単9092"), so the
+	// query "9092" is never a Prefix match — Contains mode is required. The matched
+	// train ("試単9092", TrainId "1-1-2") belongs to the SAME WorkGroup/Work as the
+	// initially committed duty, so — unlike the WebSocket test — this does not prove a
+	// cross-duty switch; it proves the local search + select + confirm flow itself works
+	// end-to-end against a JSON-backed (non-WebSocket) loader.
+	private const string LocalSearchedTrainId = "1-1-2";
+
+	[Test]
+	public void TrainSearch_LocalJsonLoader_SearchSelectConfirm()
+	{
+		// No WebSocket involved: SimulateLocalSearchForTesting loads sample_data.json
+		// through the same JSON-backed ILoader a user gets by opening a .json file.
+		// Train search must work here too (the fix this test guards), not just when
+		// connected to a server.
+		_startHomePage.SimulateLocalSearchForTesting();
+
+		var dtac = new DTACViewHostPageObject(Driver);
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"A JSON-backed loader with a committed selection should land on DTAC.");
+		Assert.That(dtac.ReadTitleViaSeam(), Is.EqualTo(CommittedWorkName),
+			"The header should show the initially committed duty's Work name.");
+
+		// The Search tab must be visible for a local (non-WebSocket) loader too.
+		dtac.OpenQuickSwitch();
+		Assert.That(dtac.IsSearchTabPresent(), Is.True,
+			"The QuickSwitch Search tab must be shown for a loaded JSON/SQLite file, not only a WebSocket connection.");
+
+		dtac.TapSearchTab();
+		dtac.TapMatchModeContains();
+		dtac.EnterTrainNumber("9092");
+		Assert.That(dtac.WaitForSearchResult(LocalSearchedTrainId, timeoutSeconds: 8), Is.True,
+			"Searching sample_data.json's own train number should find it locally, with no server involved.");
+
+		dtac.TapSearchResult(LocalSearchedTrainId);
+		dtac.AcceptConfirmDialog();
+
+		Assert.That(dtac.IsDisplayed(), Is.True,
+			"DTAC should still be displayed after confirming the searched train.");
+		Assert.That(dtac.IsHakoTabPresent(timeoutSeconds: 3), Is.True,
+			"The ハコ tab must remain visible after switching to the searched train.");
+		Assert.That(dtac.ReadTitleViaSeam(), Is.EqualTo(CommittedWorkName),
+			"The searched train belongs to the same duty, so the header's 行路番号 is unchanged.");
+
+		// Leave QuickSwitch closed: this fixture shares its Appium session with
+		// later fixtures, and an open popover breaks their SetUp recovery.
+		dtac.OpenQuickSwitch();
+		dtac.CloseQuickSwitch();
+		Assert.That(dtac.IsSearchTabPresent(timeoutSeconds: 2), Is.False,
+			"QuickSwitch must be closed at the end of the test so it doesn't leak into the next fixture's shared session.");
+	}
 }

--- a/TRViS/DTAC/PageParts/QuickSwitchPopup.xaml.cs
+++ b/TRViS/DTAC/PageParts/QuickSwitchPopup.xaml.cs
@@ -76,10 +76,11 @@ public partial class QuickSwitchPopup : ContentView
 			TrainNumberEntry.Keyboard = Keyboard.Numeric;
 		}
 
-		// The search tab is available only when connected to a WebSocket server that
-		// advertises the TrainSearch feature (ServerInfo.Features) — this also covers
-		// offline (disconnected/reconnecting), since IsTrainSearchAvailable requires an
-		// active connection.
+		// The search tab is available when data is loaded: for a WebSocket server this
+		// additionally requires it to advertise the TrainSearch feature (ServerInfo.Features)
+		// and be actively connected (hidden while offline/reconnecting); for local loaders
+		// (JSON/SQLite/sample data) it searches the already-loaded data, so any loaded
+		// source is enough. See IsTrainSearchAvailable.
 		SearchTabButton.IsVisible = ViewModel.IsTrainSearchAvailable;
 
 		// Set up tab buttons

--- a/TRViS/RootPages/StartHomePage.xaml.cs
+++ b/TRViS/RootPages/StartHomePage.xaml.cs
@@ -228,6 +228,7 @@ public partial class StartHomePage : ContentPage
 		AddTestSetLanguageJapaneseSeam();
 		AddTestSimulateWebSocketConnectedSeam();
 		AddTestSimulateWebSocketSearchSeam();
+		AddTestSimulateLocalSearchSeam();
 #endif
 
 		logger.Trace("Created");
@@ -1572,6 +1573,71 @@ public partial class StartHomePage : ContentPage
 		catch (Exception ex)
 		{
 			logger.Error(ex, "TestSimulateWebSocketSearchButton failed");
+		}
+	}
+
+	// UI_TEST-only seam: proves train search works against a LOCAL (non-WebSocket)
+	// loader — the JSON-backed SampleDataLoader stands in for a user-opened JSON/SQLite
+	// file (both go through the same ILoader-only code path in
+	// AppViewModel.IsTrainSearchAvailable / SearchTrainAsync). Commits the first
+	// WorkGroup/Work and navigates to DTAC; the E2E then searches sample_data.json's
+	// real "Linear01" train (a different WorkGroup/Work) with no canned data needed,
+	// since local search reads straight out of the loaded ILoader.
+	//
+	// Placed in the fourth column (left=90), one row below the WebSocket search seam,
+	// to stay in the proven-visible seam band without colliding with existing buttons.
+	private const string AutomationIdValueForTestSimulateLocalSearch = "StartHome.TestSimulateLocalSearchButton";
+
+	private void AddTestSimulateLocalSearchSeam()
+	{
+		var seam = new Button
+		{
+			AutomationId = AutomationIdValueForTestSimulateLocalSearch,
+			HorizontalOptions = LayoutOptions.Start,
+			VerticalOptions = LayoutOptions.Start,
+			WidthRequest = 24,
+			HeightRequest = 24,
+			Margin = new Thickness(90, 336, 0, 0),
+			BackgroundColor = Colors.Transparent,
+			BorderColor = Colors.Transparent,
+			Padding = 0,
+		};
+		seam.Clicked += TestSimulateLocalSearchButton_Clicked;
+		Grid.SetRow(seam, 0);
+		RootGrid.Children.Add(seam);
+	}
+
+	async void TestSimulateLocalSearchButton_Clicked(object? sender, EventArgs e)
+	{
+		logger.Info("TestSimulateLocalSearchButton clicked: JSON-backed loader -> DTAC");
+		try
+		{
+			var sample = await SampleDataLoader.CreateAsync();
+
+			// Committed selection: the first WorkGroup/Work in the sample data.
+			var wg = sample.GetWorkGroupList().FirstOrDefault();
+			var work = wg is null ? null : sample.GetWorkList(wg.Id)?.FirstOrDefault();
+			if (wg is null || work is null)
+			{
+				logger.Warn("TestSimulateLocalSearch: sample data missing — aborting");
+				sample.Dispose();
+				return;
+			}
+
+			await MainThread.InvokeOnMainThreadAsync(async () =>
+			{
+				var previous = viewModel.Loader;
+				viewModel.SetLoader(sample, "sample_data.json");
+				previous?.Dispose();
+				await ApplyModeForCurrentLoaderAsync();
+
+				HomeGrid.CommitPendingSelection(wg, work);
+				await HomeGridView.NavigateToDTACAsync();
+			});
+		}
+		catch (Exception ex)
+		{
+			logger.Error(ex, "TestSimulateLocalSearchButton failed");
 		}
 	}
 

--- a/TRViS/ViewModels/AppViewModel.cs
+++ b/TRViS/ViewModels/AppViewModel.cs
@@ -225,37 +225,109 @@ public partial class AppViewModel : ObservableObject
 	// ================================================================
 
 	/// <summary>
-	/// サーバーが列車検索に対応し、かつ WebSocket 接続中かどうか。QuickSwitchPopup の
-	/// 検索タブの表示可否に使う。オフライン (接続断/再接続中) の間は検索できないため
-	/// 併せて非表示にする。
+	/// 列車検索が使える状態かどうか。QuickSwitchPopup の検索タブの表示可否に使う。
+	/// WebSocket サーバー接続時はサーバーが列車検索に対応し、かつ接続中であることを要求する
+	/// (オフライン中は検索できないため)。JSON/SQLite などローカルファイルを読み込んでいる
+	/// 場合は、読み込み済みデータの中から検索できるため、ローダーが存在すれば常に利用可能。
 	/// </summary>
 	public bool IsTrainSearchAvailable
 		=> Loader is WebSocketNetworkSyncService ws
-			&& ws.IsFeatureSupported(ServerFeatureIds.TrainSearch)
-			&& ServerConnectionStatus == ServerConnectionStatus.Connected;
+			? ws.IsFeatureSupported(ServerFeatureIds.TrainSearch) && ServerConnectionStatus == ServerConnectionStatus.Connected
+			: Loader is not null;
 
 	/// <summary>
-	/// 列番でサーバーに列車を検索する。<see cref="IsTrainSearchAvailable"/> が true のときのみ有効。
+	/// 列番で列車を検索する。<see cref="IsTrainSearchAvailable"/> が true のときのみ有効。
+	/// WebSocket 接続時はサーバーに問い合わせ、JSON/SQLite などローカルファイル読み込み時は
+	/// 読み込み済みデータの中から <see cref="ILoader"/> 経由で検索する。
 	/// </summary>
 	public Task<IReadOnlyList<TrainSearchResult>> SearchTrainAsync(
 		string trainNumber, TrainSearchMatchMode matchMode = TrainSearchMatchMode.Prefix, System.Threading.CancellationToken cancellationToken = default)
 	{
-		if (Loader is not WebSocketNetworkSyncService ws)
-			throw new InvalidOperationException("Train search requires a WebSocket connection.");
-		return ws.SearchTrainAsync(trainNumber, matchMode, cancellationToken);
+		if (Loader is WebSocketNetworkSyncService ws)
+			return ws.SearchTrainAsync(trainNumber, matchMode, cancellationToken);
+
+		if (Loader is null)
+			throw new InvalidOperationException("Train search requires loaded data.");
+
+		return Task.FromResult(SearchTrainLocal(Loader, trainNumber, matchMode));
 	}
 
 	/// <summary>
 	/// 検索候補の完全な時刻表を取得する (2 段階目)。切替先の行路の列車データを
 	/// キャッシュへ確実に反映させるため、<see cref="SwitchToSearchedTrain"/> の前に呼ぶ。
+	/// ローカルローダーの場合は既に読み込み済みのデータから同期的に取得する。
 	/// </summary>
 	public Task<TrainData?> FetchSearchedTrainTimetableAsync(
 		TrainSearchResult result, System.Threading.CancellationToken cancellationToken = default)
 	{
-		if (Loader is not WebSocketNetworkSyncService ws)
-			throw new InvalidOperationException("Train timetable fetch requires a WebSocket connection.");
-		return ws.FetchSearchedTrainTimetableAsync(result, cancellationToken);
+		if (Loader is WebSocketNetworkSyncService ws)
+			return ws.FetchSearchedTrainTimetableAsync(result, cancellationToken);
+
+		if (Loader is null)
+			throw new InvalidOperationException("Train timetable fetch requires loaded data.");
+
+		if (string.IsNullOrEmpty(result.TrainId))
+			throw new ArgumentException("TrainSearchResult.TrainId must not be empty.", nameof(result));
+
+		return Task.FromResult(Loader.GetTrainData(result.TrainId));
 	}
+
+	/// <summary>
+	/// ローカルローダー (JSON/SQLite/サンプルデータ) の読み込み済みデータから列番で列車を検索する。
+	/// マッチ方式はサーバー側 (<c>ReferenceNetworkSyncServer.MatchesTrainNumber</c>) と同じ
+	/// OrdinalIgnoreCase の前方一致/中間一致/完全一致。
+	/// </summary>
+	private static IReadOnlyList<TrainSearchResult> SearchTrainLocal(
+		ILoader loader, string trainNumber, TrainSearchMatchMode matchMode)
+	{
+		if (string.IsNullOrEmpty(trainNumber))
+			return [];
+
+		List<TrainSearchResult> results = [];
+		foreach (WorkGroup workGroup in loader.GetWorkGroupList())
+		{
+			foreach (Work work in loader.GetWorkList(workGroup.Id))
+			{
+				foreach (TrainData train in loader.GetTrainDataList(work.Id))
+				{
+					if (string.IsNullOrEmpty(train.TrainNumber)
+						|| !MatchesTrainNumber(train.TrainNumber, trainNumber, matchMode))
+						continue;
+
+					// GetTrainDataList (SQLite) omits Rows for performance, so re-fetch the
+					// full record (only for actual matches) to get the start/end station
+					// display. LoaderJson/SampleDataLoader already populate Rows in
+					// GetTrainDataList, so this is a cheap redundant lookup there — but
+					// unconditional keeps both loader kinds on the exact same code path.
+					TrainData? full = loader.GetTrainData(train.Id);
+					TimetableRow? firstRow = full?.Rows?.FirstOrDefault(static r => !r.IsInfoRow);
+					TimetableRow? lastRow = full?.Rows?.LastOrDefault(static r => !r.IsInfoRow);
+
+					results.Add(new TrainSearchResult(
+						WorkGroupId: workGroup.Id,
+						WorkId: work.Id,
+						TrainId: train.Id,
+						TrainNumber: train.TrainNumber,
+						WorkName: work.Name,
+						Direction: train.Direction.ToInt(),
+						StartStationName: firstRow?.StationName,
+						StartTime: (firstRow?.DepartureTime ?? firstRow?.ArriveTime)?.GetTimeString(),
+						EndStationName: lastRow?.StationName,
+						EndTime: (lastRow?.ArriveTime ?? lastRow?.DepartureTime)?.GetTimeString()
+					));
+				}
+			}
+		}
+		return results;
+	}
+
+	private static bool MatchesTrainNumber(string trainNumber, string query, TrainSearchMatchMode matchMode)
+		=> matchMode switch
+		{
+			TrainSearchMatchMode.Contains => trainNumber.Contains(query, StringComparison.OrdinalIgnoreCase),
+			TrainSearchMatchMode.Exact => string.Equals(trainNumber, query, StringComparison.OrdinalIgnoreCase),
+			_ => trainNumber.StartsWith(query, StringComparison.OrdinalIgnoreCase),
+		};
 
 	/// <summary>
 	/// 検索して選択した列車の行路へ完全に切り替える。WorkGroupId/WorkId/TrainId を


### PR DESCRIPTION
## Summary
- 列車検索 (train search) previously only worked when connected to a WebSocket server that advertises the `TrainSearch` feature. Opening a local JSON or SQLite file hid the QuickSwitch Search tab entirely.
- `AppViewModel.IsTrainSearchAvailable` / `SearchTrainAsync` / `FetchSearchedTrainTimetableAsync` now branch on loader type: WebSocket keeps the existing server round-trip, and any other `ILoader` (JSON, SQLite, sample data) searches the already-loaded data locally via `GetWorkGroupList`/`GetWorkList`/`GetTrainDataList`/`GetTrainData`, matching `TrainNumber` with the same OrdinalIgnoreCase prefix/contains/exact semantics as the reference server.
- `SwitchToSearchedTrain` (the final step of select → confirm → switch) was already loader-agnostic — it resolves everything by ID through `SelectionManager`'s materialized lists, so no changes were needed there.

## Test plan
- [x] `TRViS.IO.Tests` (87 tests) pass — covers `LoaderJson`/`LoaderSQL` `GetTrainData`/`GetTrainDataList`, which the new local-search refetch path depends on.
- [x] `TRViS` and `TRViS.UITests` both build clean, including with `UI_TEST` defined (compiled the new seam/test code).
- [x] Added a UI_TEST seam (`SimulateLocalSearchForTesting`, JSON-backed `SampleDataLoader`, no WebSocket) and a new Appium E2E (`TrainSearch_LocalJsonLoader_SearchSelectConfirm`) proving the Search tab appears and a real search/select/confirm flow works with a locally loaded JSON file.
- [ ] Not runtime-verified in this session — the Appium suite is Android-CI-only (per the existing WebSocket test's platform note); the real confirmation is the CI run.

Known pre-existing quirk, now reachable from more code paths (not fixed here): `DirectionExtensions.FromInt` throws on a `Direction == 0` row; local search now iterates every work in the loaded file, so a single malformed row anywhere would break search, not just the work you navigate to.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>